### PR TITLE
Simplify the grammars

### DIFF
--- a/src/pharmpy/plugins/nonmem/records/grammars/definitions.lark
+++ b/src/pharmpy/plugins/nonmem/records/grammars/definitions.lark
@@ -1,8 +1,15 @@
-WS: (" " | /\t/)+
-WS_ALL: /\s+/
+// Blanks and ignored characters
 
-NEWLINE: (/\r?\n[ \t]*/ | COMMENT)+
+blank : ( WS | newline )
+
+newline : ( WS* COMMENT? NEWLINE )+
+
+WS_ALL: WS
+WS: /[ \t\f\v]+/
+NEWLINE: (/\r?\n/)+
 COMMENT: /;[^\n]*/
+
+// Numbers
 
 DIGIT: "0".."9"
 INT: DIGIT+
@@ -16,3 +23,8 @@ SIGNED_FLOAT: ["+" | "-"] FLOAT
 NUMBER: (FLOAT | INT)
 SIGNED_NUMBER: ["+" | "-"] NUMBER
 NUMERIC: (NUMBER | SIGNED_NUMBER)
+
+// Fixed values for $THETA and $OMEGA
+
+fix : blank* FIX blank*
+FIX : "FIXED" | "FIXE" | "FIX"

--- a/src/pharmpy/plugins/nonmem/records/grammars/omega_record.lark
+++ b/src/pharmpy/plugins/nonmem/records/grammars/omega_record.lark
@@ -24,25 +24,24 @@
 //   %input | VARIANCE CORRELATION BLOCK(2)\n0.64\n-0.394 0.58|
 //   %input | CHOLESKY BLOCK(2)\n0.8\n-0.3 0.7|
 
-root : NEWLINE
-     | [WS] [diagonal] ([_ws] diag_item)+ [_ws]           // form 1
-     | [_opt] block [_opt] (_item)+ [_ws]      // form 2
-     | [_opt] block [_opt] same ([_ws] comment)* [_ws]    // form 3
-     | [_opt] bare_block [_opt] same ([_ws] comment)* [_ws]    // form 3 w/o n
-     | [_opt] block [_opt] values (_opt | [_ws] comment)* [_ws]  // form 4
+root : blank+
+     | blank* [diagonal] (blank* diag_item)+ blank* // form 1
+     | [_opt] block [_opt] (_item)+ blank*                          // form 2
+     | [_opt] block [_opt] same blank*                              // form 3
+     | [_opt] bare_block [_opt] same blank*                         // form 3 w/o n
+     | [_opt] block [_opt] values (_opt | blank*)* blank*   // form 4
 
 diag_item: init [_diag_options]
-         | "(" [WS] _diag_options [WS] init [WS] ")" [n]
-         | "(" [WS] init [WS] _diag_options [WS] ")" [n]
-         | "(" [WS] _diag_options [WS] init [WS] _diag_options [WS] ")" [n]
-_diag_options: (_ws (FIX | SD | VAR))*
+         | "(" blank* _diag_options blank* init blank* ")" [n]
+         | "(" blank* init blank* _diag_options blank* ")" [n]
+         | "(" blank* _diag_options blank* init blank* _diag_options blank* ")" [n]
+_diag_options: (blank* (fix | SD | VAR))*
 
 // repeat of init or comment (form 1 & 2)
-_item : [_ws] omega | [_ws] comment
+_item : blank* omega | blank*
 
 // can be tied to WHOLE record or ONE INIT
-_opt     : (_ws (FIX | VAR | SD | CORR | COV | CHOLESKY))* [_ws]  // note ws injection as 1st child
-FIX      : "FIXED" | "FIXE" | "FIX"
+_opt     : (blank* (fix | VAR | SD | CORR | COV | CHOLESKY))* blank*  // note ws injection as 1st child
 VAR      : "VARIANCE" | "VARIANC" | "VARIAN" | "VARIA" | "VARI" | "VAR" | "VA" | "V"
 SD       : "STANDARD" | "STANDAR" | "STANDA" | "STAND" | "STAN" | "STA" | "ST" | "SD" | "S"
 CORR     : "CORRELATION" | "CORRELATIO" | "CORRELATI" | "CORRELAT" | "CORRELA" | "CORREL" | "CORRE" | "CORR" | "COR"
@@ -50,10 +49,10 @@ COV      : "COVARIANCE" | "COVARIANC" | "COVARIAN" | "COVARIA" | "COVARI" | "COV
 CHOLESKY : "CHOLESKY" | "CHOLESK" | "CHOLES" | "CHOLE" | "CHOL" | "CHO"
 
 // parentheses sizes (optional for SAME and BLOCK with SAME)
-block       : ("BLOCK" | "BLOC" | "BLO") [_ws] _lpar size _rpar
+block       : bare_block blank* _lpar size _rpar
 bare_block  : ("BLOCK" | "BLOC" | "BLO")
 same        : "SAME" [_lpar size _rpar]
-diagonal    : ("DIAGONAL" | "DIAGONA" | "DIAGON" | "DIAGO" | "DIAG" | "DIA") [_ws] _lpar [WS] size [WS] _rpar [_ws]
+diagonal    : ("DIAGONAL" | "DIAGONA" | "DIAGON" | "DIAGO" | "DIAG" | "DIA") blank* _lpar blank* size blank* _rpar blank*
 values      : "VALUES" _lpar diag sep odiag _rpar
 
 size  : INT
@@ -61,9 +60,9 @@ diag  : NUMERIC
 odiag : NUMERIC
 
 // separator and clustering of init values
-sep : WS | [WS] "," [WS]
-_lpar : "(" [WS]
-_rpar : [WS] ")"
+sep : WS+ | WS* "," WS*
+_lpar : "(" blank*
+_rpar : blank* ")"
 
 // omega init value
 omega : init _opt*
@@ -73,8 +72,4 @@ omega : init _opt*
 init  : NUMERIC
 n     : "x" INT
 
-// common misc rules
-_ws: [WS] [NEWLINE]
-comment: COMMENT
-
-%import .definitions (COMMENT, INT, NEWLINE, NUMERIC, WS, WS_ALL)
+%import .definitions (blank, fix, INT, NUMERIC, WS)

--- a/src/pharmpy/plugins/nonmem/records/grammars/theta_record.lark
+++ b/src/pharmpy/plugins/nonmem/records/grammars/theta_record.lark
@@ -15,41 +15,35 @@
 //   2. "FIXED" requires "low" & "up" to equal "init", insofar they appear.
 //   3. "FIXED" implied if "low"="init"="up".
 
-root : _ws* theta (NEWLINE | WS | theta | option)*
+root : blank* theta ( blank+ (theta | option) )* blank*
 
-?option : KEY [WS] "=" [WS] VALUE -> option
-        | VALUE                   -> option
+?option : KEY blank* "=" blank* VALUE -> option
+        | VALUE                       -> option
 
-theta : init [WS FIX]                  // form 1
+theta : init fix?                        // form 1
       | _lpar init _rpar                 // form 2+3+5 (init)
       | _lpar low sep init _rpar         // form 2+3+5 (low, init)
       | _lpar low sep init sep up _rpar  // form 2+3+5 (low, init, up)
       | _lpar low sepsep up _rpar        // form 4+5 (low, up)
-sep : WS
-    | [WS] "," [WS]
-sepsep : [WS] "," [WS] "," [WS]
-_lpar : "(" [WS]
-_rpar : [WS] FIX [WS] ")" n
-      | [WS] ")" n
-      | [WS] ")" [WS] FIX
-      | [WS] FIX [WS] ")"
-      | [WS] ")"
+sep : blank+
+    | blank* "," blank*
+sepsep : blank* "," blank* "," blank*
+_lpar : "(" blank*
+_rpar : blank* fix? ")" n
+      | blank* ")" n fix?
+      | blank* ")" fix?
+      | blank* fix? ")"
 
 init : NUMERIC
 low  : NUMERIC | NEG_INF
 up   : NUMERIC | POS_INF
 n    : "x" INT
 
-FIX : "FIXED" | "FIXE" | "FIX"
-
 // generic option terminals (key/value)
-KEY   : /(?!([0-9]|\(|FIX))\w+/      // TODO: use priority (instead of negative lookahead)
-VALUE : /(?!([0-9]|\(|FIX))[^\s=]+/  // TODO: use priority (instead of negative lookahead)
+KEY   : ( "NUMBERPOINTS" | ( "ABORT" | "NOABORT" | "NOABORTFIRST" ) )
+VALUE : INT
 
-// common misc rules
-_ws: [WS] [NEWLINE]
-
-%import .definitions (COMMENT, INT, NEWLINE, NUMERIC, WS)
+%import .definitions (blank, fix, INT, NUMERIC, WS)
 
 NEG_INF: "-INF" | "-1000000"
 POS_INF: "INF" | "1000000"


### PR DESCRIPTION
This is perhaps not a real PR in that it may be best not to merge it.  This breaks detection of FIXED theta values, and if taken to its logical next step, it would also break detection of FIXED omega values.  It also breaks several other tests.  (To help orient me to the code, I would appreciate modifications here that show how to fix the detection of FIXED parameters.)

I think that it does improve detection of comments and spaces (as shown by the debug printing of the parse tree).  And, my goal with this was to ask a question:  Is it feasible and reasonable to detect parameter names via comments as was done with PsN?  Perhaps as a first step in that direction, could the comments following parameter declaration be added to the object as a new field?