### PR TITLE
[refactor] Model plugin run metadata v0

### DIFF
--- a/src/pharmpy/workflows/model_database/baseclass.py
+++ b/src/pharmpy/workflows/model_database/baseclass.py
@@ -86,3 +86,27 @@ class ModelDatabase(ABC):
             Retrieved model object
         """
         pass
+
+    @abstractmethod
+    def store_metadata(self, model, metadata):
+        """Store metadata
+
+        Parameters
+        ----------
+        model : Model
+            Pharmpy model object
+        metadata : Dict
+            A dictionary with metadata
+        """
+        pass
+
+    @abstractmethod
+    def store_modelfit_results(self, model):
+        """Store modelfit results
+
+        Parameters
+        ----------
+        model : Model
+            Pharmpy model object
+        """
+        pass

--- a/src/pharmpy/workflows/model_database/null_database.py
+++ b/src/pharmpy/workflows/model_database/null_database.py
@@ -25,3 +25,9 @@ class NullModelDatabase(ModelDatabase):
 
     def get_model(self, name):
         pass
+
+    def store_metadata(self, model, metadata):
+        pass
+
+    def store_modelfit_results(self, model):
+        pass


### PR DESCRIPTION
  - [x] Store `stdout`, `stderr`, `returncode`, command line arguments, wrapper path, and other plugin-specific metadata
    - [x] NONMEM
    - [x] NLMIXR
  - [x] Store `results.json` and other plugin-generic metadata
    - [x] NONMEM
    - [x] NLMIXR
  - [x] ~Have a way to flag that pharmpy was not interrupted in the middle of database writes~ See #671
  - [x] ~Store model file (hash?) for cache invalidation purposes~ Out of scope for now?
  - [x] ~Store data file (hash?) for cache invalidation purposes~ This will be handled by the dataset database.