### PR TITLE
[perf] Less calls to covariance matrix

### DIFF
--- a/src/pharmpy/modeling/block_rvs.py
+++ b/src/pharmpy/modeling/block_rvs.py
@@ -151,8 +151,9 @@ def _choose_param_init(model, rvs, params):
     rvs_names = [rv.name for rv in rvs]
 
     etas = []
+    cm = rvs.covariance_matrix
     for i in range(len(rvs)):
-        elem = rvs.covariance_matrix.row(i).col(i)[0]
+        elem = cm.row(i).col(i)[0]
         if str(elem) in [p.name for p in params]:
             etas.append(rvs_names[i])
 

--- a/src/pharmpy/plugins/nonmem/update.py
+++ b/src/pharmpy/plugins/nonmem/update.py
@@ -221,7 +221,8 @@ def create_omega_single(model, rv, eta_number, record_number, comment_dict):
 
 def create_omega_block(model, rvs, eta_number, record_number, comment_dict):
     rvs = RandomVariables(rvs)
-    param_str = f'$OMEGA BLOCK({rvs.covariance_matrix.shape[0]})'
+    cm = rvs.covariance_matrix
+    param_str = f'$OMEGA BLOCK({cm.shape[0]})'
 
     rv = rvs[0]
 
@@ -232,9 +233,9 @@ def create_omega_block(model, rvs, eta_number, record_number, comment_dict):
 
     else:
         param_str += '\n'
-        for row in range(rvs.covariance_matrix.shape[0]):
+        for row in range(cm.shape[0]):
             for col in range(row + 1):
-                elem = rvs.covariance_matrix.row(row).col(col)
+                elem = cm.row(row).col(col)
                 name = str(elem[0])
                 omega = model.parameters[name]
                 param_str += f'{omega.init}'.upper()


### PR DESCRIPTION
Running `tox -e py39 -- pytest --profile-svg -n8 tests`

Before:

![Screenshot 2022-08-04 at 18 18 13](https://user-images.githubusercontent.com/101794402/182898880-f44c95d5-bf76-4f54-a490-15c8e61f3968.png)

After:

`covariance_matrix` is nowhere to be found.
