### PR TITLE
Change the best model selection criteria

### DIFF
--- a/src/pharmpy/tools/resmod/tool.py
+++ b/src/pharmpy/tools/resmod/tool.py
@@ -133,8 +133,8 @@ def _create_dataset(input_model):
 
 def _create_best_model(model, res):
     model = model.copy()
-    if any(res.models['dofv'] > 3.84):
-        idx = res.models['dofv'].idxmax()
+    if any(-res.models['dofv'] > 3.84):
+        idx = res.models['dofv'].idxmin()
         name = idx[0]
         if name == 'power':
             set_power_on_ruv(model)


### PR DESCRIPTION
Hi, the request is about changing the best model selection criteria in resmod. Because in this case, the "dofv" is always negative and we need to select the lowest one.