### PR TITLE
AMD results first version

### DIFF
--- a/src/pharmpy/modeling/amd.py
+++ b/src/pharmpy/modeling/amd.py
@@ -12,8 +12,17 @@ from .run import fit, run_tool
 
 
 class AMDResults(Results):
-    def __init__(self, final_model=None):
+    def __init__(
+        self,
+        final_model=None,
+        summary_tool=None,
+        summary_models=None,
+        summary_individuals_count=None,
+    ):
         self.final_model = final_model
+        self.summary_tool = summary_tool
+        self.summary_models = summary_models
+        self.summary_individuals_count = summary_individuals_count
 
 
 def run_amd(
@@ -148,22 +157,19 @@ def _run_modelsearch(model, search_space, path):
         model=model,
         path=path / 'modelsearch',
     )
-    selected_model = res_modelsearch.best_model
-    return selected_model
+    return res_modelsearch
 
 
 def _run_iiv(model, path):
     res_iiv = run_tool(
         'iivsearch', 'brute_force', iiv_strategy=2, model=model, path=path / 'iivsearch'
     )
-    selected_iiv_model = res_iiv.best_model
-    return selected_iiv_model
+    return res_iiv
 
 
 def _run_resmod(model, path):
     res_resmod = run_tool('resmod', model, path=path / 'resmod')
-    selected_model = res_resmod.best_model
-    return selected_model
+    return res_resmod
 
 
 def _run_covariates(model, continuous, categorical, path):


### PR DESCRIPTION
Hi Rikard, 

This PR is to concatenate the results of modelsearch, iivsearch and resmod. I didn't write the AMD test because I was not sure it will still lead to some issues or not. But I think we need to check what the tables look like, I printed them, and here are the results:  
![Screenshot from 2022-06-02 16-57-50](https://user-images.githubusercontent.com/68994239/171664236-36eba197-678b-4274-97ba-b7ca2a253df2.png)
![Screenshot from 2022-06-02 16-57-57](https://user-images.githubusercontent.com/68994239/171664254-d1ff35ed-96b8-4b81-8ad2-587e9df33532.png)
The way I concatenated the subtables is not very decent, it looks foolish...I did many tries today and this is the only way that works for me. I guess there might be a clear way which I didn't find online. I reset each subtable's index before concatenation because iivsearch has tuple multiIndex: step & model and` pd.concat(df, keys=keys)`  doesn't work in this situation. I also want to split the tuple and make the step a column so that I can fill numbers in it for other subtools. But after reset the index, it will generate a simple index like: 0,1,2... When I set index with multiIndex: tool, step and model, it will become a column so I have to drop it in the end:(

Best regards,
Zhe Huang
 