### PR TITLE
[feature] Store input model name in the tool metadata

### DIFF
--- a/src/pharmpy/tools/run.py
+++ b/src/pharmpy/tools/run.py
@@ -175,7 +175,7 @@ def run_tool(name: str, *args, **kwargs) -> Union[Model, List[Model], Tuple[Mode
     # NOTE The implementation of run_tool is split into those two functions to
     # allow for individual testing and mocking.
     tool = import_tool(name)
-    return run_tool_with_name(name, tool, *args, **kwargs)
+    return run_tool_with_name(name, tool, args, kwargs)
 
 
 def import_tool(name: str):
@@ -183,14 +183,14 @@ def import_tool(name: str):
 
 
 def run_tool_with_name(
-    name: str, _tool, *args, **kwargs
+    name: str, tool, args: Sequence, kwargs: Mapping[str, Any]
 ) -> Union[Model, List[Model], Tuple[Model], Results]:
     common_options, tool_options = split_common_options(kwargs)
 
-    if validate_input := getattr(_tool, 'validate_input', None):
+    if validate_input := getattr(tool, 'validate_input', None):
         validate_input(*args, **tool_options)
 
-    create_workflow = _tool.create_workflow
+    create_workflow = tool.create_workflow
 
     wf = create_workflow(*args, **tool_options)
 
@@ -307,7 +307,9 @@ def _create_metadata_common(common_options, dispatcher, database, toolname):
     return setup_metadata
 
 
-def _store_input_models(db: ModelDatabase, params, types, args: Sequence, kwargs: Mapping[str, Any]):
+def _store_input_models(
+    db: ModelDatabase, params, types, args: Sequence, kwargs: Mapping[str, Any]
+):
     for param_key, model in _input_models(params, types, args, kwargs):
         input_model_name = f'input_{param_key}'
         _store_input_model(db, model, input_model_name)

--- a/src/pharmpy/tools/run.py
+++ b/src/pharmpy/tools/run.py
@@ -206,10 +206,9 @@ def run_tool_with_name(
         wf=wf,
         tool_params=tool_params,
         tool_param_types=tool_param_types,
+        args=args,
         tool_options=tool_options,
         common_options=common_options,
-        args=args,
-        kwargs=kwargs,
     )
 
     database.store_metadata(tool_metadata)
@@ -230,14 +229,13 @@ def _create_metadata(
     wf: Workflow,
     tool_params,
     tool_param_types,
-    tool_options,
-    common_options,
     args: Sequence,
-    kwargs: Mapping[str, Any],
+    tool_options: Mapping[str, Any],
+    common_options: Mapping[str, Any],
 ):
 
     tool_metadata = _create_metadata_tool(
-        database, name, tool_params, tool_param_types, tool_options, args, kwargs
+        database, name, tool_params, tool_param_types, args, tool_options
     )
     setup_metadata = _create_metadata_common(database, dispatcher, wf.name, common_options)
     tool_metadata['common_options'] = setup_metadata
@@ -256,7 +254,6 @@ def _create_metadata_tool(
     tool_name: str,
     tool_params,
     tool_param_types,
-    tool_options,
     args: Sequence,
     kwargs: Mapping[str, Any],
 ):
@@ -275,13 +272,13 @@ def _create_metadata_tool(
                 name, value = p.name, args[i]
             except IndexError:
                 try:
-                    name, value = p.name, tool_options[p.name]
+                    name, value = p.name, kwargs[p.name]
                 except KeyError:
                     raise ValueError(f'{tool_name}: \'{p.name}\' was not set')
         # Named args
         else:
-            if p.name in tool_options.keys():
-                name, value = p.name, tool_options[p.name]
+            if p.name in kwargs.keys():
+                name, value = p.name, kwargs[p.name]
             else:
                 name, value = p.name, p.default
         if isinstance(value, Model):

--- a/src/pharmpy/workflows/args.py
+++ b/src/pharmpy/workflows/args.py
@@ -1,7 +1,9 @@
+from typing import Any, Mapping, Tuple
+
 from pharmpy.internals.fs.path import normalize_user_given_path
 
 
-def split_common_options(d):
+def split_common_options(d) -> Tuple[Mapping[str, Any], Mapping[str, Any]]:
     """Split the dict into common options and other options
 
     Parameters

--- a/src/pharmpy/workflows/model_database/baseclass.py
+++ b/src/pharmpy/workflows/model_database/baseclass.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from pathlib import Path
-from typing import ContextManager
+from typing import ContextManager, Union
 
 from pharmpy.model import Model, Results
 
@@ -13,7 +13,7 @@ class ModelTransaction(ABC):
         pass
 
     @abstractmethod
-    def store_local_file(self, path) -> None:
+    def store_local_file(self, path: Path, new_filename: Union[str, None] = None):
         """Store a file from the local machine for the model bound to this
         transaction
 
@@ -21,6 +21,9 @@ class ModelTransaction(ABC):
         ----------
         path : Path
             Path to file
+        new_filename: str|None
+            Filename to give to the file. Optional, defaults to original
+            filename given by path.
         """
         pass
 
@@ -124,7 +127,7 @@ class ModelDatabase(ABC):
         pass
 
     @abstractmethod
-    def store_local_file(self, model: Model, path: Path):
+    def store_local_file(self, model: Model, path: Path, new_filename: Union[str, None] = None):
         """Store a file from the local machine
 
         Parameters
@@ -133,6 +136,9 @@ class ModelDatabase(ABC):
             Pharmpy model object
         path : Path
             Path to file
+        new_filename: str|None
+            Filename to give to the file. Optional, defaults to original
+            filename given by path.
         """
         pass
 
@@ -267,8 +273,8 @@ class DummyTransaction(ModelTransaction):
     def store_model(self) -> None:
         return self.db.store_model(self.model)
 
-    def store_local_file(self, path: Path) -> None:
-        return self.db.store_local_file(self.model, path)
+    def store_local_file(self, path: Path, new_filename: Union[str, None] = None) -> None:
+        return self.db.store_local_file(self.model, path, new_filename)
 
     def store_metadata(self, metadata: dict) -> None:
         return self.db.store_metadata(self.model, metadata)
@@ -300,9 +306,11 @@ class TransactionalModelDatabase(ModelDatabase):
         with self.transaction(model) as txn:
             return txn.store_model()
 
-    def store_local_file(self, model: Model, path: Path) -> None:
+    def store_local_file(
+        self, model: Model, path: Path, new_filename: Union[str, None] = None
+    ) -> None:
         with self.transaction(model) as txn:
-            return txn.store_local_file(path)
+            return txn.store_local_file(path, new_filename)
 
     def store_metadata(self, model: Model, metadata: dict) -> None:
         with self.transaction(model) as txn:

--- a/src/pharmpy/workflows/model_database/null_database.py
+++ b/src/pharmpy/workflows/model_database/null_database.py
@@ -14,7 +14,7 @@ class NullModelDatabase(NonTransactionalModelDatabase):
     def store_model(self, model):
         pass
 
-    def store_local_file(self, model, path):
+    def store_local_file(self, model, path, new_filename=None):
         pass
 
     def store_metadata(self, model, metadata):

--- a/src/pharmpy/workflows/tool_database/baseclass.py
+++ b/src/pharmpy/workflows/tool_database/baseclass.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 
 class ToolDatabase(ABC):
@@ -12,6 +13,15 @@ class ToolDatabase(ABC):
 
     def __init__(self, toolname):
         self.toolname = toolname
+
+    @property
+    def path(self):
+        """ModelDatabase to store results of models run by tool"""
+        return self._path
+
+    @path.setter
+    def path(self, value: Path):
+        self._path = value
 
     @property
     def model_database(self):

--- a/src/pharmpy/workflows/tool_database/baseclass.py
+++ b/src/pharmpy/workflows/tool_database/baseclass.py
@@ -43,3 +43,14 @@ class ToolDatabase(ABC):
             Tool results object
         """
         pass
+
+    @abstractmethod
+    def store_metadata(self, metadata):
+        """Store tool metadata
+
+        Parameters
+        ----------
+        metadata : dict
+            Tool metadata dictionary
+        """
+        pass

--- a/src/pharmpy/workflows/tool_database/local_directory.py
+++ b/src/pharmpy/workflows/tool_database/local_directory.py
@@ -23,6 +23,8 @@ class LocalDirectoryToolDatabase(ToolDatabase):
     """
 
     def __init__(self, toolname, path=None, exist_ok=False):
+        super().__init__(toolname)
+
         if path is None:
             for i in count(1):
                 name = f'{toolname}_dir{i}'
@@ -41,8 +43,6 @@ class LocalDirectoryToolDatabase(ToolDatabase):
 
         modeldb = LocalModelDirectoryDatabase(self.path / 'models')
         self.model_database = modeldb
-
-        super().__init__(toolname)
 
     def to_dict(self):
         return {'toolname': self.toolname, 'path': str(self.path)}

--- a/src/pharmpy/workflows/tool_database/null_database.py
+++ b/src/pharmpy/workflows/tool_database/null_database.py
@@ -10,8 +10,8 @@ class NullToolDatabase(ToolDatabase):
     """
 
     def __init__(self, toolname, **kwargs):
-        self.model_database = NullModelDatabase()
         super().__init__(toolname)
+        self.model_database = NullModelDatabase()
 
     def store_local_file(self, source_path):
         pass

--- a/src/pharmpy/workflows/tool_database/null_database.py
+++ b/src/pharmpy/workflows/tool_database/null_database.py
@@ -18,3 +18,6 @@ class NullToolDatabase(ToolDatabase):
 
     def store_results(self, res):
         pass
+
+    def store_metadata(self, metadata):
+        pass

--- a/tests/tools/test_run.py
+++ b/tests/tools/test_run.py
@@ -26,21 +26,19 @@ from pharmpy.workflows import LocalDirectoryToolDatabase, local_dask
 
 
 @pytest.mark.parametrize(
-    ('tool_options', 'args', 'kwargs'),
+    ('args', 'kwargs'),
     (
         (
-            {'iiv_strategy': 'no_add'},
             ('ABSORPTION(ZO)', 'exhaustive'),
-            {},
+            {'iiv_strategy': 'no_add'},
         ),
         (
-            {'algorithm': 'exhaustive'},
             ('ABSORPTION(ZO)',),
-            {},
+            {'algorithm': 'exhaustive'},
         ),
     ),
 )
-def test_create_metadata_tool(tmp_path, pheno, tool_options, args, kwargs):
+def test_create_metadata_tool(tmp_path, pheno, args, kwargs):
     with chdir(tmp_path):
         tool_name = 'modelsearch'
         database = LocalDirectoryToolDatabase(tool_name)
@@ -53,7 +51,6 @@ def test_create_metadata_tool(tmp_path, pheno, tool_options, args, kwargs):
             tool_name=tool_name,
             tool_params=tool_params,
             tool_param_types=tool_param_types,
-            tool_options=tool_options,
             args=args,
             kwargs={'model': pheno, **kwargs},
         )
@@ -82,7 +79,6 @@ def test_create_metadata_tool_raises(tmp_path, pheno):
                 tool_name=tool_name,
                 tool_params=tool_params,
                 tool_param_types=tool_param_types,
-                tool_options={},
                 args=('ABSORPTION(ZO)',),
                 kwargs={'model': pheno},
             )

--- a/tests/tools/test_runtool.py
+++ b/tests/tools/test_runtool.py
@@ -78,5 +78,5 @@ class MockedToolWithInputValidation(MockedTool):
 )
 def test_run_tool_without_input_validation(tmp_path, pheno, name, tool, args, expected):
     with chdir(tmp_path):
-        res = run_tool_with_name(name, tool, *args, pheno)
+        res = run_tool_with_name(name, tool, (*args, pheno), {})
         assert expected(res)


### PR DESCRIPTION
> @rikardn Rebased on in #659 

  - [x] Integration tests: https://github.com/pharmpy-dev-123/pharmpy/actions/workflows/integration.yml?query=branch%3Afeature-tool-metadata-store-input-model

The first attempt was NONMEM-specific so would not work in general. But after building on @stellabelin's work to store tool input models in the model database, the implementation was straightforward. Essentially, all this does is replace the `str(model)` unexploitable representations with their name in the model database. See:

  - https://github.com/pharmpy/pharmpy/pull/704/files#diff-f3cf7ba4c2170c6ecc31bce82cd7d5e1177317eeb8be73230fe843cd422afe1bL276-R285
  - https://github.com/pharmpy/pharmpy/pull/704/files#diff-f3cf7ba4c2170c6ecc31bce82cd7d5e1177317eeb8be73230fe843cd422afe1bR290-R293