### PR TITLE
Get explicit ode system as a compartmental system when adding allometry

### DIFF
--- a/src/pharmpy/modeling/allometry.py
+++ b/src/pharmpy/modeling/allometry.py
@@ -1,3 +1,4 @@
+from pharmpy import ExplicitODESystem
 from pharmpy.parameter import Parameter
 from pharmpy.statements import Assignment, sympify
 
@@ -77,8 +78,11 @@ def add_allometry(
     """
     allometric_variable = sympify(allometric_variable)
     reference_value = sympify(reference_value)
+    statements = model.statements.copy()
+    odes = statements.ode_system
+    if type(odes) is ExplicitODESystem:
+        odes = statements.ode_system.to_compartmental_system()
 
-    odes = model.statements.ode_system
     central = odes.central_compartment
     output = odes.output_compartment
 


### PR DESCRIPTION
Hi Rikard,

I tried some codes to make the ode system works: 
 ```
statements = model.statements.copy()
 statements = statements.to_compartmental_system()
 odes = statements.ode_system
```
But it doesn't work, so I had to detect the type of the ode system and only transform it when there is an explicit ode system.

Best regards,
Zhe Huang
