### PR TITLE
Correct the iiv_on_ruv model name for best model selection.

### DIFF
--- a/src/pharmpy/tools/resmod/tool.py
+++ b/src/pharmpy/tools/resmod/tool.py
@@ -184,7 +184,7 @@ def _create_best_model(model, res):
             model.parameters.inits = {
                 'power1': res.models['parameters'].loc['power', 1, 1].get('theta') + 1
             }
-        elif name == 'iiv_on_ruv':
+        elif name == 'IIV_on_RUV':
             set_iiv_on_ruv(model)
             model.parameters.inits = {
                 'IIV_RUV1': res.models['parameters'].loc['IIV_on_RUV', 1, 1].get('omega')


### PR DESCRIPTION
Hi Rikard,

I am so sorry that I make a mistake on iiv_on_ruv model name. I forgot we use different names in `_create_iiv_on_ruv_model` and the result data frame. Here must be the capital letters as we used in the result data frame, otherwise, it will select the wrong model. I upgrade the pharmpy package to try the new resmod with some dataset and find this problem...I am very sorry! 