### PR TITLE
[fix] Workaround ETXTBSY error when running NONMEM

### DIFF
--- a/src/pharmpy/plugins/nonmem/run.py
+++ b/src/pharmpy/plugins/nonmem/run.py
@@ -37,9 +37,10 @@ def execute_model(model):
             fp.write(f"@echo off\ncd {path}\n{' '.join(args)}\n")
         cmd = str(path / 'cdwrapper.bat')
     else:
-        fd = os.open(path / 'cdwrapper', os.O_CREAT | os.O_WRONLY | os.O_CLOEXEC, mode=0o744)
+        fd = os.open(path / 'cdwrapper-tmp', os.O_CREAT | os.O_WRONLY | os.O_CLOEXEC, mode=0o744)
         with os.fdopen(fd, 'w') as fp:
             fp.write(f"#!/bin/sh\ncd {path}\n{' '.join(args)}\n")
+        os.replace(path / 'cdwrapper-tmp', path / 'cdwrapper')
         cmd = str(path / 'cdwrapper')
 
     stdout = path / 'stdout'


### PR DESCRIPTION
The could fix #730 but we have currently no way of testing this.

Implemented workarounds in this PR:
  - [x] ~Use `Popen` kwarg `close_fds`. Not sure this is what it is meant for (see https://docs.python.org/3/library/os.html#fd-inheritance)~ `close_fds=True` by default.
  - [x] Use some extra `os.replace` hoops to trick the OS into having a closed copy of the executed file. Not sure this works.
  - [x] ~Use O_CLOEXEC or equivalent when opening the executable file for writing, see https://bugs.python.org/issue16850~ Uh, maybe not, see https://github.com/dotnet/runtime/issues/58964 and this probably has no effect since finalized Python PEP 446, that seems to open all files with `O_CLOEXEC` flag on UNIX by default, says:
> NOTE: The close-on-exec flag has no effect on fork(): all file descriptors are inherited by the child process. The Python issue #16500 “Add an atfork module” proposes to add a new atfork module to execute code at fork, which may be used to automatically close file descriptors.
  - [x] ~Use [`os.register_at_fork`](https://docs.python.org/3/library/os.html?highlight=at_fork#os.register_at_fork).~ This looks like it would create more race conditions than it avoids.

Another possibility is to get rid of the `cdwrapper` script, history below:
  - 5943eba5a
  - f0aef31b7350e517a6ce9b5e65c11f06c8c0f291
  - e13f371b693b0253779bfb785447bcf46b88c4b7
  - 12c785228