### PR TITLE
Resmod example

### DIFF
--- a/tests/integration/test_resmod.py
+++ b/tests/integration/test_resmod.py
@@ -1,7 +1,7 @@
 import shutil
 
 from pharmpy import Model
-from pharmpy.modeling import run_tool
+from pharmpy.modeling import remove_covariance_step, run_tool
 from pharmpy.utils import TemporaryDirectoryChanger
 
 
@@ -13,6 +13,10 @@ def test_resmod(tmp_path, testdata):
         shutil.copy2(testdata / 'nonmem' / 'sdtab1', tmp_path)
 
         model = Model.create_model('pheno_real.mod')
+        remove_covariance_step(model)
         model.datainfo.path = tmp_path / 'pheno.dta'
-        res = run_tool('resmod', model, groups=4, p_value=0.05, skip=[])
-        assert res
+        del model.statements[0:2]
+        res = run_tool('resmod', model, groups=4, p_value=0.5, skip=[])
+        assert res.best_model.model_code.split('\n')[15] == 'IF (TAD.LT.11.5) THEN'
+        assert res.best_model.model_code.split('\n')[16] == '    Y = EPS(1)*THETA(4)*W + F'
+        assert res.best_model.model_code.split('\n')[27] == '$THETA  0.807384 ; time_varying'


### PR DESCRIPTION
Hi Rikard, 

This PR is to give an example to let resmod iterate twice in test. I think it can also be applied as the example of documentation.  I remove the covariance step and delete the TAD statement. It looks not very decent because of the large p-value but it is the easiest choice so far.

Best regards,
Zhe Huang
