### PR TITLE
Fix rate column issue (fixes #989)

### DIFF
--- a/src/pharmpy/plugins/nonmem/advan.py
+++ b/src/pharmpy/plugins/nonmem/advan.py
@@ -451,10 +451,14 @@ def _advan12_trans(trans):
 
 
 def _dosing(model, dose_comp):
-    di = model.datainfo
+    return dosing(model.datainfo, lambda: model.dataset, dose_comp)
+
+
+def dosing(di, dataset, dose_comp):
     colnames = di.names
+
     if 'RATE' in colnames and not di['RATE'].drop:
-        df = model.dataset
+        df = dataset()
         if (df['RATE'] == 0).all():
             return Bolus('AMT')
         elif (df['RATE'] == -1).any():

--- a/src/pharmpy/plugins/nonmem/model.py
+++ b/src/pharmpy/plugins/nonmem/model.py
@@ -74,6 +74,7 @@ def convert_model(model):
         code += '$PK\nY=X\n'
         code += '$ERROR\nA=B'
     nm_model = pharmpy.model.Model.create_model(StringIO(code))
+    nm_model._datainfo = model.datainfo
     nm_model.random_variables = model.random_variables
     nm_model._parameters = model.parameters
     nm_model._old_parameters = Parameters()
@@ -85,7 +86,6 @@ def convert_model(model):
     nm_model.value_type = model.value_type
     nm_model._data_frame = model.dataset
     nm_model._estimation_steps = model.estimation_steps
-    nm_model._datainfo = model.datainfo
     nm_model._initial_individual_estimates = model.initial_individual_estimates
     nm_model.observation_transformation = model.observation_transformation.subs(
         model.dependent_variable, nm_model.dependent_variable

--- a/tests/tools/test_start_model.py
+++ b/tests/tools/test_start_model.py
@@ -1,3 +1,4 @@
+from pharmpy import Bolus, Infusion
 from pharmpy.tools.amd.funcs import create_start_model
 
 
@@ -10,7 +11,11 @@ def test_create_start_model(testdata):
     assert len(model.parameters) == 6
     assert 'POP_CL' in model.parameters
     assert 'POP_MAT' not in model.parameters
-
+    assert model.statements.ode_system.dosing_compartment.dose == Bolus("AMT")
     model = create_start_model(path, modeltype='pk_oral')
     assert 'POP_CL' in model.parameters
     assert 'POP_MAT' in model.parameters
+
+    path_2 = testdata / 'nonmem' / 'modeling' / 'pheno_zero_order.csv'
+    model = create_start_model(path_2, modeltype='pk_iv')
+    assert model.statements.ode_system.dosing_compartment.dose == Infusion("AMT", duration="D1")


### PR DESCRIPTION
Hi both,

@pharmpy-dev-123 and I found the issue was made by `nonmem.plugin.model.convert_model()`. Because we need to use the dataset to change the model statements (dose type: bolus to infusion), but the path is not correct: `file.csv`. So we need to set the correct path before we change the statement. Then another issue pops out:
```
Traceback (most recent call last):

  Input In [5] in <cell line: 4>
    run_amd('C:\\Users\\zhehu311\\Desktop\\debug\\amd\\xuanlin\\dauno_filtered.csv',

  File ~\Anaconda3\lib\site-packages\pharmpy\tools\run_amd.py:102 in run_amd
    model = convert_model(model, 'nonmem')  # FIXME: Workaround for results retrieval system

  File ~\Anaconda3\lib\site-packages\pharmpy\modeling\common.py:238 in convert_model
    new = nonmem.convert_model(model)

  File ~\Anaconda3\lib\site-packages\pharmpy\plugins\nonmem\model.py:96 in convert_model
    nm_model.update_source()

  File ~\Anaconda3\lib\site-packages\pharmpy\plugins\nonmem\model.py:244 in update_source
    datapath = write_csv(self, path=dir_path, force=force)

  File ~\Anaconda3\lib\site-packages\pharmpy\modeling\write_csv.py:42 in write_csv
    raise FileExistsError(f'File at {path} already exists.')

FileExistsError: File at start.csv already exists.
```
I use the argument: `nofiles=True` in `update_source()` to solve this issue. But I just checked the start.csv dataset from the modelfit directory, the RATE column disappear...

Please have a review when you have time and if you have any ideas, please tell me!