### PR TITLE
Add separator in datainfo file and read in dataset correctly

### DIFF
--- a/src/pharmpy/datainfo.py
+++ b/src/pharmpy/datainfo.py
@@ -640,6 +640,9 @@ class DataInfo(MutableSequence):
         if path:
             path = Path(path)
         di.path = path
+        separator = d.get('separator', None)
+        if separator:
+            di.separator = separator
         return di
 
     @staticmethod

--- a/src/pharmpy/modeling/data.py
+++ b/src/pharmpy/modeling/data.py
@@ -1442,15 +1442,12 @@ def read_dataset_from_datainfo(datainfo: Union[DataInfo, Path, str]) -> pd.DataF
     """
     if not isinstance(datainfo, DataInfo):
         datainfo = DataInfo.read_json(datainfo)
-
+    if datainfo.path is None:
+        raise ValueError('datainfo.path is None')
     dtypes = {
         col.name: col.datatype if not col.drop and not col.datatype.startswith('nmtran') else 'str'
         for col in datainfo
     }
-
-    if datainfo.path is None:
-        raise ValueError('datainfo.path is None')
-
     df = pd.read_csv(
         datainfo.path, sep=datainfo.separator, dtype=dtypes, float_precision='round_trip'
     )

--- a/src/pharmpy/modeling/example_models/pheno.datainfo
+++ b/src/pharmpy/modeling/example_models/pheno.datainfo
@@ -5,4 +5,4 @@
 	{ "name": "WGT", "type": "covariate", "scale": "ratio", "unit": "kg", "descriptor": "body weight" },
 	{ "name": "APGR", "type": "covariate", "scale": "ordinal", "categories": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
 	{ "name": "DV", "type": "dv", "scale": "ratio", "unit": "mg/l", "descriptor": "plasma concentration" }
-]}
+	], "separator":"\\s+"}

--- a/src/pharmpy/tools/amd/funcs.py
+++ b/src/pharmpy/tools/amd/funcs.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import pandas as pd
 import sympy
 
 import pharmpy
@@ -20,6 +19,7 @@ from pharmpy.modeling import (
     set_first_order_absorption,
     set_proportional_error_model,
 )
+from pharmpy.modeling.data import read_dataset_from_datainfo
 from pharmpy.workflows import default_model_database
 
 
@@ -55,14 +55,14 @@ def create_start_model(dataset_path, modeltype='pk_oral', cl_init=0.01, vc_init=
     stats = ModelStatements([cl_ass, vc_ass, odes, ipred, y_ass])
 
     datainfo_path = dataset_path.with_suffix('.datainfo')
-    separator = r'\s+|,'
+
     if datainfo_path.is_file():
         di = DataInfo.read_json(dataset_path.with_suffix('.datainfo'))
-        di.separator = separator
+        di.path = dataset_path
     else:
         # FIXME: Create a default di here?
         di = None
-    df = pd.read_table(dataset_path, sep=separator, engine='python')
+    df = read_dataset_from_datainfo(di)
 
     est = EstimationStep(
         "FOCE",

--- a/tests/integration/test_amd.py
+++ b/tests/integration/test_amd.py
@@ -10,7 +10,6 @@ from pharmpy.utils import TemporaryDirectoryChanger
 #         shutil.copy2(testdata / 'nonmem' / 'pheno.dta', tmp_path)
 #         dipath = Path(pharmpy.modeling.__file__).parent / 'example_models' / 'pheno.datainfo'
 #         shutil.copy2(dipath, tmp_path)
-#
 #         res = run_amd(tmp_path / 'pheno.dta', mfl='LAGTIME();PERIPHERALS(1)')
 #         assert res
 

--- a/tests/testdata/nonmem/pheno.datainfo
+++ b/tests/testdata/nonmem/pheno.datainfo
@@ -1,8 +1,8 @@
 {"columns":[
-	{ "name": "ID", "type": "id", "scale": "nominal" },
+	{ "name": "ID", "type": "id", "scale": "nominal", "datatype": "int32", "descriptor": "subject identifier" },
 	{ "name": "TIME", "type": "idv", "scale": "ratio", "unit": "h" },
 	{ "name": "AMT", "type": "dose", "scale": "ratio", "unit": "mg" },
-	{ "name": "WGT", "type": "covariate", "scale": "ratio", "unit": "kg" },
-	{ "name": "APGR", "type": "covariate", "scale": "ordinal" },
-	{ "name": "DV", "type": "dv", "scale": "ratio", "unit": "mg/l" }
-]}
+	{ "name": "WGT", "type": "covariate", "scale": "ratio", "unit": "kg", "descriptor": "body weight" },
+	{ "name": "APGR", "type": "covariate", "scale": "ordinal", "categories": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+	{ "name": "DV", "type": "dv", "scale": "ratio", "unit": "mg/l", "descriptor": "plasma concentration" }
+	], "separator":"\\s+"}

--- a/tests/tools/test_start_model.py
+++ b/tests/tools/test_start_model.py
@@ -4,6 +4,9 @@ from pharmpy.tools.amd.funcs import create_start_model
 def test_create_start_model(testdata):
     path = testdata / 'nonmem' / 'pheno.dta'
     model = create_start_model(path, modeltype='pk_iv')
+    sep = model.datainfo.separator
+    assert sep == "\\s+"
+    assert len(model.dataset.columns) == 8
     assert len(model.parameters) == 6
     assert 'POP_CL' in model.parameters
     assert 'POP_MAT' not in model.parameters


### PR DESCRIPTION
Hi Rikard,

Here is the commit for removing the default separator,  @pharmpy-dev-123 and I found that we should put double backslash before the` s+` in the datainfo file for the white space separator, only one backslash doesn't work. 

Best regard,
Zhe Huang