### PR TITLE
[docs] Automation of R examples for web documentation

### DIFF
--- a/docs/_ext/pharmpy_snippet.py
+++ b/docs/_ext/pharmpy_snippet.py
@@ -1,0 +1,167 @@
+from abc import abstractmethod
+from typing import List, Iterator, Union
+from docutils import nodes
+from docutils.statemachine import ViewList, string2lines
+from docutils.parsers.rst import Directive, directives
+
+from conversion import transpile_py_to_r
+
+def setup(app):
+    app.add_directive('pharmpy-execute', PharmpyExecute)
+    app.add_directive('pharmpy-code', PharmpyCode)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }
+
+def csv_option(s):
+    return [p.strip() for p in s.split(",")] if s else []
+
+class RecursiveDirective(Directive):
+
+    def _convert_lines_to_nodes(self, lines: List[str]) -> List[nodes.Node]:
+        """Turn an RST string into a node that can be used in the document.
+
+           See https://github.com/sphinx-doc/sphinx/issues/8039
+        """
+
+        node = nodes.Element()
+        node.document = self.state.document
+        self.state.nested_parse(
+            ViewList(
+                string2lines('\n'.join(lines)),
+                source='[SnippetDirective]',
+            ),
+            self.content_offset,
+            node,
+        )
+
+        return node.children
+
+class PharmpyAbstractCodeDirective(RecursiveDirective):
+
+    option_spec = {
+        'linenos': directives.flag,
+        'lineno-start': directives.nonnegative_int,
+        'emphasize-lines': directives.unchanged_required,
+    }
+
+    def run(self):
+        return self._nodes()
+
+    def _nodes(self):
+        lines = self._lines()
+        return self._convert_lines_to_nodes(lines)
+
+    @abstractmethod
+    def _lines(self) -> List[str]:
+        """Return lines for this directive"""
+
+    def _input(self):
+        return [
+            '.. tabs::',
+            *_indent(3, [
+                '',
+                '.. code-tab:: py',
+                *_indent(3, self._code_option_lines()),
+                '',
+                *_indent(3, self.content),
+                '',
+                '.. code-tab:: r R',
+                *_indent(3, self._code_option_lines()),
+                '',
+                *_indent(3, transpile_py_to_r(self.content)),
+            ]),
+        ]
+
+    def _code_option_lines(self):
+        if 'emphasize-lines' in self.options:
+            yield f':emphasize-lines:{self.options.get("emphasize-lines")}'
+        if 'linenos' in self.options:
+            yield ':linenos:'
+        if 'lineno-start' in self.options:
+            yield f':lineno-start:{self.options.get("lineno-start")}'
+
+
+class PharmpyExecute(PharmpyAbstractCodeDirective):
+    required_arguments = 0
+    optional_arguments = 0
+    final_argument_whitespace = True
+    has_content = True
+
+    option_spec = {
+        **PharmpyAbstractCodeDirective.option_spec,
+        'hide-code': directives.flag,
+        'hide-output': directives.flag,
+        'code-below': directives.flag,
+        'raises': csv_option,
+        'stderr': directives.flag,
+    }
+
+    def _lines(self) -> List[str]:
+        return [
+            f'.. container:: pharmpy-snippet{"" if "hide-output" in self.options else " with-output"}',
+            '',
+            *_indent(3, self._input_output_lines())
+        ]
+
+    def _input_output_lines(self):
+        # NOTE self._output should always be returned here, even when
+        # `hide-output` is set, otherwise the code will not be executed.
+        if 'hide-code' in self.options:
+            return self._output()
+
+        if 'code-below' in self.options:
+            return [
+                *self._output(),
+                '',
+                *self._input(),
+            ]
+
+        return [
+            *self._input(),
+            '',
+            *self._output(),
+        ]
+
+
+    def _output(self):
+        return [
+            '.. jupyter-execute::',
+            *_indent(3, [
+                *self._jupyter_option_lines(),
+                '',
+                *self.content
+            ]),
+        ]
+
+    def _jupyter_option_lines(self):
+        yield ':hide-code:'
+        if 'hide-output' in self.options:
+            yield ':hide-output:'
+        if 'raise' in self.options:
+            yield f':raises:{",".join(self.options.get("raises"))}'
+        if 'stderr' in self.options:
+            yield ':stderr:'
+
+
+class PharmpyCode(PharmpyAbstractCodeDirective):
+    required_arguments = 0
+    optional_arguments = 0
+    final_argument_whitespace = True
+    has_content = True
+
+    option_spec = PharmpyAbstractCodeDirective.option_spec
+
+    def _lines(self) -> List[str]:
+        return [
+            '.. container:: pharmpy-snippet',
+            '',
+            *_indent(3, self._input())
+        ]
+
+
+def _indent(n: int, lines: Union[List[str],Iterator[str]]):
+    return map(lambda line: (' '*n + line) if line else line, lines)

--- a/docs/bootstrap.rst
+++ b/docs/bootstrap.rst
@@ -27,7 +27,7 @@ Column              Description
 ==================  =============================================
 
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     from pharmpy.results import read_results
@@ -41,14 +41,14 @@ All percentiles are calculated using linear interpolation if it falls between tw
 and :math:`x_1` the percentile would be :math:`x_0 + (x_1 - x_0) f` where :math:`f` is :math:`[np]`, the fractional part of the number of observations
 :math:`n` multiplied by the percentile :math:`p`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.parameter_distribution
 
 The ``parameter_estimates_histogram`` give histograms for the distributions of the parameter estimates:
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.parameter_estimates_histogram
@@ -56,7 +56,7 @@ The ``parameter_estimates_histogram`` give histograms for the distributions of t
 
 The raw parameter data is available in ``parameter_estimates``
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.parameter_estimates
@@ -80,21 +80,21 @@ Row                          Description
 
 Note that some of these rows will not be created if the bootstrap was run without the `dofv` option.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.ofv_statistics
 
 The ``ofv_distribution`` gives a numeric overview of the OFVs similar to the ``parameter_distriution`` described above. 
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.ofv_distribution
 
 A histogram of the bootstrap ofv from ``ofv_plot``:
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.ofv_plot
@@ -102,7 +102,7 @@ A histogram of the bootstrap ofv from ``ofv_plot``:
 The ``dofv_quantiles_plot`` show distribution of the delta-OFV metrics over the distribution quantiles. They are compared with
 a chi-square distribution.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.dofv_quantiles_plot
@@ -111,7 +111,7 @@ a chi-square distribution.
 
 The raw ofv data is available in ``ofvs``.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.ofvs
@@ -122,7 +122,7 @@ Covariance matrix
 
 A covariance matrix for the parameters is available in ``covariance_matrix``:
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.covariance_matrix
@@ -132,7 +132,7 @@ Included individuals
 
 The ``included_individuals`` is a list of lists with all individuals that were included in each bootstrap run.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     import pandas as pd

--- a/docs/cdd.rst
+++ b/docs/cdd.rst
@@ -14,7 +14,7 @@ Case results
 The ``case_results`` table contains the different results and metrics for each case.
 
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     from pharmpy.results import read_results
@@ -88,8 +88,7 @@ Case column
 
 The Name of the case column in the dataset can be found in ``case_column``.
 
-.. jupyter-execute::
-    :hide-code:
+.. pharmpy-execute::
 
     res.case_column
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,7 @@
 import os
+import sys
 
+sys.path.append(os.path.abspath('./_ext'))
 
 extensions = [
     'sphinx.ext.autodoc',
@@ -16,7 +18,9 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx_automodapi.automodapi',
     'jupyter_sphinx',
+    'sphinx_tabs.tabs',
     'sphinxcontrib.autoprogram',
+    'pharmpy_snippet',
 ]
 if os.getenv('SPELLCHECK'):
     extensions += 'sphinxcontrib.spelling',

--- a/docs/crossval.rst
+++ b/docs/crossval.rst
@@ -13,7 +13,7 @@ Crossvalidation OFVs
 
 The ``runs`` table contains the OFVs of the estimation and prediction runs of crossval.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     import pathlib
@@ -23,7 +23,7 @@ The ``runs`` table contains the OFVs of the estimation and prediction runs of cr
 
 The sum of all prediction OFVs can be found in ``prediction_ofv_sum``
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.prediction_ofv_sum

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -4,6 +4,41 @@
     overflow-x: scroll;
 }
 
+.pharmpy-snippet {
+    margin: 1em 0;
+}
+
+.pharmpy-snippet div[class*="highlight-"] {
+    margin: 0;
+}
+
+.pharmpy-snippet > .sphinx-tabs {
+    margin: 0;
+}
+
+.pharmpy-snippet > .sphinx-tabs pre {
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+}
+
+/**
+ * Could use upcoming :has(...) to use display:none fallback when not output is
+ * produced. Instead of having to manually specify :hide-output:.
+ */
+.pharmpy-snippet.with-output > .jupyter_cell {
+    padding: 1em;
+    background-color: #FFFF;
+    border: 1px solid #CCC;
+    -moz-box-shadow: 2px 2px 4px rgba(87, 87, 87, 0.2);
+    -webkit-box-shadow: 2px 2px 4px rgba(87, 87, 87, 0.2);
+    box-shadow: 2px 2px 4px rgba(87, 87, 87, 0.2);
+}
+
+.pharmpy-snippet.with-output > .jupyter_cell > .cell_output > .output > div {
+    overflow-x: scroll;
+}
+
 table.dataframe {
     border-collapse: collapse;
     border: none;

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -13,14 +13,14 @@ Retrieving the dataset from a model
 
 The dataset connected to a model can be retrieved from the `dataset` attribute. 
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
    :hide-code:
 
    from pathlib import Path
    path = Path('tests/testdata/nonmem/')
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import read_model
 
@@ -32,14 +32,14 @@ This is the dataset after applying any model specific filtering and handling of 
 
 The raw dataset can also be accessed
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    raw = model.read_raw_dataset()
    raw
 
 Note that all values here are strings
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    raw.dtypes
 
@@ -49,12 +49,13 @@ Update the dataset of a model
 
 A new or updated dataset can be set to a model
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    import numpy as np
 
    df['DV'] = np.log(df['DV'], where=(df['DV'] != 0))
-   model.dataset = df 
+   model.dataset = df
 
 ~~~~~~~~
 Subjects
@@ -62,7 +63,7 @@ Subjects
 
 An array of all subject IDs can be retrieved.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import get_ids
     model = read_model(path / "pheno_real.mod")
@@ -70,7 +71,7 @@ An array of all subject IDs can be retrieved.
 
 The number of subjects in the dataset could optionally be retrieved directly.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import get_number_of_individuals
     get_number_of_individuals(model)
@@ -82,14 +83,14 @@ Observations
 
 The observations of the dataset indexed on subject ID and the independent variable can be extracted.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import get_observations
     get_observations(model)
 
 The total number of observations can optionally be retrieved directly.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import get_number_of_observations
     get_number_of_observations(model)
@@ -103,7 +104,7 @@ Extract dosing information
 
 The doses of the dataset indexed on subject ID and the independent variable can be extracted.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import get_doses
     doses = get_doses(model)
@@ -111,17 +112,17 @@ The doses of the dataset indexed on subject ID and the independent variable can 
 
 All unique doses can be listed
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     doses.unique()
 
 as well as the largest and the smallest dose
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     doses.min()
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     doses.max()
 
@@ -130,7 +131,7 @@ Dose grouping
 
 It is possible to create a DOSEID that groups each dose period starting from 1.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import get_doseid
     ser = get_doseid(model)
@@ -141,7 +142,7 @@ Time after dose
 
 Add a column for time after dose (TAD)
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import add_time_after_dose
     add_time_after_dose(model)
@@ -152,7 +153,7 @@ Concentration parameters
 
 Extract pharmacokinetic concentration parameters from the dataset
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import get_concentration_parameters_from_data
     get_concentration_parameters_from_data
@@ -164,20 +165,21 @@ DataInfo
 
 Every model has a `DataInfo` object that describes the dataset.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     di = model.datainfo
     di
 
 The path to the dataset file if one exists.
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
     di.path
 
 Separator character for the dataset file.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     di.separator
 
@@ -186,7 +188,7 @@ ColumnInfo
 
 Each column of the dataset can here be given some additional information.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.datainfo['AMT']
 
@@ -238,7 +240,7 @@ datainfo file
 
 If a dataset file has an accompanying file with the same name and the extension ``.datainfo`` this will be read in when handling the dataset in Pharmpy. This file is a representation (a serialization) of a ``DataInfo`` object and its content can be created manually, with an external tool or by Pharmpy. Here is an example of the content:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     di.to_json()
 

--- a/docs/frem.rst
+++ b/docs/frem.rst
@@ -70,7 +70,7 @@ Covariate effects
 
 The effects of each covariate on each parameter is calculated with uncertainty and summarized in the ``covariate_effects`` table.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     from pharmpy.results import read_results
@@ -109,7 +109,7 @@ For each parameter and covariate calculate the mean, 5:th and 95:th percentile o
 
 The covariate effect plots give the covariate effects in percent with uncertainty for each parameter and covariate in turn. The red figures are the 5th and 95th percentile covariate values.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.covariate_effects_plot
@@ -121,7 +121,7 @@ Parameter covariate coefficients
 The parameter covariate coefficients for each covariate separately and for all taken together are available in ``coefficients``. The definition for one coefficient is 
 `Cov(Par, Covariate) / Var(Covariate)` and generalized for all together by the matrix :math:`\Sigma_{12}\Sigma_{22}^{-1}`
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.coefficients
@@ -131,7 +131,7 @@ Individual covariate effects
 
 The combined effects of all covariates on the parameters of each individual is calculated with uncertainty and summarized in the ``individual_effects`` table.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.individual_effects
@@ -140,7 +140,7 @@ The conditional distribution as above is calculated for the estimated parameters
 
 The plot shows the individuals with the lowest and the highest percentual covariate effect and the uncertainty.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.individual_effects_plot
@@ -151,7 +151,7 @@ Unexplained variability
 
 The unexplained variability is calculated and summarized in the ``unexplained_variability`` table.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.unexplained_variability
@@ -166,14 +166,14 @@ The presented results are the 5th and 95th percetiles of the standard deviations
 
 The plot display the original unexplained variability with the uncertainty for all parameter and covariate combinations.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.unexplained_variability_plot
 
 All variability parameters given the estimated parameters conditioned on each covariate in turn can be found in ``parameter_variability``.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.parameter_variability
@@ -184,14 +184,14 @@ Parameter estimates
 
 The parameter initial estimates and final estimates of the base model (model_1), all intermediate models and the FREM model (model_4) are tabled in ``parameter_inits_and_estimates``.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.parameter_inits_and_estimates
 
 Relative difference between of the base model parameters estimates and the final model parameter estimates are calculated in ``base_parameter_change``.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.base_parameter_change
@@ -202,7 +202,7 @@ OFV
 
 OFV of the base model, all intermediate models and the final FREM model are collected into ``ofv``.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.ofv
@@ -213,7 +213,7 @@ Estimated covariate values
 The FREM model also gives an estimate of the covariate values themselves. Ideally these values should be close to the ones in the dataset. Summary statistics for the estimated
 covariate values are put into ``estimated_covariates``.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.estimated_covariates

--- a/docs/iivsearch.rst
+++ b/docs/iivsearch.rst
@@ -15,7 +15,7 @@ The iiv tool is available both in Pharmpy/pharmr and from the command line.
 
 To initiate iiv in Python:
 
-.. code:: python
+.. pharmpy-code::
 
     from pharmpy.modeling import run_tool
 

--- a/docs/linearize.rst
+++ b/docs/linearize.rst
@@ -13,7 +13,7 @@ OFVs
 
 The OFVs of the base model and the linearized model before and after estimation are summarized in the ``ofv`` table. These values should be close. A difference signals problems with the linearization.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     from pharmpy.results import read_results
@@ -26,14 +26,14 @@ Individual OFVs
 
 The individual OFVs for the base and linearized models together with their difference is in the ``iofv`` table. If there was a deviation in the ``ofv`` these values can be used to see if some particular individual was problematic to linearize.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.iofv
 
 This is also plotted in ``iofv_plot``
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.iofv_plot

--- a/docs/model.rst
+++ b/docs/model.rst
@@ -12,14 +12,15 @@ Reading in a model
 
 Reading a model from a model specification file into a Pharmy model object can be done by using the factory constructor.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
    :hide-code:
 
    from pathlib import Path
    path = Path('tests/testdata/nonmem/')
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    from pharmpy import Model
 
@@ -34,7 +35,7 @@ Model name
 
 A model has a name property that can be read or changed. After reading a model from a file the name is set to the filename without extension.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model.name
 
@@ -46,14 +47,14 @@ Writing a model
 
 A model object can be written to a file using its source format. By default the model file will be created in the current working directory using the name of the model.
 
-.. code-block::
+.. pharmpy-code::
 
     from pharmpy.modeling import write_model
     write_model(model)
 
 Optionally a path can be specified:
 
-.. code-block::
+.. pharmpy-code::
 
    write_model(model, path='/home/user/mymodel.mod')
 
@@ -64,7 +65,7 @@ Getting the model code
 
 The model code can be retrieved as a string directly by the string method of the model object.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    print(model)
 
@@ -74,7 +75,7 @@ Model parameters
 
 Model parameters are scalar values that are used in the mathematical definition of the model and are estimated when a model is fit from data. The parameters of a model are thus optimization parameters and can in turn be used as parameters in statistical distributions or as structural parameters. A parameter is defined using the :py:class:`pharmpy.Parameter` class.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy import Parameter
 
@@ -83,14 +84,14 @@ Model parameters are scalar values that are used in the mathematical definition 
 
 A model parameter must have a name and an inital value and can optionally be constrained to a lower and or upper bound. A parameter can also be fixed meaning that it will be set to its initial value. The parameter attributes can be read out or changed via properties.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    par.lower = -1
    print(par)
 
 The parameter space of a parameter can be retrieved via a property:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
       par.parameter_space
 
@@ -100,14 +101,14 @@ Parameter sets
 
 It is often convenient to work with a set of parameters at the same time, for example all parameters of a model. In Pharmpy a multiple parameters are organized in the :py:class:`pharmpy.Parameters` class as an ordered set of :py:class:`pharmpy.Parameter`. All parameters of a model can be accessed by using the parameters attribute:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    parset = model.parameters
    parset
 
 Each parameter can be retrieved using indexing
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    parset['THETA(1)']
 
@@ -115,20 +116,20 @@ Operations on multiple parameters are made easier using methods or properties on
 
 Get all initial estimates as a dictionary:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    parset.inits
 
 Setting initial estimates of some of the parameters:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    parset.inits = {'THETA(1)': 0.5, 'OMEGA(1,1)': 0.05}
    parset
 
 Fix some parameters:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    parset.fix = {'THETA(2)': True, 'THETA(3)': True}
    parset
@@ -141,16 +142,16 @@ Modelfit results
 
 If a model has been fit the results can be retrieved directly from the model object. Here are some examples of the results that can be available:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model.modelfit_results.parameter_estimates
 
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model.modelfit_results.covariance_matrix
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model.modelfit_results.standard_errors
 
@@ -160,13 +161,14 @@ Updating initial estimates
 
 Updating all initial estimates of a model from its own results can be done either by directly setting:
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    model.parameters = model.modelfit_results.parameter_estimates
 
 or using the convenient function:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import update_inits
     update_inits(model)
@@ -177,70 +179,71 @@ Random variables
 
 The random variables of a model are available through the random_variables property:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    rvs = model.random_variables
    rvs
 
 Each random variable is a SymPy random variable and can be accessed separately using indexing:
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    eta1 = rvs['ETA(1)']
 
 And the parameters of the random variable can be retrieved:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    eta1.sympy_rv.pspace.distribution.mean
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    eta1.sympy_rv.pspace.distribution.std
 
 Joint distributions are also supported
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    frem_model = Model.create_model(path / "frem" / "pheno" / "model_4.mod")
 
    rvs = frem_model.random_variables
    rvs
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    omega = rvs['ETA(1)'].sympy_rv.pspace.distribution.sigma
    omega
 
 Substitution of numerical values can be done directly from initial values
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    omega.subs(frem_model.parameters.inits)
 
 or from estimated values
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    omega_est = omega.subs(dict(frem_model.modelfit_results.parameter_estimates))
    omega_est
 
 Operations on this parameter matrix can be done either by using SymPy
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    omega_est.cholesky()
 
 or in a pure numerical setting in NumPy
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    import numpy as np
 
    a = np.array(omega_est).astype(np.float64)
    a
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    np.linalg.cholesky(a)
 
@@ -250,7 +253,7 @@ Model statements
 
 The model statements represent the mathematical description of the model. All statements can be retrieved via the statements property as a :py:class:`pharmpy.ModelStatements` object, which is a list of model statements.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    statements = model.statements
    print(statements)
@@ -259,25 +262,25 @@ Changing the statements of a model can be done by setting the statements propert
 
 If the model has a system of ordinary differential equations this will be part of the statements. It can easily be retrieved from the statement object
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    print(statements.ode_system)
 
 ODE systems can either be described as a compartmental system via :py:class:`pharmpy.statements.CompartmentalSystem` as in the example above or as a system of explicit differential equations using :py:class:`pharmpy.statements.ExplicitODESystem`. Both representations are mathematically equivalent. The compartmental system offers some convenient methods and properties. Get the explicit odes and initial conditions:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    odes = statements.ode_system.to_explicit_system()
    odes
 
 Get the amounts vector:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    statements.ode_system.amounts
 
 Get the compartmental matrix:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    statements.ode_system.compartmental_matrix

--- a/docs/modelfit.rst
+++ b/docs/modelfit.rst
@@ -15,7 +15,7 @@ Final OFV
 
 The final OFV is available in `ofv`:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import read_model
 
@@ -28,13 +28,13 @@ Parameter estimates
 
 The `parameter_estimates` series contains the final estimates of all estimated parameters.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.parameter_estimates
 
 It is also possible to get the parameters with all variability parameters as standard deviations or correlations.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model.modelfit_results.parameter_estimates_sdcorr 
 
@@ -43,13 +43,13 @@ Standard errors of parameter estimates
 
 The standard errors of the parameter estimates are in the `standard_errors` series.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.standard_errors
 
 Or in `standard_errors_sdcorr` with variability parameters as standard deviations or correlations.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.standard_errors_sdcorr
 
@@ -59,7 +59,7 @@ Relative standard errors of parameter estimates
 The relative standard errors of the parameter estimates
 
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.relative_standard_errors
 
@@ -68,7 +68,7 @@ Covariance matrix
 
 The covariance matrix for all estimated parameters
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.covariance_matrix
 
@@ -81,7 +81,7 @@ The correlation matrix for all estimated parameters.
     Note to NONMEM users. This is a proper correlation matrix meaning that diagonal elements are 1.
     Standard errors can be retrieved from `standard_errors`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.correlation_matrix
 
@@ -90,7 +90,7 @@ Information Matrix
 
 The information matrix for all estimated parameters. This is the inverse of the covariance matrix.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.information_matrix
 
@@ -99,7 +99,7 @@ Indiviudal OFV
 
 The OFV for each individual or `iOFV` is in the `individual_ofv` series.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.individual_ofv
 
@@ -108,7 +108,7 @@ Predictions
 
 Different predictions can be found in `predictions`
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.predictions
 
@@ -117,7 +117,7 @@ Residuals
 
 Different residual metrics can be found in `residuals` 
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.residuals
 
@@ -126,12 +126,12 @@ Individual estimates
 
 Individual estimates (or EBEs)
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.individual_estimates
 
 Uncertainty for the individual estimates can be found in `individual_estimates_covariance`, which is a series of covariance matrices for each individual.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     model.modelfit_results.individual_estimates_covariance[1]

--- a/docs/modeling.rst
+++ b/docs/modeling.rst
@@ -9,7 +9,7 @@ with low level operations the modeling module offers higher level operations and
 These transformations are also available via the Pharmpy command line interface. To read more about these functions
 such as how the initial estimates of parameters are chosen, see their respective API documentation.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
    :hide-code:
 
@@ -19,7 +19,7 @@ such as how the initial estimates of parameters are chosen, see their respective
 
 The following model is the start model for the examples.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import read_model
 
@@ -43,7 +43,7 @@ Reading, writing and updating source models
 Read model from file
 ====================
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    from pharmpy.modeling import *
@@ -54,7 +54,7 @@ Read model from string
 
 If the model code is in a string variable it can be read in directly.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-output:
 
     code = '$PROBLEM base model\n$INPUT ID DV TIME\n$DATA file.csv IGNORE=@\n$PRED Y = THETA(1) + ETA(1) + ERR(1)\n$THETA 0.1\n$OMEGA 0.01\n$SIGMA 1\n$ESTIMATION METHOD=1'
@@ -65,7 +65,7 @@ Getting the model code
 
 The model code (e.g. the NONMEM code) can be retrieved using the `model_code` attribute.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    model = read_model(path / 'pheno.mod')
@@ -74,7 +74,7 @@ The model code (e.g. the NONMEM code) can be retrieved using the `model_code` at
 Write model to file
 ===================
 
-.. code::
+.. pharmpy-code::
 
    write_model(model, 'mymodel.mod')
 
@@ -86,7 +86,7 @@ Fix and unfix parameters
 
 The functions for fixing/unfixing parameters take either a list of parameter names or one single parameter name string.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    fix_parameters(model, ['THETA(1)', 'THETA(2)'])
@@ -95,7 +95,7 @@ The functions for fixing/unfixing parameters take either a list of parameter nam
 It is also possible to fix and unfix the parameters to a specified value or to a list of values. If parameter_names
 is None, all parameters will be transformed.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    fix_parameters_to(model, ['THETA(1)', 'THETA(2)'], [0, 1])
@@ -109,7 +109,7 @@ Add parameter
 
 A new parameter can be added by using the name of the new parameter.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / 'pheno.mod')
    add_individual_parameter(model, 'MAT')
@@ -138,14 +138,15 @@ Let us use a model with bolus absorption as a starting point.
      S -> "Central" [label="Bolus"];
    }
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    from pharmpy.modeling import set_bolus_absorption
    model = read_model(path / "pheno.mod")
 
 This type of absorption can be created with:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     set_bolus_absorption(model)
     print_model_diff(model_ref, model)
@@ -169,7 +170,7 @@ Let us now change to zero order absorption.
 
 See :py:func:`pharmpy.modeling.set_zero_order_absorption`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_zero_order_absorption
    set_zero_order_absorption(model)
@@ -194,7 +195,7 @@ First order absorption would mean adding an absorption (depot) compartment like 
 
 See :py:func:`pharmpy.modeling.set_first_order_absorption`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_first_order_absorption
    set_first_order_absorption(model)
@@ -219,7 +220,7 @@ Sequential zero-order absorption followed by first-order absorption will have an
 
 See :py:func:`pharmpy.modeling.set_seq_zo_fo_absorption`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_seq_zo_fo_absorption
    set_seq_zo_fo_absorption(model)
@@ -233,7 +234,7 @@ Transit compartments
 
 Transit compartments can be added or removed using the :py:func:`pharmpy.modeling.set_transit_compartments` function.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / "pheno.mod")
    from pharmpy.modeling import set_transit_compartments
@@ -245,13 +246,14 @@ Transit compartments can be added or removed using the :py:func:`pharmpy.modelin
 Lag time
 ========
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    model = read_model(path / "pheno.mod")
 
 Lag time may be added to a dose compartment of a model.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import add_lag_time
    add_lag_time(model)
@@ -259,7 +261,7 @@ Lag time may be added to a dose compartment of a model.
 
 Similarly, to remove lag time:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import remove_lag_time
    remove_lag_time(model)
@@ -274,7 +276,7 @@ elimination.
 First-order elimination
 =======================
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_first_order_elimination
    model = read_model(path / "pheno.mod")
@@ -286,7 +288,7 @@ See :py:func:`pharmpy.modeling.set_first_order_elimination`.
 Zero-order elimination
 ======================
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_zero_order_elimination
    model = read_model(path / "pheno.mod")
@@ -298,7 +300,7 @@ See :py:func:`pharmpy.modeling.set_zero_order_elimination`.
 Michaelis-Menten elimination
 ============================
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_michaelis_menten_elimination
    model = read_model(path / "pheno.mod")
@@ -310,7 +312,7 @@ See :py:func:`pharmpy.modeling.set_michaelis_menten_elimination`.
 Mixed Michaelis-Menten + First-Order elimination
 ===================================================
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_mixed_mm_fo_elimination
    model = read_model(path / "pheno.mod")
@@ -325,13 +327,14 @@ Distribution
 Add peripheral compartment
 ==========================
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    model = read_model(path / "pheno.mod")
 
 Adding a peripheral compartment.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import add_peripheral_compartment
    add_peripheral_compartment(model)
@@ -343,7 +346,7 @@ Remove peripheral compartment
 
 Removing a peripheral compartment.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import remove_peripheral_compartment
    remove_peripheral_compartment(model)
@@ -358,7 +361,7 @@ Set the number of peripheral compartments
 
 As an alternative to adding or removing one peripheral compartment a certain number of peripheral compartents can be set directly.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_peripheral_compartments
    set_peripheral_compartments(model, 2)
@@ -371,13 +374,14 @@ As an alternative to adding or removing one peripheral compartment a certain num
 Adding covariate effects
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    model = read_model(path / "pheno.mod")
 
 Covariate effects may be applied to a model.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    from pharmpy.modeling import add_covariate_effect
@@ -387,7 +391,7 @@ Here, *CL* indicates the name of the parameter onto which you want to apply the 
 covariate, and *pow* (power function) is the effect you want to apply. The effect can be either
 added or multiplied to the parameter, denoted by '*' or '+' (multiplied is default).
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    print_model_diff(model_ref, model)
 
@@ -398,7 +402,7 @@ added or multiplied to the parameter, denoted by '*' or '+' (multiplied is defau
 
 Pharmpy also supports user formatted covariate effects.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    model = read_model(path / "pheno.mod")
@@ -409,7 +413,7 @@ The covariate is denoted as *cov*, the theta as *theta* (or, if multiple thetas:
 median, and standard deviation as *mean*, *median*, and *std* respectively. This is in order for
 the names to be substituted with the correct symbols.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    print_model_diff(model_ref, model)
 
@@ -420,14 +424,15 @@ Transformation of etas
 Boxcox
 ~~~~~~
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    model = read_model(path / "pheno.mod")
 
 To apply a boxcox transformation, input a list of the etas of interest. See
 :py:func:`pharmpy.modeling.transform_etas_boxcox`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import transform_etas_boxcox
    transform_etas_boxcox(model, ['ETA(1)'])
@@ -438,7 +443,7 @@ transformation of *ETA(1)*.
 
 If no list is provided, all etas will be updated.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / "pheno.mod")
    transform_etas_boxcox(model)
@@ -451,7 +456,7 @@ Applying an approximate t-distribution transformation of etas is analogous to a 
 is a list of etas, and if no list is provided all etas will be transformed. See
 :py:func:`pharmpy.modeling.transform_etas_tdist`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / "pheno.mod")
    from pharmpy.modeling import transform_etas_tdist
@@ -464,7 +469,7 @@ John Draper
 John Draper transformation is also supported. The function takes a list of etas as input, if no list is
 provided all etas will be transformed. See :py:func:`pharmpy.modeling.transform_etas_john_draper`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / "pheno.mod")
    from pharmpy.modeling import transform_etas_john_draper
@@ -478,13 +483,14 @@ Adding new etas
 Adding IIVs
 ~~~~~~~~~~~
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    model = read_model(path / "pheno.mod")
 
 IIVs may be added to a model.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    from pharmpy.modeling import add_iiv
@@ -494,14 +500,14 @@ In this example, *S1* is the parameter to add the IIV to, *exp* is the effect on
 :py:class:`pharmpy.modeling.add_iiv` for available templates and how initial estimates are chosen). The
 operation denotes whether the new eta should be added or multiplied (default).
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    print_model_diff(model_ref, model)
 
 For some of the templates, such as proportional etas, the operation can be omitted since it is
 already defined by the effect.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / "pheno.mod")
    add_iiv(model, 'S1', 'prop')
@@ -510,7 +516,7 @@ already defined by the effect.
 A list of parameter names can also be used as input. In that case, the effect and the operation (if not omitted) must
 be either a string (in that case, all new IIVs will have those settings) or be a list of the same size.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / "pheno.mod")
    add_iiv(model, ['V', 'S1'], 'exp')
@@ -520,7 +526,7 @@ be either a string (in that case, all new IIVs will have those settings) or be a
 Similarly to when you :ref:`add a covariate effect<cov_effects>`, you can add user
 specified effects.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    model = read_model(path / "pheno.mod")
@@ -529,14 +535,14 @@ specified effects.
 
 The new etas need to be denoted as *eta_new*.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    print_model_diff(model_ref, model)
 
 You can also provide a custom eta name, i.e the name of the internal representation of the eta in Pharmpy. For
 example, if you want to be able to use the NONMEM name.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / "pheno.mod")
    add_iiv(model, 'S1', 'exp', eta_names='ETA(3)')
@@ -546,11 +552,12 @@ example, if you want to be able to use the NONMEM name.
 Adding IOVs
 ~~~~~~~~~~~
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    model = read_model(path / "pheno.mod")
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
    :hide-code:
 
@@ -559,7 +566,7 @@ Adding IOVs
 
 Similarly, you can also add IOVs to your model.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    from pharmpy.modeling import add_iov
@@ -568,24 +575,25 @@ Similarly, you can also add IOVs to your model.
 In this example, *FA1* is the name of the occasion column, and the etas on which you wish to add the IOV on are
 provided as a list. See :py:class:`pharmpy.modeling.add_iov` for information on how initial estimates are chosen.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    print_model_diff(model_ref, model)
 
 The name of the parameter may also be provided as an argument, and a mix of eta names and parameter names is
 supported.
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    model = read_model(path / "pheno.mod")
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
    :hide-code:
 
    model.dataset['FA1'] = np.random.randint(0, 2, len(model.dataset.index))
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    add_iov(model, 'FA1', ['CL', 'ETA(2)'])
    print_model_diff(model_ref, model)
@@ -599,17 +607,18 @@ the eta_names argument. For example, if you want to be able to use the NONMEM na
    The number of names must be equal to the number of created etas (i.e. the number of
    input etas times the number of categories for occasion).
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    model = read_model(path / "pheno.mod")
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
    :hide-code:
 
    model.dataset['FA1'] = np.random.randint(0, 2, len(model.dataset.index))
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    add_iov(model, 'FA1', ['ETA(1)'], eta_names=['ETA(3)', 'ETA(4)'])
    model.random_variables
@@ -622,14 +631,15 @@ Removing etas
 Remove IIVs
 ~~~~~~~~~~~
 
-.. jupyter-execute::
+.. pharmpy-execute::
+   :hide-output:
 
    model = read_model(path / "pheno.mod")
 
 Etas can also be removed by providing a list of etas and/or name of parameters to remove IIV from. See
 :py:func:`pharmpy.modeling.remove_iiv`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import remove_iiv
    remove_iiv(model, ['ETA(1)', 'V'])
@@ -637,7 +647,7 @@ Etas can also be removed by providing a list of etas and/or name of parameters t
 
 If you want to remove all etas, leave argument empty.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / "pheno.mod")
    from pharmpy.modeling import remove_iiv
@@ -650,14 +660,14 @@ Remove IOVs
 You can remove IOVs as well, however all IOV omegas will be removed. See
 :py:func:`pharmpy.modeling.remove_iov`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
    :hide-code:
 
     import warnings
     warnings.filterwarnings('ignore', message='No IOVs present')
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    model = read_model(path / "pheno.mod")
@@ -674,14 +684,14 @@ Removing the error model
 .. warning::
    Removing all epsilons might lead to a model that isn't runnable.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    model = read_model(path / "pheno.mod")
 
 The error model can be removed.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import remove_error_model
 
@@ -701,28 +711,28 @@ same error model can be approximated to :math:`y = \log f + \frac{\epsilon_a}{f}
 where the approximation is the first term of the Taylor expansion of :math:`\log(1 + x)`.
 
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    model = read_model(path / "pheno.mod")
 
 To set an additive error model:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_additive_error_model
 
    set_additive_error_model(model)
    model.statements.find_assignment('Y')
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    print_model_diff(model_ref, model)
 
 To set an additive error model with log transformed data:
 
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_additive_error_model
 
@@ -746,27 +756,27 @@ same error model can be approximated to :math:`y = \log f + \epsilon_p`. This be
 
 where again the approximation is the first term of the Taylor expansion of :math:`\log(1 + x)`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    model = read_model(path / "pheno.mod")
 
 To set a proportional error model:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_proportional_error_model
 
    set_proportional_error_model(model)
    model.statements.find_assignment('Y')
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    print_model_diff(model_ref, model)
 
 To set a proportional error model with log transformed data:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_proportional_error_model
 
@@ -789,27 +799,27 @@ same error model can be approximated to :math:`y = \log f + \epsilon_p + \frac{\
 
 where again the approximation is the first term of the Taylor expansion of :math:`\log(1 + x)`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    model = read_model(path / "pheno.mod")
 
 To set a combined error model:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_combined_error_model
 
    set_combined_error_model(model)
    model.statements.find_assignment('Y')
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    print_model_diff(model_ref, model)
 
 To set a combined error model with log transformed data:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_combined_error_model
 
@@ -823,14 +833,14 @@ See :py:func:`pharmpy.modeling.set_combined_error_model`.
 Applying IIV on RUVs
 ~~~~~~~~~~~~~~~~~~~~
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    model = read_model(path / "pheno.mod")
 
 IIVs can be added to RUVs by multiplying epsilons with an exponential new eta.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_iiv_on_ruv
 
@@ -840,7 +850,7 @@ IIVs can be added to RUVs by multiplying epsilons with an exponential new eta.
 Input a list of the epsilons you wish to transform, leave argument empty if all epsilons should be
 transformed.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / "pheno.mod")
    set_iiv_on_ruv(model)
@@ -850,7 +860,7 @@ See :py:func:`pharmpy.modeling.set_iiv_on_ruv`.
 
 Custom eta names are supported the same way as when :ref:`adding IOVs<add_iov_custom_names>`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / "pheno.mod")
    set_iiv_on_ruv(model, ['EPS(1)'], eta_names=['ETA(3)'])
@@ -860,7 +870,7 @@ Custom eta names are supported the same way as when :ref:`adding IOVs<add_iov_cu
 Power effects on RUVs
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import set_power_on_ruv
    model = read_model(path / "pheno.mod")
@@ -878,7 +888,7 @@ Estimate standard deviation of epsilons with thetas
 Someimes it is useful to estimate a theta instead of a sigma. This can be done by fixing the sigma to 1 and multiplying the
 correspondng epsilon with a theta. This way the theta will represent the standard deviation of the epsilon.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import use_thetas_for_error_stdev
     model = read_model(path / "pheno.mod")
@@ -888,7 +898,7 @@ correspondng epsilon with a theta. This way the theta will represent the standar
 Weighted error model
 ~~~~~~~~~~~~~~~~~~~~
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import set_weighted_error_model
     model = read_model(path / "pheno.mod")
@@ -898,7 +908,7 @@ Weighted error model
 dTBS error model
 ~~~~~~~~~~~~~~~~
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import set_weighted_error_model
     model = read_model(path / "pheno.mod")
@@ -909,7 +919,7 @@ dTBS error model
 Creating joint distributions of multiple etas
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    model = read_model(path / "pheno.mod")
@@ -917,7 +927,7 @@ Creating joint distributions of multiple etas
 Pharmpy supports the joining of multiple etas into a joint distribution. See
 :py:func:`pharmpy.modeling.create_joint_distribution`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import create_joint_distribution
 
@@ -927,7 +937,7 @@ Pharmpy supports the joining of multiple etas into a joint distribution. See
 The listed etas will be combined into a new distribution. Valid etas must be IIVs and cannot be
 fixed. If no list is provided as input, all etas would be included in the same distribution.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    model = read_model(path / "pheno.mod")
    create_joint_distribution(model)
@@ -943,7 +953,7 @@ fixed. If no list is provided as input, all etas would be included in the same d
 Remove covariance between etas
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. jupyter-execute::
+.. pharmpy-execute::
    :hide-output:
 
    model = read_model(path / "pheno.mod")
@@ -951,7 +961,7 @@ Remove covariance between etas
 Covariance can be removed between etas using the function :py:func:`pharmpy.modeling.split_joint_distribution`. If we have
 the model:
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import copy_model, create_joint_distribution
 
@@ -961,7 +971,7 @@ the model:
 
 Provide etas as a list.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import split_joint_distribution
 
@@ -977,7 +987,7 @@ Update initial estimates from previous run
 If there are results from a previous run, those can be used for initial estimates in your
 pharmpy model. See :py:func:`pharmpy.modeling.update_inits`.
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
    from pharmpy.modeling import read_model, update_inits
 
@@ -992,7 +1002,7 @@ Fitting a model
 
 Pharmpy is designed to be able to do fitting of models to data using different external tools. Currently only NONMEM is supported.
 
-.. code-block:: python
+.. pharmpy-code::
 
     from pharmpy.modeling import fit
     fit(model)
@@ -1004,7 +1014,7 @@ Getting results from a PsN run
 Pharmpy can create results objects from PsN run directories for some of the PsN tools. The result objects is a collection of different
 results from the tool and can be saved as either json or csv.
 
-.. code-block:: python
+.. pharmpy-code::
 
     from pharmpy.modeling import create_results
     res = create_results("bootstrap_dir1")
@@ -1017,14 +1027,14 @@ Eta shrinkage
 
 Eta shrinkage can be calculated either on the standard deviation scale or on the variance scale
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     from pharmpy.modeling import calculate_eta_shrinkage
 
     calculate_eta_shrinkage(model)
 
 
-.. jupyter-execute::
+.. pharmpy-execute::
 
     calculate_eta_shrinkage(model, sd=True)
 
@@ -1036,7 +1046,7 @@ Pharmpy has functions to calculate statistics for individual parameters that are
 in the model code or that can be defined expressions containing dataset columns and/or variables
 from the model code.
 
-.. code-block:: python
+.. pharmpy-code::
 
     from pharmpy.modeling import calculate_individual_parameter_statistics
     model = read_model(path / 'secondary_parameters'/ 'run2.mod')

--- a/docs/modelsearch.rst
+++ b/docs/modelsearch.rst
@@ -15,7 +15,7 @@ The modelsearch tool is available both in Pharmpy/pharmr and from the command li
 
 To initiate modelsearch in Python:
 
-.. code:: python
+.. pharmpy-code::
 
     from pharmpy.modeling import run_tool
 
@@ -283,7 +283,7 @@ as well as files in .csv/.json format.
 
 Consider a modelsearch run with the search space of zero order absorption and adding one peripheral compartment:
 
-.. code::
+.. pharmpy-code::
 
     res = run_tool('modelsearch',
                    'ABSORPTION(ZO);PERIPHERALS(1)',
@@ -297,7 +297,7 @@ Consider a modelsearch run with the search space of zero order absorption and ad
 The ``summary_tool`` table contains information such as which feature each model candidate has, the difference to the
 start model (in this case comparing BIC), and final ranking:
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     from pharmpy.results import read_results
@@ -309,7 +309,7 @@ you can look at the ``summary_models`` table. The table is generated with
 :py:func:`pharmpy.modeling.summarize_modelfit_results`.
 
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     import pandas as pd
@@ -318,7 +318,7 @@ you can look at the ``summary_models`` table. The table is generated with
 
 Finally, you can see different individual statistics ``summary_individuals``.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.summary_individuals

--- a/docs/nonmem_plugin.rst
+++ b/docs/nonmem_plugin.rst
@@ -66,7 +66,7 @@ When performing different transformations or manipulations of the model, the nam
 variables do not have to follow the previously mentioned name schemes. Let’s say we have a model with no etas, and
 the model is transformed accordingly:
 
-.. code-block::
+.. pharmpy-code::
 
    add_iiv(model, 'CL', 'exp')
    model.update_source()
@@ -75,7 +75,7 @@ If you add an eta to the parameter clearance (`CL`), the new eta name will defau
 `IIV_CL`. When performing subsequent transformations, `ETA_CL` and `IIV_CL` are the names you will refer to even if
 the NONMEM name for them would be `ETA(1)` and `OMEGA(1,1)` respectively. Now we want to remove that eta:
 
-.. code-block::
+.. pharmpy-code::
 
    remove_iiv(model, ['ETA_CL'])
 

--- a/docs/qa.rst
+++ b/docs/qa.rst
@@ -17,7 +17,7 @@ More details for each result can be found in the individual sections.
 The table shows an overview of possible modifications to different model aspects,
 expected improements in OFV as well as number of additional parameters used.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     import pathlib
@@ -33,7 +33,7 @@ the mean difference between model predictions and observations as a function of 
 
 The ``structural_bias`` table shows the ``CWRES`` and ``CPRED`` given different bins of the independent variable. 
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.structural_bias
@@ -46,7 +46,7 @@ This section shows the effect of including a full block correlation struture in 
 The ``fullblock_parameters`` contains the estimated standard deviation (sd), correlation (corr) and
 expected improvement in OFV after inclusion of a full block correlation structure of the random effects.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.fullblock_parameters
@@ -60,7 +60,7 @@ This section shows the effect of applying a Box-Cox transformation to the ETA va
 The ``boxcox_parameters`` contains the estimated shape parameter (Lambda) and expected improvment in OFV for a
 Box-Cox transformation of the random effects.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.boxcox_parameters
@@ -73,7 +73,7 @@ This section shows the effect of applying a t-distribution transformation to the
 The ``tdist_parameters`` contains the estimated degrees of freedom and expected improvement in OFV for a 
 t-distribution transformation of the random effects.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.tdist_parameters
@@ -86,7 +86,7 @@ This section shows the effect of including extended residual error models in the
 The ``residual_error`` table contains the residual error models, resulting expected improvement in OFV, 
 required additional model parameters as well as their estimates.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.residual_error
@@ -98,7 +98,7 @@ This section evaluates the impact of supplied covariates.
 
 The ``covariate_effects`` table shows the expected improvement when including covariates.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.covariate_effects

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ pydata-sphinx-theme==0.8.1
 sphinxcontrib-autoprogram==0.1.7
 sphinx-automodapi==0.14.1
 jupyter-sphinx==0.3.2
+sphinx-tabs==3.3.1
 markdown==3.3.7
 ipython_genutils
 -e .

--- a/docs/resmod.rst
+++ b/docs/resmod.rst
@@ -13,7 +13,7 @@ Resmod models
 
 The `models` table contains a summary of all resmod models
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     import pathlib

--- a/docs/scm.rst
+++ b/docs/scm.rst
@@ -13,7 +13,7 @@ Steps
 
 The ``steps`` table contains information on the models run in each step.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     import pathlib
@@ -58,7 +58,7 @@ OFV Summary
 The ``ofv_summary`` gives slightly different view of the runs. The included relations in the final model are
 listed under the direction "Final included".
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.ofv_summary
@@ -70,7 +70,7 @@ Candidate Summary
 The ``candidate_summary`` table give an overview of each candidate relationship. When and how often was it included, how often did it give
 errors, etc.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.candidate_summary

--- a/docs/simeval.rst
+++ b/docs/simeval.rst
@@ -13,7 +13,7 @@ Sampled Individual OFVs
 
 The ``sampled_iofv`` table contains the evaluated individual OFVs for each sampled dataset.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     import pathlib
@@ -35,7 +35,7 @@ residual outlier flag. The residual for each sample and ID is the distance from 
 
 An individual is defined as an outlier if the corresponding residual is 3 or higher.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.iofv_summary
@@ -45,7 +45,7 @@ Individual prediction plot
 
 The ``individual_predictions_plot`` show PRED, IPRED and DV vs TIME (if available) for outlying individuals.
 
-.. jupyter-execute::
+.. pharmpy-execute::
     :hide-code:
 
     res.individual_predictions_plot


### PR DESCRIPTION
  - [x] Generalize `jupyter-execute` to prepare for automated Python-to-R transpiling
  - [x] Automate Python-to-R transpiling
  - [x] Tweak Python-to-R transpiling
  - [x] Update all uses of `.. code-block:: python` and `.. jupyter-execute::`
  - [x] ~Make API docs code examples use transpilation directive (?) See https://github.com/astropy/sphinx-automodapi/issues/151~ Skip for now since we have dedicated R API docs anyway.
  - [x] Fixes #774


