### PR TITLE
[fix] Fix composition of `add_covariate_effect` calls

### DIFF
--- a/src/pharmpy/modeling/covariate_effect.py
+++ b/src/pharmpy/modeling/covariate_effect.py
@@ -156,11 +156,14 @@ def add_covariate_effect(model, parameter, covariate, effect, operation='*'):
 
     covariate_effect = _create_template(effect, model, covariate)
     thetas = _create_thetas(model, parameter, effect, covariate, covariate_effect.template)
+    covariate_effect.apply(parameter, covariate, thetas, statistics)
+    # NOTE We hoist the statistic statements to avoid referencing variables
+    # before declaring them. We also avoid duplicate statements.
+    sset[0:0] = [s for s in covariate_effect.statistic_statements if s not in sset]
 
     last_existing_parameter_assignment = sset.find_assignment(parameter)
     insertion_index = sset.index(last_existing_parameter_assignment) + 1
 
-    covariate_effect.apply(parameter, covariate, thetas, statistics)
     # NOTE We can use any assignment to the parameter since we currently only
     # use its symbol to create the new effect statement.
     effect_statement = covariate_effect.create_effect_statement(
@@ -169,7 +172,6 @@ def add_covariate_effect(model, parameter, covariate, effect, operation='*'):
 
     statements = ModelStatements()
 
-    statements += [s for s in covariate_effect.statistic_statements if s not in sset]
     statements.append(covariate_effect.template)
     statements.append(effect_statement)
 

--- a/src/pharmpy/modeling/covariate_effect.py
+++ b/src/pharmpy/modeling/covariate_effect.py
@@ -157,12 +157,15 @@ def add_covariate_effect(model, parameter, covariate, effect, operation='*'):
     covariate_effect = _create_template(effect, model, covariate)
     thetas = _create_thetas(model, parameter, effect, covariate, covariate_effect.template)
 
-    param_statement = sset.find_assignment(parameter)
-
-    index = sset.index(param_statement)
+    last_existing_parameter_assignment = sset.find_assignment(parameter)
+    insertion_index = sset.index(last_existing_parameter_assignment) + 1
 
     covariate_effect.apply(parameter, covariate, thetas, statistics)
-    effect_statement = covariate_effect.create_effect_statement(operation, param_statement)
+    # NOTE We can use any assignment to the parameter since we currently only
+    # use its symbol to create the new effect statement.
+    effect_statement = covariate_effect.create_effect_statement(
+        operation, last_existing_parameter_assignment
+    )
 
     statements = ModelStatements()
 
@@ -170,19 +173,22 @@ def add_covariate_effect(model, parameter, covariate, effect, operation='*'):
     statements.append(covariate_effect.template)
     statements.append(effect_statement)
 
-    previous_effect = sset.find_assignment(parameter)
     cov_possible = [f'{parameter}{col_name}' for col_name in model.datainfo.names]
 
-    if previous_effect.expression.args and all(
-        arg.name in cov_possible for arg in previous_effect.expression.args if str(arg) != parameter
+    # NOTE This is a heuristic that simplifies the NONMEM statements by
+    # grouping multiple effect statements in a single statement.
+    if last_existing_parameter_assignment.expression.args and all(
+        arg.name in cov_possible
+        for arg in last_existing_parameter_assignment.expression.args
+        if str(arg) != parameter
     ):
         effect_statement.expression = effect_statement.expression.subs(
-            {parameter: previous_effect.expression}
+            {parameter: last_existing_parameter_assignment.expression}
         )
-        sset.remove(previous_effect)
+        sset.remove(last_existing_parameter_assignment)
+        insertion_index -= 1
 
-    for i, statement in enumerate(statements, 1):
-        sset.insert(index + i, statement)
+    sset[insertion_index:insertion_index] = statements
 
     model.statements = sset
     return model

--- a/tests/modeling/test_modeling.py
+++ b/tests/modeling/test_modeling.py
@@ -1377,6 +1377,42 @@ def test_nested_add_covariate_effect(pheno_path):
             'VCRCL = EXP(THETA(6)*(CRCL - CRCL_MEDIAN))\n'
             'V = V*VAGE*VCRCL*VWT\n',
         ),
+        (
+            ('nonmem', 'models', 'mox2.mod'),
+            [
+                ('CL', 'CRCL', 'exp', '*'),
+                ('V', 'CRCL', 'exp', '*'),
+            ],
+            '$PK\n'
+            'CRCL_MEDIAN = 65.0000\n'
+            'CL = THETA(1)*EXP(ETA(1))\n'
+            'CLCRCL = EXP(THETA(4)*(CRCL - CRCL_MEDIAN))\n'
+            'CL = CL*CLCRCL\n'
+            'VC = THETA(2) * EXP(ETA(2))\n'
+            'MAT = THETA(3) * EXP(ETA(3))\n'
+            'KA = 1/MAT\n'
+            'V = VC\n'
+            'VCRCL = EXP(THETA(5)*(CRCL - CRCL_MEDIAN))\n'
+            'V = V*VCRCL\n',
+        ),
+        (
+            ('nonmem', 'models', 'mox2.mod'),
+            [
+                ('V', 'CRCL', 'exp', '*'),
+                ('CL', 'CRCL', 'exp', '*'),
+            ],
+            '$PK\n'
+            'CRCL_MEDIAN = 65.0000\n'
+            'CL = THETA(1)*EXP(ETA(1))\n'
+            'CLCRCL = EXP(THETA(5)*(CRCL - CRCL_MEDIAN))\n'
+            'CL = CL*CLCRCL\n'
+            'VC = THETA(2) * EXP(ETA(2))\n'
+            'MAT = THETA(3) * EXP(ETA(3))\n'
+            'KA = 1/MAT\n'
+            'V = VC\n'
+            'VCRCL = EXP(THETA(4)*(CRCL - CRCL_MEDIAN))\n'
+            'V = V*VCRCL\n',
+        ),
     ],
     ids=repr,
 )


### PR DESCRIPTION
> @stellabelin @rikardn Ready for review.

  - [x] Fix composition of `add_covariate_effect` calls on the same parameter
    - [x] 1. Fixes an off-by-one error when triggering the heuristic that simplifies the statement of multiple effects.
    - [x] 2. Add some tests to detect regressions for 1.
  - [x] Fix composition of `add_covariate_effect` calls on the same covariate
    - [x] 3. Fixes referencing of variables before their declaration by hoisting `X_MEDIAN` definitions.
    - [x] 4. Add some test to detect regressions for 3.