### PR TITLE
[refactor] Simplified and more lightweight implementation of CodeRecord#statements

### DIFF
--- a/src/pharmpy/plugins/nonmem/records/code_record.py
+++ b/src/pharmpy/plugins/nonmem/records/code_record.py
@@ -376,30 +376,30 @@ def lcsdiff(c, x, y, i, j):
         return
     elif i < 0:
         yield from lcsdiff(c, x, y, i, j - 1)
-        yield '+', y[j]
+        yield 1, y[j]
     elif j < 0:
         yield from lcsdiff(c, x, y, i - 1, j)
-        yield '-', x[i]
+        yield -1, x[i]
     elif x[i] == y[j]:
         yield from lcsdiff(c, x, y, i - 1, j - 1)
-        yield None, x[i]
+        yield 0, x[i]
     elif c[i][j - 1] >= c[i - 1][j]:
         yield from lcsdiff(c, x, y, i, j - 1)
-        yield '+', y[j]
+        yield 1, y[j]
     else:
         yield from lcsdiff(c, x, y, i - 1, j)
-        yield '-', x[i]
+        yield -1, x[i]
 
 
 def diff(old, new):
     """Get diff between a and b in order for all elements
 
     Optimizes by first handling equal elements from the head and tail
-    Each entry is a pair of operation (+, - or None) and the element
+    Each entry is a pair of operation (+1, -1 or 0) and the element
     """
     for i, (a, b) in enumerate(zip(old, new)):
         if a == b:
-            yield (None, b)
+            yield (0, b)
         else:
             break
     else:
@@ -414,7 +414,7 @@ def diff(old, new):
     saved = []
     for a, b in zip(reversed(rold), reversed(rnew)):
         if a == b:
-            saved.append((None, b))
+            saved.append((0, b))
         else:
             break
 
@@ -461,16 +461,17 @@ class CodeRecord(Record):
                 child_index = self._nodes_index[index_index][0]
                 new_children.extend(self.root.children[prev_child_index:child_index])
             else:
-                assert op == '+'
-            if op == '+':
+                assert op == 1
+            if op == 1:
                 statement_nodes = self._statement_to_nodes(defined_symbols, child_index, s)
                 new_index.append((len(new_children), len(new_children) + len(statement_nodes)))
                 new_children.extend(statement_nodes)
                 defined_symbols.add(s.symbol)
-            elif op == '-':
+            elif op == -1:
                 child_index += self._nodes_index_len(index_index)
                 index_index += 1
             else:
+                assert op == 0
                 new_index.append((len(new_children), len(new_children) + self._nodes_index_len(index_index)))
                 new_children.extend(self.root.children[child_index:self._nodes_index[index_index][1]])
                 child_index += self._nodes_index_len(index_index)

--- a/src/pharmpy/plugins/nonmem/update.py
+++ b/src/pharmpy/plugins/nonmem/update.py
@@ -116,18 +116,18 @@ def update_random_variable_records(model, rvs_diff, rec_dict, comment_dict):
 
     rvs_diff = list(rvs_diff)
 
-    rvs_removed = [RandomVariables(rvs).names for (op, (rvs, _)) in rvs_diff if op == '-']
+    rvs_removed = [RandomVariables(rvs).names for (op, (rvs, _)) in rvs_diff if op == -1]
     rvs_removed = [rv for sublist in rvs_removed for rv in sublist]
 
     for i, (op, (rvs, _)) in enumerate(rvs_diff):
-        if op == '+':
+        if op == 1:
             if len(rvs) == 1:
                 create_omega_single(model, rvs[0], eta_number, number_of_records, comment_dict)
             else:
                 create_omega_block(model, rvs, eta_number, number_of_records, comment_dict)
             eta_number += len(rvs)
             number_of_records += 1
-        elif op == '-':
+        elif op == -1:
             rvs_rec = list({rec_dict[rv.name] for rv in rvs})
             recs_to_remove = [rec for rec in rvs_rec if rec not in removed]
             if recs_to_remove:
@@ -978,7 +978,7 @@ def update_estimation(model):
 
     prev = (None, None)
     for op, est in delta:
-        if op == '+':
+        if op == 1:
             est_code = '$ESTIMATION'
             protected_attributes = []
             if est.method == 'FO':
@@ -1005,7 +1005,7 @@ def update_estimation(model):
                 op_prev, est_prev = prev
                 if (
                     est.method.startswith('FO')
-                    and op_prev == '-'
+                    and op_prev == -1
                     and est.evaluation
                     and not est_prev.evaluation
                     and est_prev.maximum_evaluations == est.maximum_evaluations
@@ -1043,7 +1043,7 @@ def update_estimation(model):
             est_code += '\n'
             newrec = create_record(est_code)
             new_records.append(newrec)
-        elif op == '-':
+        elif op == -1:
             i += 1
         else:
             new_records.append(old_records[i])


### PR DESCRIPTION
> :warning: Needs commit editing. @rikardn Ready for review.

In this PR we use children index ranges to locate statement nodes in the AST. It is lighter on reference counting and avoids the linear scan to align the children array with the statement nodes array.