### PR TITLE
[refactor] Database transactions v0

### DIFF
--- a/src/pharmpy/lock.py
+++ b/src/pharmpy/lock.py
@@ -1,0 +1,237 @@
+"""The lock module exposes a path_lock context manager function
+
+Other exported functions are implementation details subject to change.
+
+Caveats:
+    If you need to lock multiple paths you should have a total order for each
+    subset of paths that could be locked simultaneously by the same thread and call
+    path_lock multiple times respecting this total order. For instance via
+    resolved absolute path lexicographical order.
+
+    Currently, on Windows, at the process level, shared locks are "simulated" by
+    exclusive locks. Implementing true shared locks on this platform would require
+    depending on userland libraries. This would be necessary, for instance, in
+    situations where multiple processes need to lock shared resources and
+    communicate simultaneously about the state of those resources. Note that the
+    problem in this particular example can be circumvented at the cost of
+    efficiency, by simulating locked shared resources through multiple rounds of
+    exclusively-locked resources plus communication. I do not think our current
+    usage mandates the correct implementation of shared locks. It is enough that
+    the implementation is simple for Windows, and is correct on UNIX.
+
+    Currently, on Windows, at the process level, we attempt to lock the entire file
+    by passing the largest possible value to `mscvrt.locking` `nbytes` argument. If
+    we want this implementation to be correct, we would need to `fo.seek(0)` before
+    calling `mscvrt.locking` then perhaps restore the seek position? Also the
+    largest possible value is 2^31-1 which might not be enough for files larger
+    than 2GB. Again, we do not currently need this "functionality".
+
+    It is currently not possible to specify a timeout for acquiring a lock. The
+    only options currently are immediate failure or forever blocking.
+
+    The thread-level lock is currently hard-coded as non-reentrant, but we
+    could want the possibility of choice. It will require some work to figure
+    out how to combine reentrant thread-level locks with process-level locks.
+    For instance, Linux will happily "upgrade" an acquired exclusive lock to a
+    shared lock if the same fd is lockf-ed multiple times with different
+    arguments from the same process. This is not something that we want to
+    happen.
+"""
+import os
+from contextlib import contextmanager
+from threading import Condition, Lock
+
+if os.name == 'nt':
+    # Windows file locking
+    import msvcrt
+    import sys
+
+    # NOTE lock the entire file
+    _lock_length = -1 if sys.version_info.major == 2 else int(2**31 - 1)
+
+    def _is_process_level_lock_timeout_error(error: OSError) -> bool:
+        """Check if an OSError corresponds to a blocking lock timeout error
+
+        Note that the errno for a non-blocking lock failure would be 13 with a
+        strerror of "Permission denied".
+        """
+        return error.errno == 36 and error.strerror == 'Resource deadlock avoided'
+
+    def _process_level_lock(fd: int, shared: bool = False, blocking: bool = True):
+        # NOTE Simulates shared lock using an exclusive lock
+        if blocking:
+            while True:
+                try:
+                    msvcrt.locking(fd, msvcrt.LK_LOCK, _lock_length)
+                    break
+                except OSError as error:
+                    if not _is_process_level_lock_timeout_error(error):
+                        raise error
+        else:
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, _lock_length)
+
+    def _process_level_unlock(fd: int):
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, _lock_length)
+
+else:
+    # UNIX based file locking
+    import fcntl
+
+    def _process_level_lock(fd: int, shared: bool = False, blocking: bool = True):
+        operation = fcntl.LOCK_SH if shared else fcntl.LOCK_EX
+        if not blocking:
+            operation |= fcntl.LOCK_NB
+        fcntl.lockf(fd, operation)
+
+    def _process_level_unlock(fd: int):
+        fcntl.lockf(fd, fcntl.LOCK_UN)
+
+
+@contextmanager
+def process_level_lock(fd: int, shared: bool = False, blocking: bool = True):
+    _process_level_lock(fd, shared, blocking)
+
+    try:
+        yield
+
+    finally:
+        _process_level_unlock(fd)
+
+
+class ShareableThreadLock:
+    def __init__(self):
+        self._condition = Condition(Lock())
+        self._shared_count = 0
+
+    def lock(self, shared: bool = False, blocking: bool = True):
+        if shared:
+            return self._lock_sh(blocking=blocking)
+        elif blocking:
+            return self._lock_ex()
+        else:
+            return self._lock_ex_nb()
+
+    @contextmanager
+    def _lock_sh(self, blocking: bool = True):
+        self._condition.acquire(blocking=blocking)
+        try:
+            self._shared_count += 1
+        finally:
+            self._condition.release()
+
+        try:
+            yield
+
+        finally:
+
+            self._condition.acquire()
+            try:
+                self._shared_count -= 1
+                if self._shared_count == 0:
+                    self._condition.notifyAll()
+            finally:
+                self._condition.release()
+
+    @contextmanager
+    def _lock_ex(self):
+        self._condition.acquire(blocking=True)
+        try:
+            while self._shared_count != 0:
+                self._condition.wait()
+
+            yield
+
+        finally:
+            self._condition.release()
+
+    @contextmanager
+    def _lock_ex_nb(self):
+        self._condition.acquire(blocking=False)
+        try:
+            if self._shared_count != 0:
+                raise Exception('Could not acquire lock')
+
+            yield
+
+        finally:
+            self._condition.release()
+
+
+class ThreadSafeKeyedRefPool:
+    def __init__(self, lock, refs: dict, factory):
+        self._lock = lock
+        self._refs = refs
+        self._factory = factory
+
+    @contextmanager
+    def __call__(self, key: str):
+        with self._lock:
+            entry = self._refs.get(key)
+            if entry is None:
+                # NOTE We create a new object if none exists
+                obj = self._factory()
+                self._refs[key] = (obj, 1)
+            else:
+                # NOTE Otherwise we count one ref more
+                (obj, refcount) = entry
+                self._refs[key] = (obj, refcount + 1)
+
+        try:
+            yield obj
+
+        finally:
+            with self._lock:
+                (_, refcount) = self._refs[key]
+                if refcount == 1:
+                    # NOTE We remove the object from the pool since nobody
+                    # else holds a reference to it.
+                    del self._refs[key]
+                else:
+                    # NOTE Otherwise we count one ref less
+                    self._refs[key] = (obj, refcount - 1)
+
+
+_thread_level_lock_ref = ThreadSafeKeyedRefPool(Lock(), {}, ShareableThreadLock)
+
+
+@contextmanager
+def thread_level_path_lock(path: str, shared: bool = False, blocking: bool = True):
+    key = os.path.normpath(path)
+    with _thread_level_lock_ref(key) as ref:
+        with ref.lock(shared, blocking):
+            yield
+
+
+@contextmanager
+def process_level_path_lock(path: str, shared: bool = False, blocking: bool = True):
+    fd = os.open(path, os.O_RDONLY if shared else os.O_RDWR)
+    try:
+        with process_level_lock(fd, shared, blocking):
+            yield fd
+
+    finally:
+        os.close(fd)
+
+
+@contextmanager
+def path_lock(path: str, shared: bool = False, blocking: bool = True):
+    """Locks a path both at the thread-level and process-level.
+
+    Parameters
+    ----------
+    path : str
+        The path to lock. This path will be open in read-only mode if shared is
+        True, write mode otherwise. Must be the path of an existing file (not a
+        directory).
+    shared : bool
+        Whether the lock should be shared. If not shared, the lock is
+        exclusive. One can have either a single exclusive lock or any number of
+        shared lock on the same resource at any given time.
+    blocking : bool
+        Whether lock acquisition should be blocking. If True, will raise an
+        error if a lock cannot be acquired immediately. Otherwise, will block
+        until the lock can be acquired.
+    """
+    with thread_level_path_lock(path, shared, blocking):
+        with process_level_path_lock(path, shared, blocking):
+            yield

--- a/src/pharmpy/modeling/common.py
+++ b/src/pharmpy/modeling/common.py
@@ -74,7 +74,7 @@ def read_model_from_database(name, database=None):
         import pharmpy.workflows
 
         database = pharmpy.workflows.default_model_database()
-    model = database.get_model(name)
+    model = database.retrieve_model(name)
     return model
 
 

--- a/src/pharmpy/plugins/nlmixr/model.py
+++ b/src/pharmpy/plugins/nlmixr/model.py
@@ -281,20 +281,22 @@ def execute_model(model):
         ],
     }
 
-    database.store_local_file(model, path / f'{model.name}.R')
-    database.store_local_file(model, rdata_path)
+    with database.transaction(model) as txn:
 
-    database.store_local_file(model, stdout)
-    database.store_local_file(model, stderr)
+        txn.store_local_file(path / f'{model.name}.R')
+        txn.store_local_file(rdata_path)
 
-    plugin_path = path / 'nlmixr.json'
-    with open(plugin_path, 'w') as f:
-        json.dump(plugin, f, indent=2)
+        txn.store_local_file(stdout)
+        txn.store_local_file(stderr)
 
-    database.store_local_file(model, plugin_path)
+        plugin_path = path / 'nlmixr.json'
+        with open(plugin_path, 'w') as f:
+            json.dump(plugin, f, indent=2)
 
-    database.store_metadata(model, metadata)
-    database.store_modelfit_results(model)
+        txn.store_local_file(plugin_path)
+
+        txn.store_metadata(metadata)
+        txn.store_modelfit_results()
 
     read_modelfit_results(model, rdata_path)
     return model

--- a/src/pharmpy/workflows/model_database/baseclass.py
+++ b/src/pharmpy/workflows/model_database/baseclass.py
@@ -1,4 +1,87 @@
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from pathlib import Path
+from typing import ContextManager
+
+from pharmpy import Model
+
+
+class ModelTransaction(ABC):
+    @abstractmethod
+    def store_model(self) -> None:
+        """Store the model object bound to this transaction"""
+        pass
+
+    @abstractmethod
+    def store_local_file(self, path) -> None:
+        """Store a file from the local machine for the model bound to this
+        transaction
+
+        Parameters
+        ----------
+        path : Path
+            Path to file
+        """
+        pass
+
+    @abstractmethod
+    def store_metadata(self, metadata) -> None:
+        """Store metadata for the model bound to this transaction
+
+        Parameters
+        ----------
+        metadata : Dict
+            A dictionary with metadata
+        """
+        pass
+
+    @abstractmethod
+    def store_modelfit_results(self) -> None:
+        """Store modelfit results of the model bound to this transaction"""
+        pass
+
+
+class ModelSnapshot(ABC):
+    @abstractmethod
+    def retrieve_local_files(self, destination_path: Path) -> None:
+        """Retrieve all files related to the model bound to this snapshot
+
+        Parameters
+        ----------
+        destination_path : Path
+            Local destination path
+        """
+        pass
+
+    @abstractmethod
+    def retrieve_file(self, filename: str) -> Path:
+        """Retrieve one file related to the model bound to this snapshot
+
+        Note that if the database is implemented in the local filesystem
+        it is allowed to return a path directly to the file in the database.
+
+        Parameters
+        ----------
+        filename : str
+            Name of file
+
+        Returns
+        -------
+        Path
+            Path to local file
+        """
+        pass
+
+    @abstractmethod
+    def retrieve_model(self) -> Model:
+        """Get the model bound to this snapshot
+
+        Returns
+        -------
+        Model
+            Retrieved model object
+        """
+        pass
 
 
 class ModelDatabase(ABC):
@@ -14,7 +97,7 @@ class ModelDatabase(ABC):
     """
 
     @abstractmethod
-    def store_model(self, model):
+    def store_model(self, model: Model):
         """Store a model object
 
         Parameters
@@ -25,7 +108,7 @@ class ModelDatabase(ABC):
         pass
 
     @abstractmethod
-    def store_local_file(self, model, path):
+    def store_local_file(self, model: Model, path: Path):
         """Store a file from the local machine
 
         Parameters
@@ -38,57 +121,7 @@ class ModelDatabase(ABC):
         pass
 
     @abstractmethod
-    def retrieve_local_files(self, name, destination_path):
-        """Retrieve all files related to a model
-
-        Parameters
-        ----------
-        name : str
-            Name of the model
-        destination_path : Path
-            Local destination path
-        """
-        pass
-
-    @abstractmethod
-    def retrieve_file(self, name, filename):
-        """Retrieve one file related to a model
-
-        Note that if the database is implemented in the local filesystem
-        it is allowed to return a path directly to the file in the database.
-
-        Parameters
-        ----------
-        name : str
-            Name of the model
-        filename : str
-            Name of file
-
-        Returns
-        -------
-        Path
-            Path to local file
-        """
-        pass
-
-    @abstractmethod
-    def get_model(self, name):
-        """Read a model from the database
-
-        Parameters
-        ----------
-        name : str
-            Name of the model
-
-        Returns
-        -------
-        Model
-            Retrieved model object
-        """
-        pass
-
-    @abstractmethod
-    def store_metadata(self, model, metadata):
+    def store_metadata(self, model: Model, metadata: dict):
         """Store metadata
 
         Parameters
@@ -101,7 +134,7 @@ class ModelDatabase(ABC):
         pass
 
     @abstractmethod
-    def store_modelfit_results(self, model):
+    def store_modelfit_results(self, model: Model):
         """Store modelfit results
 
         Parameters
@@ -110,3 +143,152 @@ class ModelDatabase(ABC):
             Pharmpy model object
         """
         pass
+
+    @abstractmethod
+    def retrieve_local_files(self, model_name: str, destination_path: Path):
+        """Retrieve all files related to a model
+
+        Parameters
+        ----------
+        model_name : str
+            Name of the model
+        destination_path : Path
+            Local destination path
+        """
+        pass
+
+    @abstractmethod
+    def retrieve_file(self, model_name: str, filename: str) -> Path:
+        """Retrieve one file related to a model
+
+        Note that if the database is implemented in the local filesystem
+        it is allowed to return a path directly to the file in the database.
+
+        Parameters
+        ----------
+        model_name : str
+            Name of the model
+        filename : str
+            Name of file
+
+        Returns
+        -------
+        Path
+            Path to local file
+        """
+        pass
+
+    @abstractmethod
+    def retrieve_model(self, model_name: str) -> Model:
+        """Read a model from the database
+
+        Parameters
+        ----------
+        model_name : str
+            Name of the model
+
+        Returns
+        -------
+        Model
+            Retrieved model object
+        """
+        pass
+
+    @abstractmethod
+    def snapshot(self, model_name: str) -> ContextManager[ModelSnapshot]:
+        """Creates a readable snapshot context for a given model.
+
+        Parameters
+        ----------
+        model_name : str
+            Name of the Pharmpy model object
+        """
+        pass
+
+    @abstractmethod
+    def transaction(self, model: Model) -> ContextManager[ModelTransaction]:
+        """Creates a writable transaction context for a given model.
+
+        Parameters
+        ----------
+        model : Model
+            Pharmpy model object
+        """
+        pass
+
+
+class NonTransactionalModelDatabase(ModelDatabase):
+    @contextmanager
+    def snapshot(self, model_name: str):
+        yield DummySnapshot(self, model_name)
+
+    @contextmanager
+    def transaction(self, model: Model):
+        yield DummyTransaction(self, model)
+
+
+class DummyTransaction(ModelTransaction):
+    def __init__(self, database: ModelDatabase, model: Model):
+        self.db = database
+        self.model = model
+
+    def store_model(self) -> None:
+        return self.db.store_model(self.model)
+
+    def store_local_file(self, path: Path) -> None:
+        return self.db.store_local_file(self.model, path)
+
+    def store_metadata(self, metadata: dict) -> None:
+        return self.db.store_metadata(self.model, metadata)
+
+    def store_modelfit_results(self) -> None:
+        return self.db.store_modelfit_results(self.model)
+
+
+class DummySnapshot(ModelSnapshot):
+    def __init__(self, database: ModelDatabase, model_name: str):
+        self.db = database
+        self.name = model_name
+
+    def retrieve_local_files(self, destination_path: Path) -> None:
+        return self.db.retrieve_local_files(self.name, destination_path)
+
+    def retrieve_file(self, filename: str) -> Path:
+        return self.db.retrieve_file(self.name, filename)
+
+    def retrieve_model(self):
+        return self.db.retrieve_model(self.name)
+
+
+class TransactionalModelDatabase(ModelDatabase):
+    def store_model(self, model: Model) -> None:
+        with self.transaction(model) as txn:
+            return txn.store_model()
+
+    def store_local_file(self, model: Model, path: Path) -> None:
+        with self.transaction(model) as txn:
+            return txn.store_local_file(path)
+
+    def store_metadata(self, model: Model, metadata: dict) -> None:
+        with self.transaction(model) as txn:
+            return txn.store_metadata(metadata)
+
+    def store_modelfit_results(self, model: Model) -> None:
+        with self.transaction(model) as txn:
+            return txn.store_modelfit_results()
+
+    def retrieve_file(self, model_name: str, filename: str) -> Path:
+        with self.snapshot(model_name) as sn:
+            return sn.retrieve_file(filename)
+
+    def retrieve_local_files(self, model_name: str, destination_path: Path) -> None:
+        with self.snapshot(model_name) as sn:
+            return sn.retrieve_local_files(destination_path)
+
+    def retrieve_model(self, model_name: str) -> Model:
+        with self.snapshot(model_name) as sn:
+            return sn.retrieve_model()
+
+
+class PendingTransactionError(Exception):
+    pass

--- a/src/pharmpy/workflows/model_database/null_database.py
+++ b/src/pharmpy/workflows/model_database/null_database.py
@@ -1,7 +1,7 @@
-from .baseclass import ModelDatabase
+from .baseclass import NonTransactionalModelDatabase
 
 
-class NullModelDatabase(ModelDatabase):
+class NullModelDatabase(NonTransactionalModelDatabase):
     """Dummy model database implementation
 
     No operation does anything. This database can be used if no storing of files
@@ -17,17 +17,17 @@ class NullModelDatabase(ModelDatabase):
     def store_local_file(self, model, path):
         pass
 
+    def store_metadata(self, model, metadata):
+        pass
+
+    def store_modelfit_results(self, model):
+        pass
+
     def retrieve_file(self, model_name, filename):
         pass
 
     def retrieve_local_files(self, name, destination_path):
         pass
 
-    def get_model(self, name):
-        pass
-
-    def store_metadata(self, model, metadata):
-        pass
-
-    def store_modelfit_results(self, model):
+    def retrieve_model(self, name):
         pass

--- a/tests/execute/test_database.py
+++ b/tests/execute/test_database.py
@@ -1,11 +1,12 @@
 import os
 import os.path
+import shutil
 from pathlib import Path
 
 import pytest
-from pyfakefs.fake_filesystem_unittest import Patcher
 
 from pharmpy.modeling import add_time_after_dose, copy_model, read_model
+from pharmpy.utils import TemporaryDirectoryChanger
 from pharmpy.workflows import (
     LocalDirectoryDatabase,
     LocalModelDirectoryDatabase,
@@ -41,19 +42,12 @@ def test_null_database():
     db.store_local_file("path", 34)
 
 
-def test_store_model(testdata):
+def test_store_model(tmp_path, testdata):
     sep = os.path.sep
-    with Patcher(
-        additional_skip_names=[
-            'pkgutil',
-            'lark.load_grammar',
-            'pharmpy.plugins.nonmem.records.parsers',
-        ]
-    ) as patcher:
-        fs = patcher.fs
+    with TemporaryDirectoryChanger(tmp_path):
         datadir = testdata / 'nonmem'
-        fs.add_real_file(datadir / 'pheno_real.mod', target_path='pheno_real.mod')
-        fs.add_real_file(datadir / 'pheno.dta', target_path='pheno.dta')
+        shutil.copy(datadir / 'pheno_real.mod', 'pheno_real.mod')
+        shutil.copy(datadir / 'pheno.dta', 'pheno.dta')
         model = read_model("pheno_real.mod")
 
         db = LocalModelDirectoryDatabase("database")

--- a/tests/integration/test_amd.py
+++ b/tests/integration/test_amd.py
@@ -1,4 +1,5 @@
 import shutil
+from pathlib import Path
 
 from pharmpy import Model
 from pharmpy.modeling import run_iiv

--- a/tests/integration/test_amd.py
+++ b/tests/integration/test_amd.py
@@ -15,6 +15,15 @@ from pharmpy.utils import TemporaryDirectoryChanger
 #         assert res
 
 
+def _model_count(rundir: Path):
+    return sum(
+        map(
+            lambda path: 0 if path.name in ['.lock', '.datasets'] else 1,
+            ((rundir / 'models').iterdir()),
+        )
+    )
+
+
 def test_iiv(tmp_path, testdata):
     with TemporaryDirectoryChanger(tmp_path):
         shutil.copy2(testdata / 'nonmem' / 'models' / 'mox2.mod', tmp_path)
@@ -31,10 +40,10 @@ def test_iiv(tmp_path, testdata):
         assert len(res.models) == 11
         rundir1 = tmp_path / 'iiv_dir1'
         assert rundir1.is_dir()
-        assert len(list((rundir1 / 'models').iterdir())) == 9
+        assert _model_count(rundir1) == 8
         rundir2 = tmp_path / 'iiv_dir2'
         assert rundir2.is_dir()
-        assert len(list((rundir2 / 'models').iterdir())) == 5
+        assert _model_count(rundir2) == 4
 
         run_iiv(model_start, path=tmp_path / 'test_path')
 

--- a/tests/integration/test_estmethod.py
+++ b/tests/integration/test_estmethod.py
@@ -1,10 +1,20 @@
 import shutil
+from pathlib import Path
 
 import pytest
 
 from pharmpy import Model
 from pharmpy.modeling import run_tool
 from pharmpy.utils import TemporaryDirectoryChanger
+
+
+def _model_count(rundir: Path):
+    return sum(
+        map(
+            lambda path: 0 if path.name in ['.lock', '.datasets'] else 1,
+            ((rundir / 'models').iterdir()),
+        )
+    )
 
 
 @pytest.mark.parametrize(
@@ -26,7 +36,7 @@ def test_estmethod(tmp_path, testdata, methods, solvers, no_of_models, advan_ref
         assert advan_ref in res.models[-1].model_code
         rundir = tmp_path / 'estmethod_dir1'
         assert rundir.is_dir()
-        assert len(list((rundir / 'models').iterdir())) == no_of_models + 1
+        assert _model_count(rundir) == no_of_models
         assert (rundir / 'results.json').exists()
         assert (rundir / 'results.csv').exists()
         assert (rundir / 'results.html').exists()

--- a/tests/integration/test_fit.py
+++ b/tests/integration/test_fit.py
@@ -1,4 +1,5 @@
 import shutil
+from pathlib import Path
 
 import pytest
 
@@ -7,6 +8,15 @@ from pharmpy import Model
 from pharmpy.config import site_config_dir, user_config_dir
 from pharmpy.plugins.nonmem import conf
 from pharmpy.utils import TemporaryDirectoryChanger
+
+
+def _model_count(rundir: Path):
+    return sum(
+        map(
+            lambda path: 0 if path.name in ['.lock', '.datasets'] else 1,
+            ((rundir / 'models').iterdir()),
+        )
+    )
 
 
 def test_configuration():
@@ -26,7 +36,7 @@ def test_fit_single(tmp_path, testdata):
         rundir = tmp_path / 'modelfit_dir1'
         assert model.modelfit_results.ofv == pytest.approx(730.8947268137308)
         assert rundir.is_dir()
-        assert len(list((rundir / 'models').iterdir())) == 2
+        assert _model_count(rundir) == 1
         assert (rundir / 'models' / 'pheno' / '.pharmpy').exists()
 
 
@@ -47,7 +57,7 @@ def test_fit_multiple(tmp_path, testdata):
         assert model_1.modelfit_results.ofv == pytest.approx(730.8947268137308)
         assert model_2.modelfit_results.ofv == pytest.approx(730.8947268137308)
         assert rundir.is_dir()
-        assert len(list((rundir / 'models').iterdir())) == 3
+        assert _model_count(rundir) == 2
 
 
 def test_fit_copy(tmp_path, testdata):
@@ -61,7 +71,7 @@ def test_fit_copy(tmp_path, testdata):
 
         rundir_1 = tmp_path / 'modelfit_dir1'
         assert rundir_1.is_dir()
-        assert len(list((rundir_1 / 'models').iterdir())) == 2
+        assert _model_count(rundir_1) == 1
 
         model_2 = modeling.copy_model(model_1, 'pheno_copy')
         modeling.update_inits(model_2)
@@ -69,7 +79,7 @@ def test_fit_copy(tmp_path, testdata):
 
         rundir_2 = tmp_path / 'modelfit_dir1'
         assert rundir_2.is_dir()
-        assert len(list((rundir_2 / 'models').iterdir())) == 2
+        assert _model_count(rundir_2) == 1
 
         assert model_1.modelfit_results.ofv != model_2.modelfit_results.ofv
 

--- a/tests/integration/test_iiv.py
+++ b/tests/integration/test_iiv.py
@@ -1,4 +1,5 @@
 import shutil
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -6,6 +7,15 @@ import pytest
 from pharmpy import Model
 from pharmpy.modeling import create_joint_distribution, run_tool, set_seq_zo_fo_absorption
 from pharmpy.utils import TemporaryDirectoryChanger
+
+
+def _model_count(rundir: Path):
+    return sum(
+        map(
+            lambda path: 0 if path.name in ['.lock', '.datasets'] else 1,
+            ((rundir / 'models').iterdir()),
+        )
+    )
 
 
 @pytest.mark.parametrize(
@@ -32,7 +42,7 @@ def test_iiv_block_structure(tmp_path, testdata, no_of_models, best_model_name):
         assert res.best_model.name == best_model_name
         rundir = tmp_path / 'iiv_dir1'
         assert rundir.is_dir()
-        assert len(list((rundir / 'models').iterdir())) == no_of_models + 2
+        assert _model_count(rundir) == no_of_models + 1
         assert (rundir / 'metadata.json').exists()
 
 
@@ -51,7 +61,7 @@ def test_iiv_no_of_etas(tmp_path, testdata):
         assert res.best_model.name == 'iiv_no_of_etas_candidate3'
         rundir = tmp_path / 'iiv_dir1'
         assert rundir.is_dir()
-        assert len(list((rundir / 'models').iterdir())) == 9
+        assert _model_count(rundir) == 8
         assert (rundir / 'metadata.json').exists()
 
 
@@ -84,7 +94,7 @@ def test_iiv_no_of_etas_added_iiv(tmp_path, testdata, iiv_strategy, best_model_n
         assert res.best_model.name == best_model_name
         rundir = tmp_path / 'iiv_dir1'
         assert rundir.is_dir()
-        assert len(list((rundir / 'models').iterdir())) == 17
+        assert _model_count(rundir) == 16
         assert (rundir / 'metadata.json').exists()
 
 
@@ -104,5 +114,5 @@ def test_iiv_no_of_etas_fullblock(tmp_path, testdata):
         assert res.best_model.name == 'iiv_no_of_etas_candidate3'
         rundir = tmp_path / 'iiv_dir1'
         assert rundir.is_dir()
-        assert len(list((rundir / 'models').iterdir())) == 9
+        assert _model_count(rundir) == 8
         assert (rundir / 'metadata.json').exists()

--- a/tests/integration/test_modelsearch.py
+++ b/tests/integration/test_modelsearch.py
@@ -1,11 +1,21 @@
 import shutil
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pytest
 
 from pharmpy.modeling import fit, read_model, run_tool
 from pharmpy.utils import TemporaryDirectoryChanger
+
+
+def _model_count(rundir: Path):
+    return sum(
+        map(
+            lambda path: 0 if path.name in ['.lock', '.datasets'] else 1,
+            ((rundir / 'models').iterdir()),
+        )
+    )
 
 
 def test_exhaustive(tmp_path, start_model):
@@ -23,7 +33,7 @@ def test_exhaustive(tmp_path, start_model):
         )
         rundir = tmp_path / 'modelsearch_dir1'
         assert rundir.is_dir()
-        assert len(list((rundir / 'models').iterdir())) == 4
+        assert _model_count(rundir) == 3
         assert (rundir / 'results.json').exists()
         assert (rundir / 'results.csv').exists()
         assert (rundir / 'metadata.json').exists()
@@ -65,7 +75,7 @@ def test_exhaustive_stepwise_basic(
 
         rundir = tmp_path / 'modelsearch_dir1'
         assert rundir.is_dir()
-        assert len(list((rundir / 'models').iterdir())) == no_of_models + 1
+        assert _model_count(rundir) == no_of_models
         assert (rundir / 'results.json').exists()
         assert (rundir / 'results.csv').exists()
         assert (rundir / 'metadata.json').exists()
@@ -114,7 +124,7 @@ def test_exhaustive_stepwise_add_iivs(
 
         rundir = tmp_path / 'modelsearch_dir1'
         assert rundir.is_dir()
-        assert len(list((rundir / 'models').iterdir())) == no_of_models + 1
+        assert _model_count(rundir) == no_of_models
         assert (rundir / 'results.json').exists()
         assert (rundir / 'results.csv').exists()
         assert (rundir / 'metadata.json').exists()
@@ -136,7 +146,7 @@ def test_exhaustive_stepwise_start_model_not_fitted(tmp_path, start_model):
         assert len(res.models) == 4
         rundir = tmp_path / 'modelsearch_dir1'
         assert rundir.is_dir()
-        assert len(list((rundir / 'models').iterdir())) == 5
+        assert _model_count(rundir) == 5
 
 
 def test_exhaustive_stepwise_peripheral_upper_limit(tmp_path, start_model):
@@ -182,7 +192,7 @@ def test_exhaustive_stepwise_peripheral_upper_limit(tmp_path, start_model):
 
 #        rundir = tmp_path / 'modelsearch_dir1'
 #        assert rundir.is_dir()
-#        assert len(list((rundir / 'models').iterdir())) == no_of_models + 2
+#        assert _model_count(rundir) == no_of_models + 1
 #        assert (rundir / 'results.json').exists()
 #        assert (rundir / 'results.csv').exists()
 #        assert (rundir / 'metadata.json').exists()


### PR DESCRIPTION
The goal is to have a generic way to do atomic reads and writes on the different databases.

**TODO**:
  - [ ] Sanity check we are not going to end up in a dead-lock with current usage.
    - @rikardn I think there are some issues where reading the `modelfit_results` attribute inside any of the database methods may cause locking recursion. We should be able to detect if this happens by using nonreentrant thread locks.

**DONE**:
  - [x] Make it work with processes.
    - [x] **UNIX** (using `fcntl`)
      - [x] `blocking`
      - [x] `shared`
    - [x] **Windows** (using `msvcrt`) 
      - [x] `blocking`: Make it block forever (so that it behaves like `fcntl`)
      - [x] `shared`: ~Do not "simulate" a shared acquire using an exclusive acquire.~ Good enough for now. Maybe not possible without additional libraries such as `win32file` (see for instance https://github.com/WoLpH/portalocker/blob/00cffcb1831208691d3bf6850df4768989a0bd4c/portalocker/portalocker.py). 
    - [x] Make sure `fcntl` and `msvcrt` create advisory non-persistent locks (see https://github.com/conan-io/conan/issues/6079). Difficult to find documentation on this, but @ZheHuang96 and I did some testing on Windows and the behavior we observed is expected (everything is automatically released on process exit, files can be opened even when a lock exists, in fact you need to open first and lock given the obtained `fd`).
  - [x] Make it work with threads. Perhaps using `threading.Lock` with some global fs-path-to-lock mapping.
  - [x] Allow many-read XOR single-write per-database locks. Using `LOCK_SH` but making sure multi-threading does not wrongfully upgrade an existing `LOCK_EX` lock. This is achieved by acquiring a lock at the thread-level (with some `threading.Condition` and counting magic), then acquiring the process-level lock.
  - [x] Make it clear it only works with existing file paths (file has to exist on both UNIX and Windows, path cannot be a directory on Windows)

Some links in the wild:
  - https://www.oreilly.com/library/view/python-cookbook/0596001673/ch04s25.html
  - https://github.com/harlowja/fasteners
  - https://github.com/WoLpH/portalocker/blob/00cffcb1831208691d3bf6850df4768989a0bd4c/portalocker/portalocker.py
  - https://docs.openstack.org/pylockfile/latest/