### PR TITLE
Add model object as input of amd function

### DIFF
--- a/src/pharmpy/modeling/amd.py
+++ b/src/pharmpy/modeling/amd.py
@@ -1,6 +1,7 @@
 from functools import partial
 
 import pharmpy.tools.scm as scm
+from pharmpy import plugins
 from pharmpy.results import Results
 from pharmpy.tools.amd.funcs import create_start_model
 from pharmpy.workflows import default_tool_database
@@ -16,7 +17,7 @@ class AMDResults(Results):
 
 
 def run_amd(
-    dataset_path,
+    input,
     modeltype='pk_oral',
     cl_init=0.01,
     vc_init=1,
@@ -33,8 +34,8 @@ def run_amd(
 
     Parameters
     ----------
-    dataset_path : Model
-        Path to a dataset
+    input : Model
+        Read model object/Path to a dataset
     modeltype : str
         Type of model to build. Either 'pk_oral' or 'pk_iv'
     cl_init : float
@@ -71,11 +72,16 @@ def run_amd(
     run_tool
 
     """
-
-    model = create_start_model(
-        dataset_path, modeltype=modeltype, cl_init=cl_init, vc_init=vc_init, mat_init=mat_init
-    )
-    model = convert_model(model, 'nonmem')  # FIXME: Workaround for results retrieval system
+    if type(input) is str:
+        model = create_start_model(
+            input, modeltype=modeltype, cl_init=cl_init, vc_init=vc_init, mat_init=mat_init
+        )
+        model = convert_model(model, 'nonmem')  # FIXME: Workaround for results retrieval system
+    elif type(input) is plugins.nonmem.model.Model:
+        model = input
+        model.name = 'start'
+    else:
+        raise TypeError('Only model and dataset are supported currently')
 
     if lloq is not None:
         remove_loq_data(model, lloq=lloq)


### PR DESCRIPTION
Hi Rikard,

This PR is a very basic version of adding the model object as the input of AMD function. There are also some things I am not very sure about:

 My understanding is if we want to use the model object as the starting point, we should have a pharmpy model or do `model=read_model(path)`, then we do `run_amd(model, ...)`. The benefit is the flexibility of input, `run_amd` can follow some functions which return a model object (I think?). But this is just my intuitive feeling.

Another possibility to deal with it is to give a path of the mod file and let the AMD function handle different situations. For example, we can have `path= '~/xxx.mod' ` or `path= '~/xxx.csv'` and we convert model inside our AMD function. 

Which one do you think is more user-friendly?

Best regards,
Zhe Huang


