### PR TITLE
[fix] Make NONMEM use datainfo drop information in `_read_dataset`

### DIFF
--- a/src/pharmpy/plugins/nonmem/model.py
+++ b/src/pharmpy/plugins/nonmem/model.py
@@ -110,6 +110,7 @@ class Model(pharmpy.model.Model):
             self.database = default_model_database(path=path.parent)
             self.filename_extension = path.suffix
         self.control_stream = parser.parse(code)
+        self._has_real_datainfo = False
         self._create_datainfo()
         self._initial_individual_estimates_updated = False
         self._updated_etas_file = None
@@ -972,6 +973,7 @@ class Model(pharmpy.model.Model):
                 di.path = dataset_path
                 self.datainfo = di
                 self._old_datainfo = di.copy()
+                self._has_real_datainfo = True
                 return
         (colnames, drop, replacements) = self._column_info()
         column_info = []
@@ -1032,6 +1034,9 @@ class Model(pharmpy.model.Model):
         ignore_character = data_records[0].ignore_character
         null_value = data_records[0].null_value
         (colnames, drop, replacements) = self._column_info()
+
+        if self._has_real_datainfo:
+            drop = [column.drop for column in self.datainfo]
 
         if raw:
             ignore = None

--- a/tests/testdata/nonmem/models/mox_simulated_normal.datainfo
+++ b/tests/testdata/nonmem/models/mox_simulated_normal.datainfo
@@ -1,0 +1,254 @@
+{
+  "columns": [
+    {
+      "name": "ID",
+      "type": "id",
+      "unit": "1",
+      "scale": "nominal",
+      "datatype": "int32",
+      "continuous": false
+    },
+    {
+      "name": "VISI",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "nominal",
+      "datatype": "int32",
+      "continuous": false
+    },
+    {
+      "name": "XAT2",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "DGRP",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "DOSE",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "FLAG",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "ONO",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "XIME",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "NEUY",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "SCR",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "AGE",
+      "type": "covariate",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64"
+    },
+    {
+      "name": "SEX",
+      "type": "covariate",
+      "unit": "1",
+      "scale": "nominal",
+      "datatype": "int32",
+      "continuous": false
+    },
+    {
+      "name": "NYHA",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "WT",
+      "type": "covariate",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "descriptor": "body weight"
+    },
+    {
+      "name": "COMP",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "ACE",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "DIG",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "DIU",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "NUMB",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "TAD",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "TIME",
+      "type": "idv",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64"
+    },
+    {
+      "name": "VIDD",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "CLCR",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64"
+    },
+    {
+      "name": "AMT",
+      "type": "dose",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64"
+    },
+    {
+      "name": "SS",
+      "type": "ss",
+      "unit": "1",
+      "scale": "nominal",
+      "datatype": "int32",
+      "continuous": false
+    },
+    {
+      "name": "II",
+      "type": "ii",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64"
+    },
+    {
+      "name": "VID",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "CMT",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "CONO",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    },
+    {
+      "name": "DV",
+      "type": "dv",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64"
+    },
+    {
+      "name": "EVID",
+      "type": "event",
+      "unit": "1",
+      "scale": "nominal",
+      "datatype": "int32",
+      "continuous": false
+    },
+    {
+      "name": "OVID",
+      "type": "unknown",
+      "unit": "1",
+      "scale": "ratio",
+      "datatype": "float64",
+      "drop": true
+    }
+  ]
+}

--- a/tests/testdata/nonmem/pheno.datainfo
+++ b/tests/testdata/nonmem/pheno.datainfo
@@ -4,5 +4,6 @@
 	{ "name": "AMT", "type": "dose", "scale": "ratio", "unit": "mg" },
 	{ "name": "WGT", "type": "covariate", "scale": "ratio", "unit": "kg", "descriptor": "body weight" },
 	{ "name": "APGR", "type": "covariate", "scale": "ordinal", "categories": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+	{ "name": "FA1", "type": "covariate", "scale": "nominal", "categories": [0, 1] },
 	{ "name": "DV", "type": "dv", "scale": "ratio", "unit": "mg/l", "descriptor": "plasma concentration" }
 	], "separator":"\\s+"}


### PR DESCRIPTION
TODO:

  - [ ] make sure this does not break other things