### PR TITLE
Change best model selection criteria with p=0.01 in resmod

### DIFF
--- a/src/pharmpy/tools/resmod/tool.py
+++ b/src/pharmpy/tools/resmod/tool.py
@@ -223,7 +223,7 @@ def _time_after_dose(model):
 def _create_best_model(model, res, groups=4):
     model = model.copy()
     _time_after_dose(model)
-    if any(res.models['dofv'] > 3.84):
+    if any(res.models['dofv'] > 6.64):
         idx = res.models['dofv'].idxmax()
         name = idx[0]
         if name == 'power':


### PR DESCRIPTION
Hi Rikard,

Mats suggested using p=0.01 instead of p=0.05 as the selection criteria for resmod models, so I changed the cutoff in resmod.

Best regards,
Zhe Huang