### PR TITLE
Compare full models in resmod and avoid unnecessary iteration in amd

### DIFF
--- a/src/pharmpy/modeling/amd.py
+++ b/src/pharmpy/modeling/amd.py
@@ -124,7 +124,9 @@ def _run_resmod(model, path):
     res_resmod = run_tool('resmod', model, path=path / 'resmod1')
     selected_model = res_resmod.best_model
     name = res_resmod.selected_model_name
-    if name[:12] == 'time_varying':
+    if name == 'base':
+        return selected_model
+    elif name[:12] == 'time_varying':
         skip.append('time_varying')
     else:
         skip.append(name)
@@ -132,7 +134,9 @@ def _run_resmod(model, path):
     res_resmod = run_tool('resmod', selected_model, skip=skip, path=path / 'resmod2')
     selected_model = res_resmod.best_model
     name = res_resmod.selected_model_name
-    if name[:12] == 'time_varying':
+    if name == 'base':
+        return selected_model
+    elif name[:12] == 'time_varying':
         skip.append('time_varying')
     else:
         skip.append(name)


### PR DESCRIPTION
Hi Rikard,

I change the commit message so I close the previous PR and open a new one. I use the same cutoff for CWRES model comparison and full model comparison. If there is no significant difference between the start model and the best model generated by resmod, the best model will be the start model and the selected_model_name will be called 'base' so that we can stop the iteration in amd when the model name is 'base'.

Best regards,
Zhe Huang