### PR TITLE
[docs] Improve CSS for Pharmpy code snippets in dark mode

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -28,7 +28,6 @@
  */
 .pharmpy-snippet.with-output > .jupyter_cell {
     padding: 1em;
-    background-color: #FFFF;
     border: 1px solid #CCC;
     -moz-box-shadow: 2px 2px 4px rgba(87, 87, 87, 0.2);
     -webkit-box-shadow: 2px 2px 4px rgba(87, 87, 87, 0.2);


### PR DESCRIPTION
Fallback to default background-color in pharmpy snippets.