### PR TITLE
[dev] Speed up tests by caching model parsing

### DIFF
--- a/src/pharmpy/model.py
+++ b/src/pharmpy/model.py
@@ -394,7 +394,11 @@ class Model:
     def copy(self):
         """Create a deepcopy of the model object"""
         model_copy = copy.deepcopy(self)
-        model_copy.parent_model = self.name
+        try:
+            model_copy.parent_model = self.name
+        except AttributeError:
+            # NOTE Name could be absent.
+            pass
         return model_copy
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Dict, Hashable, Optional, Union
 
 import pytest
 
@@ -20,7 +21,85 @@ def pheno_path(datadir):
 
 
 @pytest.fixture(scope='session')
-def pheno(pheno_path):
-    import pharmpy
+def pheno(load_model_for_test, pheno_path):
+    return load_model_for_test(pheno_path)
 
-    return pharmpy.Model.create_model(pheno_path)
+
+@pytest.fixture(scope='session')
+def load_model_for_test(tmp_path_factory):
+
+    from pharmpy import Model
+
+    _cache: Dict[Hashable, Model] = {}
+
+    def _load(given_path: Union[str, Path]) -> Model:
+        # TODO Cache based on file contents instead.
+
+        def _parse_model():
+            return Model.create_model(given_path)
+
+        basetemp = tmp_path_factory.getbasetemp().resolve()
+
+        resolved_path = Path(given_path).resolve()
+
+        try:
+            # NOTE This skips caching when we are reading from a temporary
+            # directory.
+            resolved_path.relative_to(basetemp)
+            return _parse_model()
+        except ValueError:
+            # NOTE This is raised when resolved_path is not descendant of
+            # basetemp. With Python >= 3.9 we could use is_relative_to instead.
+            pass
+
+        from pharmpy.plugins.nonmem import conf
+
+        key = (str(conf), str(resolved_path))
+
+        if key not in _cache:
+            _cache[key] = _parse_model()
+
+        return _cache[key].copy()
+
+    return _load
+
+
+@pytest.fixture(scope='session')
+def load_example_model_for_test():
+
+    from pharmpy import Model
+    from pharmpy.modeling import load_example_model
+
+    _cache: Dict[Hashable, Model] = {}
+
+    def _load(given_name: str) -> Model:
+        def _parse_model():
+            return load_example_model(given_name)
+
+        from pharmpy.plugins.nonmem import conf
+
+        key = (str(conf), given_name)
+
+        if key not in _cache:
+            _cache[key] = _parse_model()
+
+        return _cache[key].copy()
+
+    return _load
+
+
+@pytest.fixture(scope='session')
+def create_model_for_test(load_example_model_for_test):
+
+    from io import StringIO
+
+    from pharmpy import Model
+
+    def _create(code: str, dataset: Optional[str] = None) -> Model:
+        model = Model.create_model(StringIO(code))
+        if dataset is not None:
+            # NOTE This yields a copy of the dataset through Model#copy
+            model.dataset = load_example_model_for_test(dataset).dataset
+        return model
+
+    return _create

--- a/tests/execute/test_database.py
+++ b/tests/execute/test_database.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from pharmpy.modeling import add_time_after_dose, copy_model, read_model
+from pharmpy.modeling import add_time_after_dose, copy_model
 from pharmpy.utils import TemporaryDirectoryChanger
 from pharmpy.workflows import (
     LocalDirectoryDatabase,
@@ -43,13 +43,13 @@ def test_null_database():
     db.store_local_file("path", 34)
 
 
-def test_store_model(tmp_path, testdata):
+def test_store_model(tmp_path, load_model_for_test, testdata):
     sep = os.path.sep
     with TemporaryDirectoryChanger(tmp_path):
         datadir = testdata / 'nonmem'
         shutil.copy(datadir / 'pheno_real.mod', 'pheno_real.mod')
         shutil.copy(datadir / 'pheno.dta', 'pheno.dta')
-        model = read_model("pheno_real.mod")
+        model = load_model_for_test("pheno_real.mod")
 
         db = LocalModelDirectoryDatabase("database")
         db.store_model(model)

--- a/tests/modeling/test_allometry.py
+++ b/tests/modeling/test_allometry.py
@@ -1,11 +1,11 @@
 import pytest
 
-from pharmpy.modeling import add_allometry, add_peripheral_compartment, read_model
+from pharmpy.modeling import add_allometry, add_peripheral_compartment
 from pharmpy.statements import Assignment
 
 
-def test_allometry(testdata):
-    model = read_model(testdata / 'nonmem' / 'pheno.mod')
+def test_allometry(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     ref_model = model.copy()
     add_allometry(
         model,
@@ -102,14 +102,14 @@ def test_allometry(testdata):
     assert model.parameters['ALLO_VP2'].init == 1.0
     assert model.parameters['ALLO_QP2'].init == 0.75
 
-    model = read_model(testdata / 'nonmem' / 'models' / 'pheno_trans1.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'pheno_trans1.mod')
     with pytest.raises(ValueError):
         add_allometry(model, allometric_variable='WGT', reference_value=70)
 
-    model = read_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan3.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan3.mod')
     add_allometry(model, allometric_variable='WGT', reference_value=70)
     assert model.parameters['ALLO_Q'].init == 0.75
-    model = read_model(testdata / 'nonmem' / 'models' / 'pheno_advan3_trans1.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'pheno_advan3_trans1.mod')
     with pytest.raises(ValueError):
         add_allometry(model, allometric_variable='WGT', reference_value=70)
 

--- a/tests/modeling/test_block_rvs.py
+++ b/tests/modeling/test_block_rvs.py
@@ -1,9 +1,6 @@
-from io import StringIO
-
 import pytest
 from sympy import Symbol as S
 
-from pharmpy import Model
 from pharmpy.modeling import add_iiv, create_joint_distribution
 from pharmpy.modeling.block_rvs import _choose_param_init
 from pharmpy.random_variables import RandomVariable, RandomVariables
@@ -74,10 +71,9 @@ def test_choose_param_init(load_model_for_test, pheno_path):
         assert init == 0.0031045
 
 
-def test_choose_param_init_fo():
-    model = Model.create_model(
-        StringIO(
-            '''$PROBLEM PHENOBARB SIMPLE MODEL
+def test_choose_param_init_fo(create_model_for_test):
+    model = create_model_for_test(
+        '''$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV
 $SUBROUTINE ADVAN1 TRANS2
@@ -98,7 +94,6 @@ $SIGMA 0.013241
 
 $ESTIMATION METHOD=0
 '''
-        )
     )
     params = (model.parameters['OMEGA(1,1)'], model.parameters['OMEGA(2,2)'])
     rvs = RandomVariables(model.random_variables.etas)
@@ -107,10 +102,9 @@ $ESTIMATION METHOD=0
     assert init == 0.01
 
 
-def test_names():
-    model = Model.create_model(
-        StringIO(
-            '''$PROBLEM PHENOBARB SIMPLE MODEL
+def test_names(create_model_for_test):
+    model = create_model_for_test(
+        '''$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV
 $SUBROUTINE ADVAN1 TRANS2
@@ -131,7 +125,6 @@ $SIGMA 0.013241
 
 $ESTIMATION METHOD=1 INTERACTION
 '''
-        )
     )
     create_joint_distribution(model, model.random_variables.names)
     assert 'IIV_CL_V_IIV_S1' in model.parameters.names

--- a/tests/modeling/test_block_rvs.py
+++ b/tests/modeling/test_block_rvs.py
@@ -18,8 +18,8 @@ from pharmpy.results import ModelfitResults
         (['ETA(1)'], 'At least two random variables are needed'),
     ],
 )
-def test_incorrect_params(testdata, rvs, exception_msg):
-    model = Model.create_model(
+def test_incorrect_params(load_model_for_test, testdata, rvs, exception_msg):
+    model = load_model_for_test(
         testdata / 'nonmem' / 'modelfit_results' / 'onePROB' / 'multEST' / 'noSIM' / 'withBayes.mod'
     )
 
@@ -27,19 +27,19 @@ def test_incorrect_params(testdata, rvs, exception_msg):
         create_joint_distribution(model, rvs)
 
 
-def test_choose_param_init(pheno_path, testdata):
-    model = Model.create_model(pheno_path)
+def test_choose_param_init(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     params = (model.parameters['OMEGA(1,1)'], model.parameters['OMEGA(2,2)'])
     rvs = RandomVariables(model.random_variables.etas)
     init = _choose_param_init(model, rvs, *params)
     assert init == 0.0118179
 
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
     model.modelfit_results = None
     init = _choose_param_init(model, rvs, *params)
     assert init == 0.0031045
 
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
     rv_new = RandomVariable.normal('ETA(3)', 'IIV', 0, S('OMEGA(3,3)'))
     rvs.append(rv_new)
     res = model.modelfit_results
@@ -52,7 +52,7 @@ def test_choose_param_init(pheno_path, testdata):
     assert init == 0.0118179
 
     # If one eta doesn't have individual estimates
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
     add_iiv(model, 'S1', 'add')
     params = (model.parameters['OMEGA(1,1)'], model.parameters['IIV_S1'])
     rvs = RandomVariables([model.random_variables['ETA(1)'], model.random_variables['ETA_S1']])
@@ -60,7 +60,7 @@ def test_choose_param_init(pheno_path, testdata):
     assert init == 0.0052789
 
     # If the standard deviation in individual estimates of one eta is 0
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
     res = model.modelfit_results
     ie = res.individual_estimates
     ie['ETA(1)'] = 0
@@ -107,7 +107,7 @@ $ESTIMATION METHOD=0
     assert init == 0.01
 
 
-def test_names(testdata):
+def test_names():
     model = Model.create_model(
         StringIO(
             '''$PROBLEM PHENOBARB SIMPLE MODEL

--- a/tests/modeling/test_common.py
+++ b/tests/modeling/test_common.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 import sympy
 
-from pharmpy import Model
 from pharmpy.modeling import (
     convert_model,
     copy_model,
@@ -45,7 +44,7 @@ def test_read_model_expanduser(testdata):
     assert model.parameters['THETA(1)'].init == 0.1
 
 
-def test_read_model_from_string(testdata):
+def test_read_model_from_string():
     model = read_model_from_string(
         """$PROBLEM base model
 $INPUT ID DV TIME
@@ -63,14 +62,14 @@ $ESTIMATION METHOD=1 INTER MAXEVALS=9990 PRINT=2 POSTHOC
     assert model.parameters['THETA(1)'].init == 0.1
 
 
-def test_write_model(testdata, tmp_path):
-    model = read_model(testdata / 'nonmem' / 'minimal.mod')
+def test_write_model(testdata, load_model_for_test, tmp_path):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     write_model(model, tmp_path / 'run1.mod')
     assert Path(tmp_path / 'run1.mod').is_file()
 
 
-def test_generate_model_code(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_generate_model_code(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     fix_parameters(model, ['THETA(1)'])
     assert generate_model_code(model).split('\n')[7] == '$THETA 0.1 FIX'
 
@@ -84,9 +83,9 @@ def test_load_example_model():
         load_example_model("grekztalb23=")
 
 
-def test_get_model_covariates(pheno, testdata):
+def test_get_model_covariates(pheno, testdata, load_model_for_test):
     assert set(get_model_covariates(pheno)) == {sympy.Symbol('WGT'), sympy.Symbol('APGR')}
-    minimal = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+    minimal = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     assert set(get_model_covariates(minimal)) == set()
 
 

--- a/tests/modeling/test_common.py
+++ b/tests/modeling/test_common.py
@@ -1,3 +1,4 @@
+import os.path
 from pathlib import Path
 
 import pytest
@@ -20,11 +21,28 @@ from pharmpy.modeling import (
 )
 
 
-def test_read_model(testdata):
-    model = read_model(testdata / 'nonmem' / 'minimal.mod')
+def test_read_model_path(testdata):
+    path = testdata / 'nonmem' / 'minimal.mod'
+    model = read_model(path)
     assert model.parameters['THETA(1)'].init == 0.1
-    model2 = read_model(str(testdata / 'nonmem' / 'minimal.mod'))
-    assert model2.parameters['THETA(1)'].init == 0.1
+
+
+def test_read_model_str(testdata):
+    path = str(testdata / 'nonmem' / 'minimal.mod')
+    model = read_model(path)
+    assert model.parameters['THETA(1)'].init == 0.1
+
+
+def test_read_model_expanduser(testdata):
+    model_path = testdata / "nonmem" / "minimal.mod"
+    model_path_relative_to_home = ''
+    try:
+        model_path_relative_to_home = model_path.relative_to(Path.home())
+    except ValueError:
+        pytest.skip(f'{model_path} is not a descendant of home directory ({Path.home()})')
+    path = os.path.join('~', model_path_relative_to_home)
+    model = read_model(path)
+    assert model.parameters['THETA(1)'].init == 0.1
 
 
 def test_read_model_from_string(testdata):

--- a/tests/modeling/test_covariate_effect.py
+++ b/tests/modeling/test_covariate_effect.py
@@ -2,7 +2,6 @@ import pytest
 from sympy import Symbol as S
 from sympy import exp
 
-from pharmpy import Model
 from pharmpy.modeling.covariate_effect import CovariateEffect, _choose_param_inits
 
 
@@ -33,8 +32,8 @@ def test_apply(cov_eff, symbol, expression):
 @pytest.mark.parametrize(
     'cov_eff, init, lower, upper', [('exp', 0.001, -0.8696, 0.8696), ('pow', 0.001, -100, 100000)]
 )
-def test_choose_param_inits(pheno_path, cov_eff, init, lower, upper):
-    model = Model.create_model(pheno_path)
+def test_choose_param_inits(pheno_path, load_model_for_test, cov_eff, init, lower, upper):
+    model = load_model_for_test(pheno_path)
 
     inits = _choose_param_inits(cov_eff, model, 'WGT')
 

--- a/tests/modeling/test_data_funcs.py
+++ b/tests/modeling/test_data_funcs.py
@@ -19,47 +19,47 @@ from pharmpy.modeling import (
     get_number_of_observations_per_individual,
     get_observations,
     list_time_varying_covariates,
-    load_example_model,
-    read_model,
     remove_loq_data,
     translate_nmtran_time,
     undrop_columns,
 )
 
-model = load_example_model("pheno")
 
-
-def test_get_ids():
+def test_get_ids(load_example_model_for_test):
+    model = load_example_model_for_test('pheno')
     assert get_ids(model) == list(range(1, 60))
 
 
-def test_get_doseid():
+def test_get_doseid(load_example_model_for_test):
+    model = load_example_model_for_test('pheno')
     doseid = get_doseid(model)
     assert len(doseid) == 744
     assert doseid[0] == 1
     assert doseid[743] == 13
 
     # Same timepoint for dose and observation
-    newmod = model.copy()
-    newmod.dataset.loc[742, 'TIME'] = newmod.dataset.loc[743, 'TIME']
-    doseid = get_doseid(newmod)
+    model.dataset.loc[742, 'TIME'] = model.dataset.loc[743, 'TIME']
+    doseid = get_doseid(model)
     assert len(doseid) == 744
     assert doseid[743] == 12
     assert doseid[742] == 13
 
 
-def test_get_number_of_individuals():
+def test_get_number_of_individuals(load_example_model_for_test):
+    model = load_example_model_for_test('pheno')
     assert get_number_of_individuals(model) == 59
 
 
-def test_get_observations():
+def test_get_observations(load_example_model_for_test):
+    model = load_example_model_for_test('pheno')
     ser = get_observations(model)
     assert ser.loc[1, 2.0] == 17.3
     assert ser.loc[2, 63.5] == 24.6
     assert len(ser) == 155
 
 
-def test_number_of_observations():
+def test_number_of_observations(load_example_model_for_test):
+    model = load_example_model_for_test('pheno')
     assert get_number_of_observations(model) == 155
     assert list(get_number_of_observations_per_individual(model)) == [
         2,
@@ -124,7 +124,8 @@ def test_number_of_observations():
     ]
 
 
-def test_covariate_baselines():
+def test_covariate_baselines(load_example_model_for_test):
+    model = load_example_model_for_test('pheno')
     covs = model.datainfo[['WGT', 'APGR']].set_types('covariate')
     model.datainfo = model.datainfo[0:3] + covs + model.datainfo[5:]
     df = get_covariate_baselines(model)
@@ -135,18 +136,21 @@ def test_covariate_baselines():
     assert df['APGR'].loc[11] == 7.0
 
 
-def test_doses():
+def test_doses(load_example_model_for_test):
+    model = load_example_model_for_test('pheno')
     ser = get_doses(model)
     assert len(ser) == 589
     assert ser.loc[1, 0.0] == 25.0
 
 
-def test_timevarying_covariates():
+def test_timevarying_covariates(load_example_model_for_test):
+    model = load_example_model_for_test('pheno')
     a = list_time_varying_covariates(model)
     assert a == []
 
 
-def test_get_mdv():
+def test_get_mdv(load_example_model_for_test):
+    model = load_example_model_for_test('pheno')
     mdv = get_mdv(model)
     label_test = model.datainfo.typeix['dose'][0].name
     data_test = model.dataset[label_test].astype('float64').squeeze()
@@ -155,26 +159,27 @@ def test_get_mdv():
     assert result is True
 
 
-def test_get_evid():
+def test_get_evid(load_example_model_for_test):
+    model = load_example_model_for_test("pheno")
     evid = get_evid(model)
     assert evid.sum() == 589
 
 
-def test_get_cmt():
+def test_get_cmt(load_example_model_for_test):
+    model = load_example_model_for_test("pheno")
     cmt = get_cmt(model)
     assert cmt.sum() == 589
 
 
-def test_add_time_after_dose(testdata):
-    model = load_example_model("pheno")
-    m = model.copy()
+def test_add_time_after_dose(load_model_for_test, load_example_model_for_test, testdata):
+    m = load_example_model_for_test("pheno")
     add_time_after_dose(m)
     tad = m.dataset['TAD']
     assert tad[0] == 0.0
     assert tad[1] == 2.0
     assert tad[743] == 2.0
 
-    m = read_model(testdata / 'nonmem' / 'models' / 'pef.mod')
+    m = load_model_for_test(testdata / 'nonmem' / 'models' / 'pef.mod')
     add_time_after_dose(m)
     tad = list(m.dataset['TAD'].iloc[0:21])
     assert tad == [
@@ -203,19 +208,20 @@ def test_add_time_after_dose(testdata):
     assert m.dataset.loc[103, 'TAD'] == 0.0
     assert m.dataset.loc[104, 'TAD'] == pytest.approx(1.17)
 
-    m = read_model(testdata / 'nonmem' / 'models' / 'mox1.mod')
+    m = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox1.mod')
     add_time_after_dose(m)
     tad = list(m.dataset['TAD'].iloc[0:16])
     assert tad == [0.0, 1.0, 1.5, 2.0, 4.0, 6.0, 8.0, 0.0, 12.0, 0.5, 1.0, 1.5, 2.0, 4.0, 6.0, 8.0]
 
 
-def test_get_concentration_parameters_from_data():
+def test_get_concentration_parameters_from_data(load_example_model_for_test):
+    model = load_example_model_for_test('pheno')
     df = get_concentration_parameters_from_data(model)
     assert df['Cmax'].loc[1, 1] == 17.3
 
 
-def test_drop_columns():
-    m = model.copy()
+def test_drop_columns(load_example_model_for_test):
+    m = load_example_model_for_test('pheno')
     m = drop_columns(m, "APGR")
     correct = ['ID', 'TIME', 'AMT', 'WGT', 'DV', 'FA1', 'FA2']
     assert m.datainfo.names == correct
@@ -228,8 +234,8 @@ def test_drop_columns():
     assert list(m.dataset.columns) == ['TIME', 'AMT', 'WGT', 'FA1', 'FA2']
 
 
-def test_drop_dropped_columns():
-    m = model.copy()
+def test_drop_dropped_columns(load_example_model_for_test):
+    m = load_example_model_for_test('pheno')
     m = drop_dropped_columns(m)
     correct = ['ID', 'TIME', 'AMT', 'WGT', 'APGR', 'DV', 'FA1', 'FA2']
     assert list(m.dataset.columns) == correct
@@ -238,40 +244,42 @@ def test_drop_dropped_columns():
     assert list(m.dataset.columns) == ['WGT', 'APGR', 'DV', 'FA1', 'FA2']
 
 
-def test_undrop_columns():
-    m = model.copy()
+def test_undrop_columns(load_example_model_for_test):
+    m = load_example_model_for_test('pheno')
     drop_columns(m, ["APGR", "WGT"], mark=True)
     undrop_columns(m, "WGT")
     assert not m.datainfo["WGT"].drop
     assert m.datainfo["APGR"].drop
 
 
-def test_remove_loq_data():
-    m = model.copy()
+def test_remove_loq_data(load_example_model_for_test):
+    m = load_example_model_for_test('pheno')
     remove_loq_data(m, lloq=10, uloq=40)
     assert len(m.dataset) == 736
 
 
-def test_check_dataset():
-    m = model.copy()
+def test_check_dataset(load_example_model_for_test):
+    m = load_example_model_for_test('pheno')
     check_dataset(m)
 
     df = check_dataset(m, verbose=True, dataframe=True)
+    assert df is not None
     assert df[df['code'] == 'A1']['result'].iloc[0] == 'OK'
     assert df[df['code'] == 'A4']['result'].iloc[0] == 'SKIP'
 
     m.dataset.loc[743, 'WGT'] = -1
     df = check_dataset(m, verbose=True, dataframe=True)
+    assert df is not None
     assert df[df['code'] == 'A3']['result'].iloc[0] == 'FAIL'
 
 
-def test_nmtran_time():
-    m = load_example_model("pheno_linear")
+def test_nmtran_time(load_example_model_for_test):
+    m = load_example_model_for_test("pheno_linear")
     translate_nmtran_time(m)
 
 
-def test_expand_additional_doses(testdata):
-    model = read_model(testdata / 'nonmem' / 'models' / 'pef.mod')
+def test_expand_additional_doses(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'pef.mod')
     expand_additional_doses(model)
     df = model.dataset
     assert len(df) == 1494
@@ -287,7 +295,7 @@ def test_expand_additional_doses(testdata):
     assert df.loc[3, 'TIME'] == 36.0
     assert df.loc[4, 'TIME'] == 48.0
 
-    model = read_model(testdata / 'nonmem' / 'models' / 'pef.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'pef.mod')
     expand_additional_doses(model, flag=True)
     df = model.dataset
     assert len(df) == 1494

--- a/tests/modeling/test_distribution.py
+++ b/tests/modeling/test_distribution.py
@@ -1,23 +1,13 @@
-from io import StringIO
-
 import sympy
 
-from pharmpy import Model
 from pharmpy.modeling import (
     add_peripheral_compartment,
-    load_example_model,
     remove_peripheral_compartment,
     set_peripheral_compartments,
 )
 
 
-def create_model(s, testdata):
-    model = Model.create_model(StringIO(s))
-    model.dataset = load_example_model("pheno").dataset
-    return model
-
-
-def test_advan1(testdata):
+def test_advan1(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -35,7 +25,7 @@ $OMEGA 0.0309626  ; IVV
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     add_peripheral_compartment(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -68,7 +58,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert rate == sympy.Symbol('Q') / sympy.Symbol('V1')
 
 
-def test_advan2(testdata):
+def test_advan2(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -89,7 +79,7 @@ $OMEGA 0.0309626  ; IVMAT
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     add_peripheral_compartment(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -120,7 +110,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_advan2_trans1(testdata):
+def test_advan2_trans1(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -141,7 +131,7 @@ $OMEGA 0.0309626  ; IVMAT
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     add_peripheral_compartment(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -172,7 +162,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_advan3(testdata):
+def test_advan3(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -196,7 +186,7 @@ $OMEGA 0.0309626  ; IVV
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     add_peripheral_compartment(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -230,7 +220,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_advan4(testdata):
+def test_advan4(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -257,7 +247,7 @@ $OMEGA 0.0309626  ; IVMAT
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     add_peripheral_compartment(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -294,7 +284,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_advan1_two_periphs(testdata):
+def test_advan1_two_periphs(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -312,7 +302,7 @@ $OMEGA 0.0309626  ; IVV
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     add_peripheral_compartment(model)
     add_peripheral_compartment(model)
     model.model_code
@@ -348,7 +338,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_advan1_remove(testdata):
+def test_advan1_remove(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -366,12 +356,12 @@ $OMEGA 0.0309626  ; IVV
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code)
     remove_peripheral_compartment(model)
     assert model.model_code == code
 
 
-def test_advan3_remove(testdata):
+def test_advan3_remove(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -395,7 +385,7 @@ $OMEGA 0.0309626  ; IVV
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     remove_peripheral_compartment(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -417,7 +407,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_advan4_remove(testdata):
+def test_advan4_remove(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -445,7 +435,7 @@ $OMEGA 0.0309626  ; IVMAT
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     remove_peripheral_compartment(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -471,7 +461,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_advan11_remove(testdata):
+def test_advan11_remove(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -501,7 +491,7 @@ $OMEGA 0.0309626  ; IVV
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     remove_peripheral_compartment(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -529,7 +519,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_advan12_remove(testdata):
+def test_advan12_remove(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -562,7 +552,7 @@ $OMEGA 0.0309626  ; IVMAT
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     remove_peripheral_compartment(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -593,7 +583,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_advan11_remove_two_periphs(testdata):
+def test_advan11_remove_two_periphs(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -623,7 +613,7 @@ $OMEGA 0.0309626  ; IVV
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     remove_peripheral_compartment(model)
     remove_peripheral_compartment(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
@@ -646,7 +636,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_advan4_roundtrip(testdata):
+def test_advan4_roundtrip(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -674,7 +664,7 @@ $OMEGA 0.0309626  ; IVMAT
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     add_peripheral_compartment(model)
     remove_peripheral_compartment(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
@@ -707,7 +697,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_set_peripheral_compartments(testdata):
+def test_set_peripheral_compartments(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -737,7 +727,7 @@ $OMEGA 0.0309626  ; IVV
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = create_model(code, testdata)
+    model = create_model_for_test(code, dataset='pheno')
     set_peripheral_compartments(model, 0)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@

--- a/tests/modeling/test_error.py
+++ b/tests/modeling/test_error.py
@@ -1,11 +1,7 @@
-from io import StringIO
-
-from pharmpy import Model
 from pharmpy.modeling import (
     has_additive_error_model,
     has_combined_error_model,
     has_proportional_error_model,
-    load_example_model,
     read_model_from_string,
     remove_error_model,
     set_additive_error_model,
@@ -138,7 +134,7 @@ def test_set_combined_error_model_with_time_varying_and_eta_on_ruv(testdata, loa
     )
 
 
-def test_remove_error_without_f():
+def test_remove_error_without_f(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV
@@ -156,7 +152,7 @@ $OMEGA 0.031128  ; IVV
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = Model.create_model(StringIO(code))
+    model = create_model_for_test(code)
     remove_error_model(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
@@ -177,7 +173,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_additive_error_without_f():
+def test_additive_error_without_f(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -196,8 +192,7 @@ $OMEGA 0.031128  ; IVV
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = Model.create_model(StringIO(code))
-    model.dataset = load_example_model("pheno").dataset
+    model = create_model_for_test(code, dataset='pheno')
     set_additive_error_model(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -231,7 +226,7 @@ def test_get_prop_init(testdata, load_model_for_test):
     assert init == 0.01
 
 
-def test_has_additive_error_model():
+def test_has_additive_error_model(create_model_for_test):
     code = """$PROBLEM base model
 $INPUT ID DV TIME
 $DATA file.csv IGNORE=@
@@ -279,11 +274,11 @@ $ESTIMATION METHOD=1 INTER MAXEVALS=9990 PRINT=2 POSTHOC
     model = read_model_from_string(code)
     assert not has_additive_error_model(model)
 
-    model = Model.create_model(StringIO(code))
+    model = create_model_for_test(code)
     assert not has_additive_error_model(model)
 
 
-def test_has_proportional_error_model():
+def test_has_proportional_error_model(create_model_for_test):
     code = """$PROBLEM base model
 $INPUT ID DV TIME
 $DATA file.csv IGNORE=@
@@ -314,11 +309,11 @@ $ESTIMATION METHOD=1 INTER MAXEVALS=9990 PRINT=2 POSTHOC
     model = read_model_from_string(code)
     assert has_proportional_error_model(model)
 
-    model = Model.create_model(StringIO(code))
+    model = create_model_for_test(code)
     assert has_proportional_error_model(model)
 
 
-def test_has_combined_error_model():
+def test_has_combined_error_model(create_model_for_test):
     code = """$PROBLEM base model
 $INPUT ID DV TIME
 $DATA file.csv IGNORE=@
@@ -349,7 +344,7 @@ $ESTIMATION METHOD=1 INTER MAXEVALS=9990 PRINT=2 POSTHOC
     model = read_model_from_string(code)
     assert not has_combined_error_model(model)
 
-    model = Model.create_model(StringIO(code))
+    model = create_model_for_test(code)
     assert not has_combined_error_model(model)
 
     code = """$PROBLEM base model

--- a/tests/modeling/test_estimation_steps.py
+++ b/tests/modeling/test_estimation_steps.py
@@ -45,13 +45,13 @@ from pharmpy.modeling import (
         ),
     ],
 )
-def test_set_estimation_step(testdata, method, kwargs, code_ref):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_set_estimation_step(testdata, load_model_for_test, method, kwargs, code_ref):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     set_estimation_step(model, method, **kwargs)
     assert generate_model_code(model).split('\n')[-2] == code_ref
 
 
-def test_set_estimation_step_est_middle(testdata):
+def test_set_estimation_step_est_middle():
     model = Model.create_model(
         StringIO(
             '''$PROBLEM base model
@@ -72,37 +72,37 @@ $SIGMA 1
     assert '$ESTIMATION METHOD=COND INTER MAXEVAL=999999\n$COVARIANCE' in model.model_code
 
 
-def test_add_estimation_step(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_add_estimation_step(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     assert len(model.estimation_steps) == 1
     add_estimation_step(model, 'fo')
     assert len(model.estimation_steps) == 2
     assert generate_model_code(model).split('\n')[-2] == '$ESTIMATION METHOD=ZERO'
 
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     assert len(model.estimation_steps) == 1
     add_estimation_step(model, 'fo', evaluation=True)
     assert len(model.estimation_steps) == 2
     assert generate_model_code(model).split('\n')[-2] == '$ESTIMATION METHOD=ZERO MAXEVAL=0'
 
 
-def test_add_estimation_step_non_int(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_add_estimation_step_non_int(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     add_estimation_step(model, 'fo', idx=1.0)
     with pytest.raises(TypeError, match='Index must be integer'):
         add_estimation_step(model, 'fo', idx=1.5)
 
 
-def test_remove_estimation_step(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_remove_estimation_step(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     assert len(model.estimation_steps) == 1
     remove_estimation_step(model, 0)
     assert not model.estimation_steps
     assert generate_model_code(model).split('\n')[-2] == '$SIGMA 1'
 
 
-def test_add_covariance_step(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_add_covariance_step(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     assert len(model.estimation_steps) == 1
     add_covariance_step(model)
     print(model.model_code)
@@ -110,8 +110,8 @@ def test_add_covariance_step(testdata):
     assert generate_model_code(model).split('\n')[-2] == '$COVARIANCE'
 
 
-def test_remove_covariance_step(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_remove_covariance_step(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     add_covariance_step(model)
     assert generate_model_code(model).split('\n')[-2] == '$COVARIANCE'
     remove_covariance_step(model)
@@ -121,8 +121,8 @@ def test_remove_covariance_step(testdata):
     )
 
 
-def test_append_estimation_step_options(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_append_estimation_step_options(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     assert len(model.estimation_steps) == 1
     append_estimation_step_options(model, {'SADDLE_RESET': 1}, 0)
     assert (
@@ -131,7 +131,7 @@ def test_append_estimation_step_options(testdata):
     )
 
 
-def test_set_evaluation_step(testdata):
+def test_set_evaluation_step():
     model = Model.create_model(
         StringIO(
             '''$PROBLEM base model

--- a/tests/modeling/test_estimation_steps.py
+++ b/tests/modeling/test_estimation_steps.py
@@ -1,8 +1,5 @@
-from io import StringIO
-
 import pytest
 
-from pharmpy import Model
 from pharmpy.modeling import (
     add_covariance_step,
     add_estimation_step,
@@ -51,10 +48,9 @@ def test_set_estimation_step(testdata, load_model_for_test, method, kwargs, code
     assert generate_model_code(model).split('\n')[-2] == code_ref
 
 
-def test_set_estimation_step_est_middle():
-    model = Model.create_model(
-        StringIO(
-            '''$PROBLEM base model
+def test_set_estimation_step_est_middle(create_model_for_test):
+    model = create_model_for_test(
+        '''$PROBLEM base model
 $INPUT ID DV TIME
 $DATA file.csv IGNORE=@
 
@@ -66,7 +62,6 @@ $THETA 0.1
 $OMEGA 0.01
 $SIGMA 1
 '''
-        )
     )
     set_estimation_step(model, 'FOCE', interaction=True, cov=True, idx=0)
     assert '$ESTIMATION METHOD=COND INTER MAXEVAL=999999\n$COVARIANCE' in model.model_code
@@ -131,10 +126,9 @@ def test_append_estimation_step_options(testdata, load_model_for_test):
     )
 
 
-def test_set_evaluation_step():
-    model = Model.create_model(
-        StringIO(
-            '''$PROBLEM base model
+def test_set_evaluation_step(create_model_for_test):
+    model = create_model_for_test(
+        '''$PROBLEM base model
 $INPUT ID DV TIME
 $DATA file.csv IGNORE=@
 
@@ -146,7 +140,6 @@ $OMEGA 0.01
 $SIGMA 1
 $ESTIMATION METHOD=COND INTERACTION MAXEVAL=999999
 '''
-        )
     )
     set_evaluation_step(model)
     assert model.model_code.split('\n')[-2] == '$ESTIMATION METHOD=COND INTER MAXEVAL=0'

--- a/tests/modeling/test_eta_additions.py
+++ b/tests/modeling/test_eta_additions.py
@@ -4,7 +4,7 @@ import pytest
 import sympy
 from sympy import Symbol as S
 
-from pharmpy.modeling import add_iov, read_model, remove_iov
+from pharmpy.modeling import add_iov, remove_iov
 from pharmpy.modeling.eta_additions import EtaAddition
 
 
@@ -32,13 +32,13 @@ def test_apply(addition, expression):
         ('ETA_IOV_3_1', 'ETA_IOV_2_1'),
     ],
 )
-def test_regression_code_record(testdata, eta_iov_1, eta_iov_2):
+def test_regression_code_record(load_model_for_test, testdata, eta_iov_1, eta_iov_2):
     """This is a regression test for NONMEM CodeRecord statements property round-trip
     serialization.
     See https://github.com/pharmpy/pharmpy/pull/771
     """
 
-    model_no_iov = read_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    model_no_iov = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     model = model_no_iov.copy()
     add_iov(model, occ="VISI")
     model.model_code  # this triggers AST update

--- a/tests/modeling/test_evaluate.py
+++ b/tests/modeling/test_evaluate.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from pharmpy import Model
 from pharmpy.modeling import (
     evaluate_epsilon_gradient,
     evaluate_eta_gradient,
@@ -23,16 +22,16 @@ lincorrect = read_nonmem_dataset(
 )
 
 
-def test_evaluate_expression(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'pheno_noifs.mod')
+def test_evaluate_expression(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'pheno_noifs.mod')
     ser = evaluate_expression(model, 'TVV')
     assert ser[0] == pytest.approx(1.413062)
     assert ser[743] == pytest.approx(1.110262)
 
 
-def test_evaulate_population_prediction(testdata):
+def test_evaulate_population_prediction(load_model_for_test, testdata):
     path = testdata / 'nonmem' / 'minimal.mod'
-    model = Model.create_model(path)
+    model = load_model_for_test(path)
 
     dataset = pd.DataFrame({'ID': [1, 2], 'TIME': [0, 0], 'DV': [3, 4]})
     pred = evaluate_population_prediction(model, dataset=dataset)
@@ -40,15 +39,15 @@ def test_evaulate_population_prediction(testdata):
     assert list(pred) == [0.1, 0.1]
 
     linpath = testdata / 'nonmem' / 'pheno_real_linbase.mod'
-    linmod = Model.create_model(linpath)
+    linmod = load_model_for_test(linpath)
     pred = evaluate_population_prediction(linmod)
 
     pd.testing.assert_series_equal(lincorrect['PRED'], pred, rtol=1e-4, check_names=False)
 
 
-def test_evaluate_individual_prediction(testdata):
+def test_evaluate_individual_prediction(load_model_for_test, testdata):
     path = testdata / 'nonmem' / 'minimal.mod'
-    model = Model.create_model(path)
+    model = load_model_for_test(path)
 
     dataset = read_nonmem_dataset(StringIO('1 0 3\n2 0 4\n'), colnames=['ID', 'TIME', 'DV'])
     pred = evaluate_individual_prediction(model, dataset=dataset)
@@ -56,7 +55,7 @@ def test_evaluate_individual_prediction(testdata):
     assert list(pred) == [0.1, 0.1]
 
     linpath = testdata / 'nonmem' / 'pheno_real_linbase.mod'
-    linmod = Model.create_model(linpath)
+    linmod = load_model_for_test(linpath)
     pred = evaluate_individual_prediction(
         model=linmod, etas=linmod.modelfit_results.individual_estimates
     )
@@ -64,37 +63,37 @@ def test_evaluate_individual_prediction(testdata):
     pd.testing.assert_series_equal(lincorrect['CIPREDI'], pred, rtol=1e-4, check_names=False)
 
 
-def test_evaluate_eta_gradient(testdata):
+def test_evaluate_eta_gradient(load_model_for_test, testdata):
     path = testdata / 'nonmem' / 'minimal.mod'
-    model = Model.create_model(path)
+    model = load_model_for_test(path)
 
     dataset = read_nonmem_dataset(StringIO('1 0 3\n2 0 4\n'), colnames=['ID', 'TIME', 'DV'])
     grad = evaluate_eta_gradient(model, dataset=dataset)
     pd.testing.assert_frame_equal(grad, pd.DataFrame([1.0, 1.0], columns=['dF/dETA(1)']))
 
     linpath = testdata / 'nonmem' / 'pheno_real_linbase.mod'
-    linmod = Model.create_model(linpath)
+    linmod = load_model_for_test(linpath)
     grad = evaluate_eta_gradient(linmod)
     pd.testing.assert_series_equal(lincorrect['G11'], grad.iloc[:, 0], rtol=1e-4, check_names=False)
     pd.testing.assert_series_equal(lincorrect['G21'], grad.iloc[:, 1], rtol=1e-4, check_names=False)
 
 
-def test_evaluate_epsilon_gradient(testdata):
+def test_evaluate_epsilon_gradient(load_model_for_test, testdata):
     path = testdata / 'nonmem' / 'minimal.mod'
-    model = Model.create_model(path)
+    model = load_model_for_test(path)
 
     dataset = read_nonmem_dataset(StringIO('1 0 3\n2 0 4\n'), colnames=['ID', 'TIME', 'DV'])
     grad = evaluate_epsilon_gradient(model, dataset=dataset)
     pd.testing.assert_frame_equal(grad, pd.DataFrame([1.0, 1.0], columns=['dY/dEPS(1)']))
 
     linpath = testdata / 'nonmem' / 'pheno_real_linbase.mod'
-    linmod = Model.create_model(linpath)
+    linmod = load_model_for_test(linpath)
     grad = evaluate_epsilon_gradient(linmod, etas=linmod.modelfit_results.individual_estimates)
     pd.testing.assert_series_equal(lincorrect['H11'], grad.iloc[:, 0], rtol=1e-4, check_names=False)
 
 
-def test_evaluate_weighted_residuals(testdata):
+def test_evaluate_weighted_residuals(load_model_for_test, testdata):
     linpath = testdata / 'nonmem' / 'pheno_real_linbase.mod'
-    linmod = Model.create_model(linpath)
+    linmod = load_model_for_test(linpath)
     wres = evaluate_weighted_residuals(linmod)
     pd.testing.assert_series_equal(lincorrect['WRES'], wres, rtol=1e-4, check_names=False)

--- a/tests/modeling/test_expressions.py
+++ b/tests/modeling/test_expressions.py
@@ -23,7 +23,6 @@ from pharmpy.modeling import (
     has_random_effect,
     make_declarative,
     mu_reference_model,
-    read_model,
     read_model_from_string,
     simplify_expression,
     solve_ode_system,
@@ -34,8 +33,8 @@ def s(x):
     return sympy.Symbol(x)
 
 
-def test_get_observation_expression(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real_linbase.mod')
+def test_get_observation_expression(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real_linbase.mod')
     expr = get_observation_expression(model)
     assert expr == s('D_EPSETA1_2') * s('EPS(1)') * (s('ETA(2)') - s('OETA2')) + s('D_ETA1') * (
         s('ETA(1)') - s('OETA1')
@@ -46,28 +45,28 @@ def test_get_observation_expression(testdata):
     )
 
 
-def test_get_individual_prediction_expression(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real_linbase.mod')
+def test_get_individual_prediction_expression(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real_linbase.mod')
     expr = get_individual_prediction_expression(model)
     assert expr == s('D_ETA1') * (s('ETA(1)') - s('OETA1')) + s('D_ETA2') * (
         s('ETA(2)') - s('OETA2')
     ) + s('OPRED')
 
 
-def test_get_population_prediction_expression(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real_linbase.mod')
+def test_get_population_prediction_expression(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real_linbase.mod')
     expr = get_population_prediction_expression(model)
     assert expr == -s('D_ETA1') * s('OETA1') - s('D_ETA2') * s('OETA2') + s('OPRED')
 
 
-def test_calculate_eta_gradient_expression(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real_linbase.mod')
+def test_calculate_eta_gradient_expression(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real_linbase.mod')
     expr = calculate_eta_gradient_expression(model)
     assert expr == [s('D_ETA1'), s('D_ETA2')]
 
 
-def test_calculate_epsilon_gradient_expression(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real_linbase.mod')
+def test_calculate_epsilon_gradient_expression(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real_linbase.mod')
     expr = calculate_epsilon_gradient_expression(model)
     assert expr == [
         s('D_EPS1')
@@ -76,7 +75,7 @@ def test_calculate_epsilon_gradient_expression(testdata):
     ]
 
 
-def test_mu_reference_model_full(testdata):
+def test_mu_reference_model_full():
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -155,7 +154,7 @@ $ESTIMATION METHOD=1 INTERACTION
         ),
     ],
 )
-def test_mu_reference_model_generic(testdata, statements, correct):
+def test_mu_reference_model_generic(statements, correct):
     model = Model()
     model.statements = Statements(statements)
     eta1 = RandomVariable.normal('ETA(1)', 'iiv', 0, s('omega1'))
@@ -327,8 +326,8 @@ def test_greekify_model(pheno):
     ),
     ids=repr,
 )
-def test_get_pk_parameters(testdata, model_path, kind, expected):
-    model = read_model(testdata / model_path)
+def test_get_pk_parameters(load_model_for_test, testdata, model_path, kind, expected):
+    model = load_model_for_test(testdata / model_path)
     assert set(get_pk_parameters(model, kind)) == set(expected)
 
 
@@ -380,8 +379,8 @@ def test_get_pk_parameters(testdata, model_path, kind, expected):
     ),
     ids=repr,
 )
-def test_get_individual_parameters(testdata, model_path, level, expected):
-    model = read_model(testdata / model_path)
+def test_get_individual_parameters(load_model_for_test, testdata, model_path, level, expected):
+    model = load_model_for_test(testdata / model_path)
     assert set(get_individual_parameters(model, level)) == set(expected)
 
 
@@ -433,8 +432,8 @@ def test_get_individual_parameters(testdata, model_path, level, expected):
     ),
     ids=repr,
 )
-def test_has_random_effect(testdata, model_path, level, expected):
-    model = read_model(testdata / model_path)
+def test_has_random_effect(load_model_for_test, testdata, model_path, level, expected):
+    model = load_model_for_test(testdata / model_path)
     params_with_random_effect = set(expected)
     for param in get_pk_parameters(model):
         if param in params_with_random_effect:

--- a/tests/modeling/test_help_functions.py
+++ b/tests/modeling/test_help_functions.py
@@ -1,12 +1,11 @@
 import pytest
 
-from pharmpy import Model
 from pharmpy.modeling import fix_parameters
 from pharmpy.modeling.help_functions import _as_integer, _get_etas
 
 
-def test_get_etas(pheno_path, testdata):
-    model = Model.create_model(pheno_path)
+def test_get_etas(pheno_path, testdata, load_model_for_test):
+    model = load_model_for_test(pheno_path)
 
     etas = _get_etas(model, ['ETA(1)'])
     assert len(etas) == 1
@@ -20,7 +19,7 @@ def test_get_etas(pheno_path, testdata):
     with pytest.raises(KeyError):
         _get_etas(model, ['ETA(23)'])
 
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_block.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_block.mod')
     rvs = _get_etas(model, None)
     assert rvs[0].name == 'ETA(1)'
 
@@ -28,7 +27,7 @@ def test_get_etas(pheno_path, testdata):
     rvs = _get_etas(model, None)
     assert rvs[0].name == 'ETA(2)'
 
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_block.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_block.mod')
     model.random_variables['ETA(1)'].level = 'IOV'
     rvs = _get_etas(model, None)
     assert rvs[0].name == 'ETA(2)'

--- a/tests/modeling/test_modeling.py
+++ b/tests/modeling/test_modeling.py
@@ -50,8 +50,8 @@ from pharmpy.modeling.odes import find_clearance_parameters, find_volume_paramet
 from pharmpy.utils import TemporaryDirectoryChanger
 
 
-def test_set_first_order_elimination(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+def test_set_first_order_elimination(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     correct = model.model_code
     set_first_order_elimination(model)
     assert model.model_code == correct
@@ -109,8 +109,8 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_set_zero_order_elimination(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+def test_set_zero_order_elimination(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     assert not has_zero_order_elimination(model)
     set_zero_order_elimination(model)
     assert has_zero_order_elimination(model)
@@ -174,7 +174,7 @@ $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
     assert model.model_code == correct
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     set_mixed_mm_fo_elimination(model)
     set_zero_order_elimination(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
@@ -205,8 +205,8 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_set_michaelis_menten_elimination(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+def test_set_michaelis_menten_elimination(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     assert not has_michaelis_menten_elimination(model)
     set_michaelis_menten_elimination(model)
     assert has_michaelis_menten_elimination(model)
@@ -273,7 +273,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_fo_mm_eta(testdata):
+def test_fo_mm_eta():
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -319,7 +319,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_set_michaelis_menten_elimination_from_k(testdata):
+def test_set_michaelis_menten_elimination_from_k():
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -360,7 +360,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_combined_mm_fo_elimination(testdata):
+def test_combined_mm_fo_elimination():
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -435,7 +435,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_combined_mm_fo_elimination_from_k(testdata):
+def test_combined_mm_fo_elimination_from_k():
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -507,12 +507,12 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_transit_compartments(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
+def test_transit_compartments(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     set_transit_compartments(model, 0)
     transits = model.statements.ode_system.find_transit_compartments(model.statements)
     assert len(transits) == 0
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_2transits.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_2transits.mod')
     set_transit_compartments(model, 1)
     transits = model.statements.ode_system.find_transit_compartments(model.statements)
     assert len(transits) == 1
@@ -564,7 +564,7 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
 """
     )
     assert model.model_code == correct
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_2transits.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_2transits.mod')
     set_transit_compartments(model, 4)
     transits = model.statements.ode_system.find_transit_compartments(model.statements)
     assert len(transits) == 4
@@ -619,21 +619,21 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
 '''
     )
     assert model.model_code == correct
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
     set_transit_compartments(model, 1)
 
     assert not re.search(r'K *= *', model.model_code)
     assert re.search('K30 = CL/V', model.model_code)
 
 
-def test_transits_absfo(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
+def test_transits_absfo(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
     set_transit_compartments(model, 0, keep_depot=False)
     transits = model.statements.ode_system.find_transit_compartments(model.statements)
     assert len(transits) == 0
     assert len(model.statements.ode_system) == 2
 
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_2transits.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_2transits.mod')
     set_transit_compartments(model, 1, keep_depot=False)
     transits = model.statements.ode_system.find_transit_compartments(model.statements)
     assert len(transits) == 0
@@ -682,7 +682,7 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
 """
     assert model.model_code == correct
 
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_2transits.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_2transits.mod')
     set_transit_compartments(model, 4, keep_depot=False)
     transits = model.statements.ode_system.find_transit_compartments(model.statements)
     assert len(transits) == 4
@@ -735,15 +735,15 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
 '''
     )
     assert model.model_code == correct
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
     set_transit_compartments(model, 1, keep_depot=False)
 
     assert not re.search(r'K *= *', model.model_code)
     assert re.search('KA = 1/MDT', model.model_code)
 
 
-def test_transit_compartments_added_mdt(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_nodepot.mod')
+def test_transit_compartments_added_mdt(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_nodepot.mod')
     set_transit_compartments(model, 2)
     transits = model.statements.ode_system.find_transit_compartments(model.statements)
     assert len(transits) == 2
@@ -797,8 +797,8 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == correct
 
 
-def test_transit_compartments_change_advan(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
+def test_transit_compartments_change_advan(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     set_transit_compartments(model, 3)
     transits = model.statements.ode_system.find_transit_compartments(model.statements)
     assert len(transits) == 3
@@ -850,8 +850,8 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == correct
 
 
-def test_transit_compartments_change_number(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+def test_transit_compartments_change_number(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     set_transit_compartments(model, 3)
     set_transit_compartments(model, 2)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
@@ -883,7 +883,7 @@ $ESTIMATION METHOD=1 INTERACTION
 """
     assert model.model_code == correct
 
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     set_transit_compartments(model, 2)
     set_transit_compartments(model, 3)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
@@ -917,8 +917,8 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_transits_non_linear_elim_with_update(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+def test_transits_non_linear_elim_with_update(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     set_transit_compartments(model, 3)
     model.model_code
     set_zero_order_elimination(model)
@@ -926,7 +926,7 @@ def test_transits_non_linear_elim_with_update(testdata):
     assert 'CLMM = THETA(4)*EXP(ETA(1))' in model.model_code
     assert 'CL =' not in model.model_code
 
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     set_transit_compartments(model, 3)
     model.model_code
     set_michaelis_menten_elimination(model)
@@ -934,7 +934,7 @@ def test_transits_non_linear_elim_with_update(testdata):
     assert 'CLMM = THETA(4)*EXP(ETA(1))' in model.model_code
     assert 'CL =' not in model.model_code
 
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     set_transit_compartments(model, 3)
     model.model_code
     set_mixed_mm_fo_elimination(model)
@@ -943,8 +943,8 @@ def test_transits_non_linear_elim_with_update(testdata):
     assert 'CL = THETA(1) * EXP(ETA(1))' in model.model_code
 
 
-def test_lag_time(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
+def test_lag_time(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     before = model.model_code
     add_lag_time(model)
     correct = '''$PROBLEM PHENOBARB SIMPLE MODEL
@@ -991,8 +991,8 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == before
 
 
-def test_add_lag_time_updated_dose(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
+def test_add_lag_time_updated_dose(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     add_lag_time(model)
     set_first_order_absorption(model)
     correct = '''$PROBLEM PHENOBARB SIMPLE MODEL
@@ -1083,8 +1083,8 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == correct
 
 
-def test_nested_transit_peripherals(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+def test_nested_transit_peripherals(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     set_transit_compartments(model, 1)
     model.model_code
     set_peripheral_compartments(model, 1)
@@ -1092,8 +1092,8 @@ def test_nested_transit_peripherals(testdata):
     set_peripheral_compartments(model, 2)
 
 
-def test_nan_add_covariate_effect(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_nan_add_covariate_effect(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     data = model.dataset
 
     new_col = [np.nan] * 10 + ([1.0] * (len(data.index) - 10))
@@ -1108,15 +1108,15 @@ def test_nan_add_covariate_effect(pheno_path):
     assert re.search(r'NEW_COL\.EQ\.-99', model.model_code)
 
 
-def test_nested_add_covariate_effect(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_nested_add_covariate_effect(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
 
     add_covariate_effect(model, 'CL', 'WGT', 'exp')
 
     with pytest.warns(UserWarning):
         add_covariate_effect(model, 'CL', 'WGT', 'exp')
 
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
 
     add_covariate_effect(model, 'CL', 'WGT', 'exp')
     add_covariate_effect(model, 'CL', 'APGR', 'exp')
@@ -1416,8 +1416,8 @@ def test_nested_add_covariate_effect(pheno_path):
     ],
     ids=repr,
 )
-def test_add_covariate_effect(testdata, model_path, effects, expected):
-    model = Model.create_model(testdata.joinpath(*model_path))
+def test_add_covariate_effect(load_model_for_test, testdata, model_path, effects, expected):
+    model = load_model_for_test(testdata.joinpath(*model_path))
     error_record_before = ''.join(map(str, model.control_stream.get_records('ERROR')))
 
     for effect in effects:
@@ -1433,7 +1433,7 @@ def test_add_covariate_effect(testdata, model_path, effects, expected):
         assert f'POP_{effect[0]}{effect[1]}' in model.model_code
 
 
-def test_add_depot(testdata):
+def test_add_depot():
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -1547,40 +1547,40 @@ $ESTIMATION METHOD=1 INTERACTION
     # assert model.model_code == correct
 
 
-def test_absorption_rate(testdata, tmp_path):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
+def test_absorption_rate(load_model_for_test, testdata, tmp_path):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     advan1_before = model.model_code
     set_bolus_absorption(model)
     assert advan1_before == model.model_code
 
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
     set_bolus_absorption(model)
     assert model.model_code == advan1_before
 
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan3.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan3.mod')
     advan3_before = model.model_code
     set_bolus_absorption(model)
     assert model.model_code == advan3_before
 
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan4.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan4.mod')
     set_bolus_absorption(model)
     assert model.model_code == advan3_before
 
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan11.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan11.mod')
     advan11_before = model.model_code
     set_bolus_absorption(model)
     assert model.model_code == advan11_before
 
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan12.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan12.mod')
     set_bolus_absorption(model)
     assert model.model_code == advan11_before
 
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_nodepot.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_nodepot.mod')
     advan5_nodepot_before = model.model_code
     set_bolus_absorption(model)
     assert model.model_code == advan5_nodepot_before
 
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_depot.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_depot.mod')
     set_bolus_absorption(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA ../pheno.dta IGNORE=@
@@ -1624,26 +1624,26 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == correct
 
     # 0-order to 0-order
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1_zero_order.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1_zero_order.mod')
     advan1_zero_order_before = model.model_code
     set_zero_order_absorption(model)
     assert model.model_code == advan1_zero_order_before
 
     # 0-order to Bolus
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1_zero_order.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1_zero_order.mod')
     set_bolus_absorption(model)
     model.update_source(nofiles=True)
     assert model.model_code.split('\n')[2:] == advan1_before.split('\n')[2:]
 
     # 1st order to 1st order
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
     advan2_before = model.model_code
     set_first_order_absorption(model)
     model.update_source(nofiles=True)
     assert model.model_code == advan2_before
 
     # 0-order to 1st order
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1_zero_order.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1_zero_order.mod')
     set_first_order_absorption(model)
     model.update_source(nofiles=True)
     correct = '''$PROBLEM PHENOBARB SIMPLE MODEL
@@ -1687,7 +1687,7 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == correct
 
     # Bolus to 1st order
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     set_first_order_absorption(model)
     model.update_source(nofiles=True)
     assert model.model_code.split('\n')[2:] == correct.split('\n')[2:]
@@ -1786,8 +1786,8 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == correct
 
 
-def test_seq_to_FO(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2_seq.mod')
+def test_seq_to_FO(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2_seq.mod')
     set_first_order_absorption(model)
     model.update_source(nofiles=True)
     correct = '''$PROBLEM PHENOBARB SIMPLE MODEL
@@ -1830,8 +1830,8 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == correct
 
 
-def test_seq_to_ZO(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2_seq.mod')
+def test_seq_to_ZO(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2_seq.mod')
     set_zero_order_absorption(model)
     model.update_source(nofiles=True)
     correct = '''$PROBLEM PHENOBARB SIMPLE MODEL
@@ -1874,8 +1874,8 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == correct
 
 
-def test_bolus_to_seq(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
+def test_bolus_to_seq(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     set_seq_zo_fo_absorption(model)
     model.update_source(nofiles=True)
     correct = '''$PROBLEM PHENOBARB SIMPLE MODEL
@@ -1922,8 +1922,8 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == correct
 
 
-def test_ZO_to_seq(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1_zero_order.mod')
+def test_ZO_to_seq(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1_zero_order.mod')
     set_seq_zo_fo_absorption(model)
     model.update_source(nofiles=True)
     correct = '''$PROBLEM PHENOBARB SIMPLE MODEL
@@ -1969,8 +1969,8 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == correct
 
 
-def test_FO_to_seq(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
+def test_FO_to_seq(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
     set_seq_zo_fo_absorption(model)
     model.update_source(nofiles=True)
     correct = '''$PROBLEM PHENOBARB SIMPLE MODEL
@@ -2016,23 +2016,23 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     assert model.model_code == correct
 
 
-def test_absorption_keep_mat(testdata):
+def test_absorption_keep_mat(load_model_for_test, testdata):
     # FO to ZO (start model with MAT-eta)
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     set_zero_order_absorption(model)
     assert 'MAT = THETA(3) * EXP(ETA(3))' in model.model_code
     assert 'KA =' not in model.model_code
     assert 'D1 =' in model.model_code
 
     # FO to seq-ZO-FO
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     set_seq_zo_fo_absorption(model)
     assert 'MAT = THETA(3) * EXP(ETA(3))' in model.model_code
     assert 'KA =' in model.model_code
     assert 'D1 =' in model.model_code
 
     # ZO to seq-ZO-FO
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     set_zero_order_absorption(model)
     set_seq_zo_fo_absorption(model)
     assert 'MAT = THETA(3) * EXP(ETA(3))' in model.model_code
@@ -2041,7 +2041,7 @@ def test_absorption_keep_mat(testdata):
     assert 'MAT1' not in model.model_code
 
     # ZO to FO
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     set_zero_order_absorption(model)
     set_first_order_absorption(model)
     assert 'MAT = THETA(3) * EXP(ETA(3))' in model.model_code
@@ -2049,28 +2049,28 @@ def test_absorption_keep_mat(testdata):
     assert 'D1 =' not in model.model_code
 
     # Transit without keeping depot
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     set_transit_compartments(model, 3, keep_depot=False)
     assert 'MDT = THETA(3)*EXP(ETA(3))' in model.model_code
 
 
-def test_has_zero_order_absorption(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_has_zero_order_absorption(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     assert not has_zero_order_absorption(model)
     set_zero_order_absorption(model)
     assert has_zero_order_absorption(model)
 
 
-def test_lag_on_nl_elim(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+def test_lag_on_nl_elim(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     set_zero_order_elimination(model)
     model.model_code
     add_lag_time(model)
     assert 'ALAG' in model.model_code
 
 
-def test_zo_abs_on_nl_elim(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+def test_zo_abs_on_nl_elim(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     set_zero_order_elimination(model)
     # model.model_code
     set_zero_order_absorption(model)
@@ -2107,8 +2107,8 @@ def test_zo_abs_on_nl_elim(testdata):
         ),
     ],
 )
-def test_transform_etas_boxcox(pheno_path, etas, etab, buf_new):
-    model = Model.create_model(pheno_path)
+def test_transform_etas_boxcox(load_model_for_test, pheno_path, etas, etab, buf_new):
+    model = load_model_for_test(pheno_path)
 
     transform_etas_boxcox(model, etas)
     model.update_source()
@@ -2129,8 +2129,8 @@ def test_transform_etas_boxcox(pheno_path, etas, etab, buf_new):
     assert model.parameters['lambda1'].init == 0.01
 
 
-def test_transform_etas_tdist(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_transform_etas_tdist(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
 
     transform_etas_tdist(model, ['ETA(1)'])
     model.update_source()
@@ -2185,8 +2185,8 @@ def test_transform_etas_tdist(pheno_path):
         ),
     ],
 )
-def test_transform_etas_john_draper(pheno_path, etas, etad, buf_new):
-    model = Model.create_model(pheno_path)
+def test_transform_etas_john_draper(load_model_for_test, pheno_path, etas, etad, buf_new):
+    model = load_model_for_test(pheno_path)
 
     transform_etas_john_draper(model, etas)
     model.update_source()
@@ -2236,8 +2236,17 @@ def test_transform_etas_john_draper(pheno_path, etas, etad, buf_new):
         ),
     ],
 )
-def test_add_iiv(pheno_path, parameter, expression, operation, eta_name, buf_new, no_of_omega_recs):
-    model = Model.create_model(pheno_path)
+def test_add_iiv(
+    load_model_for_test,
+    pheno_path,
+    parameter,
+    expression,
+    operation,
+    eta_name,
+    buf_new,
+    no_of_omega_recs,
+):
+    model = load_model_for_test(pheno_path)
 
     add_iiv(
         model,
@@ -2272,8 +2281,8 @@ def test_add_iiv(pheno_path, parameter, expression, operation, eta_name, buf_new
     assert '$OMEGA  0.09 ; IIV_' in str(omega_rec[-1])
 
 
-def test_add_iiv_missing_param(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_add_iiv_missing_param(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     with pytest.raises(ValueError):
         add_iiv(model, 'non_existing_param', 'add')
 
@@ -2410,8 +2419,8 @@ def test_add_iiv_missing_param(pheno_path):
         ),
     ],
 )
-def test_create_joint_distribution(testdata, etas, pk_ref, omega_ref):
-    model = Model.create_model(testdata / 'nonmem/pheno_block.mod')
+def test_create_joint_distribution(load_model_for_test, testdata, etas, pk_ref, omega_ref):
+    model = load_model_for_test(testdata / 'nonmem/pheno_block.mod')
 
     create_joint_distribution(model, etas)
     model.update_source()
@@ -2486,8 +2495,8 @@ def test_create_joint_distribution(testdata, etas, pk_ref, omega_ref):
         ),
     ],
 )
-def test_create_joint_distribution_nested(testdata, etas, pk_ref, omega_ref):
-    model = Model.create_model(testdata / 'nonmem/pheno_block.mod')
+def test_create_joint_distribution_nested(load_model_for_test, testdata, etas, pk_ref, omega_ref):
+    model = load_model_for_test(testdata / 'nonmem/pheno_block.mod')
 
     create_joint_distribution(model, etas[0])
     model.update_source()
@@ -2593,8 +2602,8 @@ def test_create_joint_distribution_nested(testdata, etas, pk_ref, omega_ref):
         ),
     ],
 )
-def test_split_joint_distribution(testdata, etas, pk_ref, omega_ref):
-    model = Model.create_model(testdata / 'nonmem/pheno_block.mod')
+def test_split_joint_distribution(load_model_for_test, testdata, etas, pk_ref, omega_ref):
+    model = load_model_for_test(testdata / 'nonmem/pheno_block.mod')
     create_joint_distribution(model)
     model.update_source()
 
@@ -2670,8 +2679,10 @@ def test_split_joint_distribution(testdata, etas, pk_ref, omega_ref):
         ),
     ],
 )
-def test_set_iiv_on_ruv(pheno_path, epsilons, same_eta, eta_names, err_ref, omega_ref):
-    model = Model.create_model(pheno_path)
+def test_set_iiv_on_ruv(
+    load_model_for_test, pheno_path, epsilons, same_eta, eta_names, err_ref, omega_ref
+):
+    model = load_model_for_test(pheno_path)
 
     model_str = model.model_code
     model_more_eps = re.sub(
@@ -2792,8 +2803,8 @@ def test_set_iiv_on_ruv(pheno_path, epsilons, same_eta, eta_names, err_ref, omeg
         ),
     ],
 )
-def test_remove_iiv(testdata, etas, pk_ref, omega_ref):
-    model = Model.create_model(testdata / 'nonmem/pheno_block.mod')
+def test_remove_iiv(load_model_for_test, testdata, etas, pk_ref, omega_ref):
+    model = load_model_for_test(testdata / 'nonmem/pheno_block.mod')
     remove_iiv(model, etas)
     model.update_source()
 
@@ -2804,8 +2815,8 @@ def test_remove_iiv(testdata, etas, pk_ref, omega_ref):
     assert rec_omega == omega_ref
 
 
-def test_remove_iov(testdata):
-    model = Model.create_model(testdata / 'nonmem/pheno_block.mod')
+def test_remove_iov(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem/pheno_block.mod')
 
     model_str = model.model_code
     model_with_iov = model_str.replace(
@@ -2830,24 +2841,24 @@ def test_remove_iov(testdata):
 
     assert rec_omega == '$OMEGA 0.1\n' '$OMEGA BLOCK(2)\n' '0.0309626\n' '0.0005 0.031128\n'
 
-    model = Model.create_model(testdata / 'nonmem/pheno_block.mod')
+    model = load_model_for_test(testdata / 'nonmem/pheno_block.mod')
 
     with pytest.warns(UserWarning):
         remove_iov(model)
 
 
-def test_remove_iov_github_issues_538_and_561_1(testdata):
+def test_remove_iov_github_issues_538_and_561_1(load_model_for_test, testdata):
 
-    m = Model.create_model(testdata / 'nonmem' / 'models' / 'fviii6.mod')
+    m = load_model_for_test(testdata / 'nonmem' / 'models' / 'fviii6.mod')
 
     remove_iov(m)
 
     assert not m.random_variables.iov
 
 
-def test_remove_iov_github_issues_538_and_561_2(testdata):
+def test_remove_iov_github_issues_538_and_561_2(load_model_for_test, testdata):
 
-    m = Model.create_model(testdata / 'nonmem' / 'models' / 'fviii6.mod')
+    m = load_model_for_test(testdata / 'nonmem' / 'models' / 'fviii6.mod')
 
     remove_iov(m, 'ETA(4)')
 
@@ -3014,11 +3025,13 @@ $OMEGA  0.1'''
     ),
     ids=repr,
 )
-def test_remove_iov_with_options(tmp_path, testdata, distribution, occ, to_remove, cases, rest):
+def test_remove_iov_with_options(
+    tmp_path, load_model_for_test, testdata, distribution, occ, to_remove, cases, rest
+):
     with TemporaryDirectoryChanger(tmp_path):
         shutil.copy2(testdata / 'nonmem' / 'models' / 'mox2.mod', tmp_path)
         shutil.copy2(testdata / 'nonmem' / 'models' / 'mox_simulated_normal.csv', tmp_path)
-        model = Model.create_model('mox2.mod')
+        model = load_model_for_test('mox2.mod')
         model.datainfo = model.datainfo.derive(path=tmp_path / 'mox_simulated_normal.csv')
 
         start_model = add_iov(model, occ=occ, distribution=distribution)
@@ -3035,7 +3048,7 @@ def test_remove_iov_with_options(tmp_path, testdata, distribution, occ, to_remov
     'etas_file, force, file_exists',
     [('', False, False), ('', True, True), ('$ETAS FILE=run1.phi', False, True)],
 )
-def test_update_inits(testdata, etas_file, force, file_exists, tmp_path):
+def test_update_inits(load_model_for_test, testdata, etas_file, force, file_exists, tmp_path):
     shutil.copy(testdata / 'nonmem/pheno.mod', tmp_path / 'run1.mod')
     shutil.copy(testdata / 'nonmem/pheno.phi', tmp_path / 'run1.phi')
     shutil.copy(testdata / 'nonmem/pheno.ext', tmp_path / 'run1.ext')
@@ -3045,7 +3058,7 @@ def test_update_inits(testdata, etas_file, force, file_exists, tmp_path):
         with open('run1.mod', 'a') as f:
             f.write(etas_file)
 
-        model = Model.create_model('run1.mod')
+        model = load_model_for_test('run1.mod')
         update_inits(model, force)
         model.update_source()
 
@@ -3053,8 +3066,8 @@ def test_update_inits(testdata, etas_file, force, file_exists, tmp_path):
         assert (os.path.isfile('run1_input.phi')) is file_exists
 
 
-def test_update_inits_move_est(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_update_inits_move_est(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     res = model.modelfit_results
 
     create_joint_distribution(model)
@@ -3072,8 +3085,8 @@ def test_update_inits_move_est(pheno_path):
     assert round(model.parameters['IIV_CL_IIV_V'].init, 6) == 0.025757
 
 
-def test_update_inits_zero_fix(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_update_inits_zero_fix(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     d = {name: 0 for name in model.random_variables.iiv.parameter_names}
     fix_parameters_to(model, d)
     res = model.modelfit_results
@@ -3083,7 +3096,7 @@ def test_update_inits_zero_fix(pheno_path):
     assert model.parameters['OMEGA(1,1)'].init == 0
     assert model.parameters['OMEGA(1,1)'].fix
 
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
     d = {name: 0 for name in model.random_variables.iiv.parameter_names}
     fix_parameters_to(model, d)
     res = model.modelfit_results
@@ -3191,8 +3204,8 @@ def test_set_power_on_ruv(testdata, epsilons, err_ref, theta_ref, tmp_path):
         )
 
 
-def test_nested_update_source(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_nested_update_source(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
 
     create_joint_distribution(model)
     model.update_source()
@@ -3200,7 +3213,7 @@ def test_nested_update_source(pheno_path):
 
     assert 'IIV_CL_IIV_V' in model.model_code
 
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
 
     remove_iiv(model, 'CL')
 
@@ -3210,7 +3223,7 @@ def test_nested_update_source(pheno_path):
     assert '0.031128 ; IVV' in model.model_code
     assert '0.0309626  ;       IVCL' not in model.model_code
 
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
 
     remove_iiv(model, 'V')
 
@@ -3565,9 +3578,18 @@ def test_nested_update_source(pheno_path):
     ],
 )
 def test_add_iov(
-    testdata, path, occ, etas, eta_names, pk_start_ref, pk_end_ref, omega_ref, distribution
+    load_model_for_test,
+    testdata,
+    path,
+    occ,
+    etas,
+    eta_names,
+    pk_start_ref,
+    pk_end_ref,
+    omega_ref,
+    distribution,
 ):
-    model = Model.create_model(testdata / path)
+    model = load_model_for_test(testdata / path)
     add_iov(model, occ, etas, eta_names, distribution=distribution)
     model.update_source()
 
@@ -3587,12 +3609,12 @@ def test_add_iov(
     assert rec_omega[-len(omega_ref) :] == omega_ref
 
 
-def test_add_iov_compose(pheno_path):
-    model1 = Model.create_model(pheno_path)
+def test_add_iov_compose(load_model_for_test, pheno_path):
+    model1 = load_model_for_test(pheno_path)
     add_iov(model1, 'FA1', ['ETA(1)', 'ETA(2)'])
     model1.update_source()
 
-    model2 = Model.create_model(pheno_path)
+    model2 = load_model_for_test(pheno_path)
     add_iov(model2, 'FA1', 'ETA(1)')
     model2.update_source()
     add_iov(model2, 'FA1', 'ETA(2)')
@@ -3612,8 +3634,8 @@ def test_add_iov_compose(pheno_path):
     assert rec_omega_1 == rec_omega_2
 
 
-def test_add_iov_only_one_level(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_add_iov_only_one_level(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     model.dataset['FA1'] = 1
 
     with pytest.raises(ValueError, match='Only one value in FA1 column.'):
@@ -3705,24 +3727,26 @@ def test_add_iov_only_one_level(pheno_path):
         ),
     ),
 )
-def test_add_iov_raises(pheno_path, occ, params, new_eta_names, distribution, error, message):
-    model = Model.create_model(pheno_path)
+def test_add_iov_raises(
+    load_model_for_test, pheno_path, occ, params, new_eta_names, distribution, error, message
+):
+    model = load_model_for_test(pheno_path)
     with pytest.raises(error, match=re.escape(message)):
         add_iov(model, occ, params, eta_names=new_eta_names, distribution=distribution)
 
 
-def test_set_ode_solver(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_set_ode_solver(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     assert model.estimation_steps[0].solver is None
     assert 'ADVAN1' in model.model_code
 
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
     set_michaelis_menten_elimination(model)
     set_ode_solver(model, 'LSODA')
     assert model.estimation_steps[0].solver == 'LSODA'
     assert 'ADVAN13' in model.model_code
 
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
     set_zero_order_elimination(model)
     assert 'ADVAN13' in model.model_code
     set_ode_solver(model, 'LSODA')
@@ -3734,8 +3758,8 @@ def test_set_ode_solver(pheno_path):
     assert 'ADVAN6' in model.model_code
 
 
-def test_add_pk_iiv(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_add_pk_iiv(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     set_zero_order_elimination(model)
     add_pk_iiv(model)
     iivs = set(model.random_variables.iiv.names)
@@ -3745,7 +3769,7 @@ def test_add_pk_iiv(pheno_path):
     iivs = set(model.random_variables.iiv.names)
     assert iivs == {'ETA(1)', 'ETA(2)', 'ETA_KM', 'ETA_VP1', 'ETA_QP1'}
 
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
     set_zero_order_elimination(model)
     add_peripheral_compartment(model)
     add_pk_iiv(model)
@@ -3753,20 +3777,20 @@ def test_add_pk_iiv(pheno_path):
     assert iivs == {'ETA(1)', 'ETA(2)', 'ETA_KM', 'ETA_VP1', 'ETA_QP1'}
 
 
-def test_add_pk_iiv_nested_params(testdata, pheno_path):
-    model = Model.create_model(pheno_path)
+def test_add_pk_iiv_nested_params(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     set_transit_compartments(model, 3)
     add_pk_iiv(model)
     iivs = set(model.random_variables.iiv.names)
     assert iivs == {'ETA(1)', 'ETA(2)', 'ETA_MDT'}
 
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
     set_first_order_absorption(model)
     add_pk_iiv(model)
     iivs = set(model.random_variables.iiv.names)
     assert iivs == {'ETA(1)', 'ETA(2)', 'ETA_MAT'}
 
-    model = Model.create_model(pheno_path)
+    model = load_model_for_test(pheno_path)
     set_transit_compartments(model, 3)
     add_pk_iiv(model, initial_estimate=0.01)
     assert model.parameters['IIV_MDT'].init == 0.01

--- a/tests/modeling/test_modeling.py
+++ b/tests/modeling/test_modeling.py
@@ -1,14 +1,12 @@
 import os
 import re
 import shutil
-from io import StringIO
 
 import numpy as np
 import pandas as pd
 import pytest
 import sympy
 
-from pharmpy import Model
 from pharmpy.modeling import (
     add_covariate_effect,
     add_iiv,
@@ -23,7 +21,6 @@ from pharmpy.modeling import (
     has_mixed_mm_fo_elimination,
     has_zero_order_absorption,
     has_zero_order_elimination,
-    load_example_model,
     remove_iiv,
     remove_iov,
     remove_lag_time,
@@ -273,7 +270,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_fo_mm_eta():
+def test_fo_mm_eta(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -291,8 +288,7 @@ $OMEGA 0.5  ; IIV_V
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = Model.create_model(StringIO(code))
-    model.dataset = load_example_model("pheno").dataset
+    model = create_model_for_test(code, dataset='pheno')
     set_michaelis_menten_elimination(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -319,7 +315,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_set_michaelis_menten_elimination_from_k():
+def test_set_michaelis_menten_elimination_from_k(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -333,8 +329,7 @@ $OMEGA 0.0309626  ; IVCL
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = Model.create_model(StringIO(code))
-    model.dataset = load_example_model("pheno").dataset
+    model = create_model_for_test(code, dataset='pheno')
     set_michaelis_menten_elimination(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -360,7 +355,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_combined_mm_fo_elimination():
+def test_combined_mm_fo_elimination(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -378,8 +373,7 @@ $OMEGA 0.031128  ; IVV
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = Model.create_model(StringIO(code))
-    model.dataset = load_example_model("pheno").dataset
+    model = create_model_for_test(code, dataset='pheno')
     assert not has_mixed_mm_fo_elimination(model)
     set_mixed_mm_fo_elimination(model)
     assert has_mixed_mm_fo_elimination(model)
@@ -435,7 +429,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_combined_mm_fo_elimination_from_k():
+def test_combined_mm_fo_elimination_from_k(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -449,8 +443,7 @@ $OMEGA 0.0309626  ; IVCL
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = Model.create_model(StringIO(code))
-    model.dataset = load_example_model("pheno").dataset
+    model = create_model_for_test(code, dataset='pheno')
     set_mixed_mm_fo_elimination(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -477,8 +470,7 @@ $ESTIMATION METHOD=1 INTERACTION
 """
     assert model.model_code == correct
 
-    model = Model.create_model(StringIO(code))
-    model.dataset = load_example_model("pheno").dataset
+    model = create_model_for_test(code, dataset='pheno')
     set_zero_order_elimination(model)
     set_mixed_mm_fo_elimination(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
@@ -1433,7 +1425,7 @@ def test_add_covariate_effect(load_model_for_test, testdata, model_path, effects
         assert f'POP_{effect[0]}{effect[1]}' in model.model_code
 
 
-def test_add_depot():
+def test_add_depot(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
@@ -1455,8 +1447,7 @@ $SIGMA 0.013241
 
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = Model.create_model(StringIO(code))
-    model.dataset = load_example_model("pheno").dataset
+    model = create_model_for_test(code, dataset='pheno')
     set_first_order_absorption(model)
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA run1.csv IGNORE=@
@@ -1485,7 +1476,7 @@ $ESTIMATION METHOD=1 INTERACTION
     assert model.model_code == correct
 
 
-def test_absrate_from_explicit():
+def test_absrate_from_explicit(create_model_for_test):
     code = """
 $PROBLEM    PHENOBARB SIMPLE MODEL
 $DATA      pheno.dta IGNORE=@
@@ -1511,8 +1502,7 @@ $OMEGA  DIAGONAL(2)
 $SIGMA  1e-7
 $ESTIMATION METHOD=1 INTERACTION
 """
-    model = Model.create_model(StringIO(code))
-    model.dataset = load_example_model("pheno").dataset
+    model = create_model_for_test(code, dataset='pheno')
     set_first_order_absorption(model)
     correct = """
 $PROBLEM    PHENOBARB SIMPLE MODEL
@@ -1698,7 +1688,7 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
     shutil.copy(datadir / 'pheno_advan1.mod', tmp_path / 'abs')
     shutil.copy(datadir / 'pheno_advan2.mod', tmp_path / 'abs')
     shutil.copy(datadir.parent / 'pheno.dta', tmp_path)
-    model = Model.create_model(tmp_path / 'abs' / 'pheno_advan1.mod')
+    model = load_model_for_test(tmp_path / 'abs' / 'pheno_advan1.mod')
     set_zero_order_absorption(model)
     correct = '''$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno_advan1.csv IGNORE=@
@@ -1780,7 +1770,7 @@ $TABLE ID TIME DV AMT WGT APGR IPRED PRED RES TAD CWRES NPDE NOAPPEND
 '''
 
     # 1st to 0-order
-    model = Model.create_model(tmp_path / 'abs' / 'pheno_advan2.mod')
+    model = load_model_for_test(tmp_path / 'abs' / 'pheno_advan2.mod')
     set_zero_order_absorption(model)
     model.update_source(nofiles=True)
     assert model.model_code == correct
@@ -2680,7 +2670,14 @@ def test_split_joint_distribution(load_model_for_test, testdata, etas, pk_ref, o
     ],
 )
 def test_set_iiv_on_ruv(
-    load_model_for_test, pheno_path, epsilons, same_eta, eta_names, err_ref, omega_ref
+    create_model_for_test,
+    load_model_for_test,
+    pheno_path,
+    epsilons,
+    same_eta,
+    eta_names,
+    err_ref,
+    omega_ref,
 ):
     model = load_model_for_test(pheno_path)
 
@@ -2691,7 +2688,7 @@ def test_set_iiv_on_ruv(
     model_sigma = re.sub(
         r'\$SIGMA 0.013241', '$SIGMA 0.013241\n$SIGMA 0.1\n$SIGMA 0.1', model_more_eps
     )
-    model = Model.create_model(StringIO(model_sigma))
+    model = create_model_for_test(model_sigma)
 
     print("START")
     print(model.parameters)
@@ -2815,7 +2812,7 @@ def test_remove_iiv(load_model_for_test, testdata, etas, pk_ref, omega_ref):
     assert rec_omega == omega_ref
 
 
-def test_remove_iov(load_model_for_test, testdata):
+def test_remove_iov(create_model_for_test, load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem/pheno_block.mod')
 
     model_str = model.model_code
@@ -2824,7 +2821,7 @@ def test_remove_iov(load_model_for_test, testdata):
         '$OMEGA BLOCK(1)\n0.1\n$OMEGA BLOCK(1) SAME\n',
     )
 
-    model = Model.create_model(StringIO(model_with_iov))
+    model = create_model_for_test(model_with_iov)
 
     remove_iov(model)
     model.update_source()
@@ -2874,10 +2871,9 @@ def test_remove_iov_github_issues_538_and_561_2(load_model_for_test, testdata):
     }
 
 
-def test_remove_iov_diagonal():
-    model = Model.create_model(
-        StringIO(
-            '''$PROBLEM PHENOBARB SIMPLE MODEL
+def test_remove_iov_diagonal(create_model_for_test):
+    model = create_model_for_test(
+        '''$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV FA1 FA2
 $SUBROUTINE ADVAN1 TRANS1
@@ -2899,7 +2895,6 @@ $OMEGA BLOCK(1) SAME
 $SIGMA 0.013241
 $ESTIMATION METHOD=1 INTERACTION
 '''
-        )
     )
 
     remove_iov(model)
@@ -3107,19 +3102,19 @@ def test_update_inits_zero_fix(load_model_for_test, pheno_path):
     assert model.parameters['OMEGA(1,1)'].fix
 
 
-def test_update_inits_no_res(testdata, tmp_path):
+def test_update_inits_no_res(load_model_for_test, testdata, tmp_path):
     shutil.copy(testdata / 'nonmem/pheno.mod', tmp_path / 'run1.mod')
     shutil.copy(testdata / 'nonmem/pheno.dta', tmp_path / 'pheno.dta')
 
     with TemporaryDirectoryChanger(tmp_path):
-        model = Model.create_model('run1.mod')
+        model = load_model_for_test('run1.mod')
         with pytest.raises(ValueError):
             update_inits(model)
 
         shutil.copy(testdata / 'nonmem/pheno.ext', tmp_path / 'run1.ext')
         shutil.copy(testdata / 'nonmem/pheno.lst', tmp_path / 'run1.lst')
 
-        model = Model.create_model('run1.mod')
+        model = load_model_for_test('run1.mod')
 
         model.modelfit_results.parameter_estimates = pd.Series(
             np.nan, name='estimates', index=list(model.parameters.nonfixed.inits.keys())
@@ -3166,14 +3161,16 @@ def test_update_inits_no_res(testdata, tmp_path):
         ),
     ],
 )
-def test_set_power_on_ruv(testdata, epsilons, err_ref, theta_ref, tmp_path):
+def test_set_power_on_ruv(
+    load_model_for_test, create_model_for_test, testdata, epsilons, err_ref, theta_ref, tmp_path
+):
     shutil.copy(testdata / 'nonmem/pheno_real.mod', tmp_path / 'run1.mod')
     shutil.copy(testdata / 'nonmem/pheno_real.phi', tmp_path / 'run1.phi')
     shutil.copy(testdata / 'nonmem/pheno_real.ext', tmp_path / 'run1.ext')
     shutil.copy(testdata / 'nonmem/pheno.dta', tmp_path / 'pheno.dta')
 
     with TemporaryDirectoryChanger(tmp_path):
-        model_pheno = Model.create_model('run1.mod')
+        model_pheno = load_model_for_test('run1.mod')
         model_more_eps = re.sub(
             r'( 0.031128  ;        IVV\n)',
             '$SIGMA 0.1\n$SIGMA 0.1',
@@ -3184,7 +3181,7 @@ def test_set_power_on_ruv(testdata, epsilons, err_ref, theta_ref, tmp_path):
             r'IPRED=F+EPS(2)\nIRES=DV-IPRED+EPS(3)',
             model_more_eps,
         )
-        model = Model.create_model(StringIO(model_more_eps))
+        model = create_model_for_test(model_more_eps)
         model.dataset = model_pheno.dataset
 
         set_power_on_ruv(model, epsilons, zero_protection=True)

--- a/tests/modeling/test_parameter_sampling.py
+++ b/tests/modeling/test_parameter_sampling.py
@@ -2,7 +2,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pharmpy import Model
 from pharmpy.modeling import (
     create_rng,
     load_example_model,
@@ -27,8 +26,8 @@ def test_sample_parameters_uniformly():
     assert df['THETA(1)'][0] == 0.004877674495376137
 
 
-def test_sample_parameter_from_covariance_matrix(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_sample_parameter_from_covariance_matrix(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     rng = np.random.default_rng(318)
     samples = sample_parameters_from_covariance_matrix(model, n=3, rng=rng)
     correct = pd.DataFrame(
@@ -48,8 +47,8 @@ def test_sample_parameter_from_covariance_matrix(testdata):
         sample_parameters_from_covariance_matrix(model, n=1, force_posdef_covmatrix=True)
 
 
-def test_sample_individual_estimates(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_sample_individual_estimates(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     rng = np.random.default_rng(86)
     samples = sample_individual_estimates(model, rng=rng)
     assert len(samples) == 59 * 100

--- a/tests/modeling/test_parameters.py
+++ b/tests/modeling/test_parameters.py
@@ -1,6 +1,5 @@
 import sympy
 
-from pharmpy import Model
 from pharmpy.modeling import (
     add_population_parameter,
     fix_or_unfix_parameters,
@@ -35,42 +34,42 @@ def test_get_sigmas(pheno):
     assert sigmas['SIGMA(1,1)'].init == 0.013241
 
 
-def test_fix_parameters(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_fix_parameters(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     assert not model.parameters['THETA(1)'].fix
     fix_parameters(model, ['THETA(1)'])
     assert model.parameters['THETA(1)'].fix
 
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     assert not model.parameters['THETA(1)'].fix
     fix_parameters(model, 'THETA(1)')
     assert model.parameters['THETA(1)'].fix
 
 
-def test_unfix_parameters(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_unfix_parameters(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     fix_parameters(model, ['THETA(1)'])
     assert model.parameters['THETA(1)'].fix
     unfix_parameters(model, ['THETA(1)'])
     assert not model.parameters['THETA(1)'].fix
 
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     fix_parameters(model, 'THETA(1)')
     assert model.parameters['THETA(1)'].fix
     unfix_parameters(model, 'THETA(1)')
     assert not model.parameters['THETA(1)'].fix
 
 
-def test_fix_or_unfix_parameters(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_fix_or_unfix_parameters(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     fix_or_unfix_parameters(model, {'THETA(1)': True})
     assert model.parameters['THETA(1)'].fix
     fix_or_unfix_parameters(model, {'THETA(1)': False})
     assert not model.parameters['THETA(1)'].fix
 
 
-def test_unconstrain_parameters(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_unconstrain_parameters(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     fix_or_unfix_parameters(model, {'THETA(1)': True})
     unconstrain_parameters(model, ['THETA(1)'])
     assert not model.parameters['THETA(1)'].fix
@@ -79,34 +78,34 @@ def test_unconstrain_parameters(testdata):
     assert not model.parameters['THETA(1)'].fix
 
 
-def test_fix_parameters_to(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_fix_parameters_to(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     fix_parameters_to(model, {'THETA(1)': 0})
     assert model.parameters['THETA(1)'].fix
     assert model.parameters['THETA(1)'].init == 0
 
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     fix_parameters_to(model, {'THETA(1)': 0, 'OMEGA(1,1)': 0})
     assert model.parameters['THETA(1)'].fix
     assert model.parameters['THETA(1)'].init == 0
     assert model.parameters['THETA(1)'].fix
     assert model.parameters['OMEGA(1,1)'].init == 0
 
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     fix_parameters_to(model, {'THETA(1)': 0, 'OMEGA(1,1)': 1})
     assert model.parameters['THETA(1)'].init == 0
     assert model.parameters['OMEGA(1,1)'].init == 1
 
 
-def test_unfix_parameters_to(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_unfix_parameters_to(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     fix_parameters(model, ['THETA(1)'])
     assert model.parameters['THETA(1)'].fix
     unfix_parameters_to(model, {'THETA(1)': 0})
     assert not model.parameters['THETA(1)'].fix
     assert model.parameters['THETA(1)'].init == 0
 
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     fix_parameters(model, ['THETA(1)', 'OMEGA(1,1)'])
     assert model.parameters['THETA(1)'].fix
     assert model.parameters['OMEGA(1,1)'].fix
@@ -117,8 +116,8 @@ def test_unfix_parameters_to(testdata):
     assert model.parameters['OMEGA(1,1)'].init == 0
 
 
-def test_set_bounds(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_set_bounds(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     set_upper_bounds(model, {'THETA(1)': 100})
     assert model.parameters['THETA(1)'].upper == 100
     assert model.parameters['OMEGA(1,1)'].upper == sympy.oo
@@ -127,8 +126,8 @@ def test_set_bounds(testdata):
     assert model.parameters['OMEGA(1,1)'].lower == 0
 
 
-def test_add_population_parameter(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
+def test_add_population_parameter(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     add_population_parameter(model, 'NEWPARAM', 23)
     assert len(model.parameters) == 4
     assert model.parameters['NEWPARAM'].init == 23

--- a/tests/modeling/test_plots.py
+++ b/tests/modeling/test_plots.py
@@ -1,14 +1,13 @@
-from pharmpy import Model
-from pharmpy.modeling import load_example_model, plot_individual_predictions, plot_iofv_vs_iofv
+from pharmpy.modeling import plot_individual_predictions, plot_iofv_vs_iofv
 
 
-def test_plot_iofv_vs_iofv():
-    model = load_example_model('pheno')
+def test_plot_iofv_vs_iofv(load_example_model_for_test):
+    model = load_example_model_for_test('pheno')
     assert plot_iofv_vs_iofv(model, model)
 
 
-def test_plot_individual_predictions(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_plot_individual_predictions(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     plot = plot_individual_predictions(model)
     assert plot
     plot = plot_individual_predictions(model, predictions=['PRED'], individuals=[1, 2, 5])

--- a/tests/modeling/test_results.py
+++ b/tests/modeling/test_results.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pharmpy import Model
 from pharmpy.modeling import (
     calculate_aic,
     calculate_bic,
@@ -105,7 +104,9 @@ k_e,median,13.319584,2.67527,2.633615
     # pd.testing.assert_frame_equal(df, correct, atol=1e-4)
 
 
-def test_summarize_modelfit_results(load_model_for_test, testdata, pheno_path):
+def test_summarize_modelfit_results(
+    load_model_for_test, create_model_for_test, testdata, pheno_path
+):
     pheno = load_model_for_test(pheno_path)
 
     summary_single = summarize_modelfit_results(pheno)
@@ -126,7 +127,7 @@ def test_summarize_modelfit_results(load_model_for_test, testdata, pheno_path):
     assert len(summary_multiple.index) == 2
     assert list(summary_multiple.index) == ['pheno_real', 'mox1']
 
-    pheno_no_res = Model.create_model(StringIO(pheno.model_code))
+    pheno_no_res = create_model_for_test(pheno.model_code)
     pheno_no_res.name = 'pheno_no_res'
 
     summary_no_res = summarize_modelfit_results([pheno, pheno_no_res])
@@ -162,7 +163,7 @@ def test_summarize_modelfit_results(load_model_for_test, testdata, pheno_path):
 
     assert not summary_multest_full.loc['pheno_multEST', 1]['minimization_successful']
 
-    pheno_multest_no_res = Model.create_model(StringIO(pheno_multest.model_code))
+    pheno_multest_no_res = create_model_for_test(pheno_multest.model_code)
     pheno_multest_no_res.name = 'pheno_multest_no_res'
 
     summary_multest_full_no_res = summarize_modelfit_results(

--- a/tests/modeling/test_results.py
+++ b/tests/modeling/test_results.py
@@ -22,8 +22,8 @@ from pharmpy.modeling import (
 from pharmpy.utils import TemporaryDirectoryChanger
 
 
-def test_calculate_eta_shrinkage(testdata):
-    pheno = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_calculate_eta_shrinkage(load_model_for_test, testdata):
+    pheno = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     shrinkage = calculate_eta_shrinkage(pheno)
     assert len(shrinkage) == 2
     assert pytest.approx(shrinkage['ETA(1)'], 0.0001) == 7.2048e01 / 100
@@ -34,15 +34,15 @@ def test_calculate_eta_shrinkage(testdata):
     assert pytest.approx(shrinkage['ETA(2)'], 0.0001) == 1.2839e01 / 100
 
 
-def test_calculate_individual_shrinkage(testdata):
-    pheno = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_calculate_individual_shrinkage(load_model_for_test, testdata):
+    pheno = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     ishr = calculate_individual_shrinkage(pheno)
     assert len(ishr) == 59
     assert pytest.approx(ishr['ETA(1)'][1], 1e-15) == 0.84778949807160287
 
 
-def test_calculate_individual_parameter_statistics(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'secondary_parameters' / 'pheno.mod')
+def test_calculate_individual_parameter_statistics(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'secondary_parameters' / 'pheno.mod')
     rng = np.random.default_rng(103)
     stats = calculate_individual_parameter_statistics(model, 'CL/V', rng=rng)
 
@@ -50,14 +50,14 @@ def test_calculate_individual_parameter_statistics(testdata):
     assert stats['variance'][0] == pytest.approx(8.086653508585209e-06)
     assert stats['stderr'][0] == pytest.approx(0.0035089729730046304, abs=1e-6)
 
-    model = Model.create_model(testdata / 'nonmem' / 'secondary_parameters' / 'run1.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'secondary_parameters' / 'run1.mod')
     rng = np.random.default_rng(5678)
     stats = calculate_individual_parameter_statistics(model, 'CL/V', rng=rng)
     assert stats['mean'][0] == pytest.approx(0.0049100899539843)
     assert stats['variance'][0] == pytest.approx(7.391076132098555e-07)
     assert stats['stderr'][0] == pytest.approx(0.0009425952783595735, abs=1e-6)
 
-    covmodel = Model.create_model(testdata / 'nonmem' / 'secondary_parameters' / 'run2.mod')
+    covmodel = load_model_for_test(testdata / 'nonmem' / 'secondary_parameters' / 'run2.mod')
     rng = np.random.default_rng(8976)
     stats = calculate_individual_parameter_statistics(covmodel, 'K = CL/V', rng=rng)
     assert stats['mean']['K', 'median'] == pytest.approx(0.004525842355027405)
@@ -71,8 +71,8 @@ def test_calculate_individual_parameter_statistics(testdata):
     assert stats['stderr']['K', 'p95'] == pytest.approx(0.0069971678916412716, abs=1e-6)
 
 
-def test_calculate_pk_parameters_statistics(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox1.mod')
+def test_calculate_pk_parameters_statistics(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox1.mod')
     rng = np.random.default_rng(103)
     df = calculate_pk_parameters_statistics(model, rng=rng)
     assert df['mean'].loc['t_max', 'median'] == pytest.approx(1.5999856886869577)
@@ -83,10 +83,10 @@ def test_calculate_pk_parameters_statistics(testdata):
     assert df['stderr'].loc['C_max_dose', 'median'] == pytest.approx(0.11328030491204867)
 
 
-def test_calc_pk_two_comp_bolus(testdata):
+def test_calc_pk_two_comp_bolus(load_model_for_test, testdata):
     # Warning: These results are based on a manually modified cov-matrix
     # Results are not verified
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox_2comp.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox_2comp.mod')
     rng = np.random.default_rng(103)
     df = calculate_pk_parameters_statistics(model, rng=rng)
     # FIXME: Why doesn't random state handle this difference in stderr?
@@ -105,8 +105,8 @@ k_e,median,13.319584,2.67527,2.633615
     # pd.testing.assert_frame_equal(df, correct, atol=1e-4)
 
 
-def test_summarize_modelfit_results(testdata, pheno_path):
-    pheno = Model.create_model(pheno_path)
+def test_summarize_modelfit_results(load_model_for_test, testdata, pheno_path):
+    pheno = load_model_for_test(pheno_path)
 
     summary_single = summarize_modelfit_results(pheno)
 
@@ -115,7 +115,7 @@ def test_summarize_modelfit_results(testdata, pheno_path):
 
     assert len(summary_single.index) == 1
 
-    mox = Model.create_model(testdata / 'nonmem' / 'models' / 'mox1.mod')
+    mox = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox1.mod')
 
     summary_multiple = summarize_modelfit_results([pheno, mox])
 
@@ -135,7 +135,7 @@ def test_summarize_modelfit_results(testdata, pheno_path):
     assert np.isnan(summary_no_res.loc['pheno_no_res']['ofv'])
     assert np.all(np.isnan(summary_no_res.filter(regex='estimate$').loc['pheno_no_res']))
 
-    pheno_multest = Model.create_model(
+    pheno_multest = load_model_for_test(
         testdata
         / 'nonmem'
         / 'modelfit_results'
@@ -175,9 +175,9 @@ def test_summarize_modelfit_results(testdata, pheno_path):
     assert estimates.isnull().all()
 
 
-def test_summarize_modelfit_results_errors(testdata, tmp_path, pheno_path):
+def test_summarize_modelfit_results_errors(load_model_for_test, testdata, tmp_path, pheno_path):
     with TemporaryDirectoryChanger(tmp_path):
-        model = Model.create_model(pheno_path)
+        model = load_model_for_test(pheno_path)
         shutil.copy2(testdata / 'pheno_data.csv', tmp_path)
 
         error_path = testdata / 'nonmem' / 'errors'
@@ -185,13 +185,13 @@ def test_summarize_modelfit_results_errors(testdata, tmp_path, pheno_path):
         shutil.copy2(testdata / 'nonmem' / 'pheno_real.mod', tmp_path / 'pheno_no_header.mod')
         shutil.copy2(error_path / 'no_header_error.lst', tmp_path / 'pheno_no_header.lst')
         shutil.copy2(testdata / 'nonmem' / 'pheno_real.ext', tmp_path / 'pheno_no_header.ext')
-        model_no_header = Model.create_model('pheno_no_header.mod')
+        model_no_header = load_model_for_test('pheno_no_header.mod')
         model_no_header.datainfo = model_no_header.datainfo.derive(path=tmp_path / 'pheno_data.csv')
 
         shutil.copy2(testdata / 'nonmem' / 'pheno_real.mod', tmp_path / 'pheno_rounding_error.mod')
         shutil.copy2(error_path / 'rounding_error.lst', tmp_path / 'pheno_rounding_error.lst')
         shutil.copy2(testdata / 'nonmem' / 'pheno_real.ext', tmp_path / 'pheno_rounding_error.ext')
-        model_rounding_error = Model.create_model('pheno_rounding_error.mod')
+        model_rounding_error = load_model_for_test('pheno_rounding_error.mod')
         model_rounding_error.datainfo = model_rounding_error.datainfo.derive(
             path=tmp_path / 'pheno_data.csv'
         )
@@ -207,9 +207,9 @@ def test_summarize_modelfit_results_errors(testdata, tmp_path, pheno_path):
         assert summary.loc['pheno_rounding_error']['warnings_found'] == 0
 
 
-def test_summarize_errors(testdata, tmp_path, pheno_path):
+def test_summarize_errors(load_model_for_test, testdata, tmp_path, pheno_path):
     with TemporaryDirectoryChanger(tmp_path):
-        model = Model.create_model(pheno_path)
+        model = load_model_for_test(pheno_path)
         shutil.copy2(testdata / 'pheno_data.csv', tmp_path)
 
         error_path = testdata / 'nonmem' / 'errors'
@@ -217,13 +217,13 @@ def test_summarize_errors(testdata, tmp_path, pheno_path):
         shutil.copy2(testdata / 'nonmem' / 'pheno_real.mod', tmp_path / 'pheno_no_header.mod')
         shutil.copy2(error_path / 'no_header_error.lst', tmp_path / 'pheno_no_header.lst')
         shutil.copy2(testdata / 'nonmem' / 'pheno_real.ext', tmp_path / 'pheno_no_header.ext')
-        model_no_header = Model.create_model('pheno_no_header.mod')
+        model_no_header = load_model_for_test('pheno_no_header.mod')
         model_no_header.datainfo = model_no_header.datainfo.derive(path=tmp_path / 'pheno_data.csv')
 
         shutil.copy2(testdata / 'nonmem' / 'pheno_real.mod', tmp_path / 'pheno_rounding_error.mod')
         shutil.copy2(error_path / 'rounding_error.lst', tmp_path / 'pheno_rounding_error.lst')
         shutil.copy2(testdata / 'nonmem' / 'pheno_real.ext', tmp_path / 'pheno_rounding_error.ext')
-        model_rounding_error = Model.create_model('pheno_rounding_error.mod')
+        model_rounding_error = load_model_for_test('pheno_rounding_error.mod')
         model_rounding_error.datainfo = model_rounding_error.datainfo.derive(
             path=tmp_path / 'pheno_data.csv'
         )
@@ -300,13 +300,13 @@ def test_rank_models():
     assert np.isnan(df.loc['m5']['rank'])
 
 
-def test_aic(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+def test_aic(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     assert calculate_aic(model) == 740.8947268137307
 
 
-def test_bic(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+def test_bic(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     assert calculate_bic(model, type='iiv') == 739.0498017015422
     assert calculate_bic(model, type='fixed') == 756.111852398327
     assert calculate_bic(model, type='random') == 751.2824140332593
@@ -315,9 +315,9 @@ def test_bic(testdata):
     assert calculate_bic(model) == 755.359951477165
 
 
-def test_check_parameters_near_bounds(testdata):
+def test_check_parameters_near_bounds(load_model_for_test, testdata):
     onePROB = testdata / 'nonmem' / 'modelfit_results' / 'onePROB'
-    nearbound = Model.create_model(onePROB / 'oneEST' / 'noSIM' / 'near_bounds.mod')
+    nearbound = load_model_for_test(onePROB / 'oneEST' / 'noSIM' / 'near_bounds.mod')
     correct = pd.Series(
         [False, True, False, False, False, False, False, False, True, True, False],
         index=[

--- a/tests/modeling/test_units.py
+++ b/tests/modeling/test_units.py
@@ -1,10 +1,10 @@
 from sympy.physics import units
 
-from pharmpy.modeling import get_unit_of, read_model
+from pharmpy.modeling import get_unit_of
 
 
-def test_get_unit_of(testdata):
-    model = read_model(testdata / "nonmem" / "pheno_real.mod")
+def test_get_unit_of(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / "nonmem" / "pheno_real.mod")
     assert get_unit_of(model, "Y") == units.milligram / units.l
     assert get_unit_of(model, "V") == units.l
     assert get_unit_of(model, "WGT") == units.kilogram

--- a/tests/nonmem/conftest.py
+++ b/tests/nonmem/conftest.py
@@ -1,17 +1,5 @@
 import pytest
 
-import pharmpy
-
-
-@pytest.fixture(scope='session')
-def datadir(testdata):
-    return testdata / 'nonmem'
-
-
-@pytest.fixture(scope='session')
-def pheno_path(datadir):
-    return datadir / 'pheno_real.mod'
-
 
 @pytest.fixture(scope='session')
 def pheno_ext(datadir):
@@ -36,8 +24,3 @@ def pheno_lst(datadir):
 @pytest.fixture(scope='session')
 def pheno_data(datadir):
     return datadir / 'pheno.dta'
-
-
-@pytest.fixture(scope='session')
-def pheno(pheno_path):
-    return pharmpy.Model.create_model(pheno_path)

--- a/tests/nonmem/records/test_abbreviated.py
+++ b/tests/nonmem/records/test_abbreviated.py
@@ -1,8 +1,5 @@
-from pharmpy import Model
-
-
-def test_data_filename_set(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_abbr.mod')
+def test_data_filename_set(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_abbr.mod')
     assert model.control_stream.abbreviated.replace == {
         'THETA(CL)': 'THETA(1)',
         'THETA(V)': 'THETA(2)',
@@ -16,8 +13,8 @@ def test_replace(parser):
     assert rec.replace == {'K34': '3,4'}
 
 
-def test_translate_to_pharmpy_names(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_abbr.mod')
+def test_translate_to_pharmpy_names(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_abbr.mod')
     new_dict = model.control_stream.abbreviated.translate_to_pharmpy_names()
     assert new_dict == {
         'THETA(1)': 'THETA_CL',

--- a/tests/nonmem/test_advan.py
+++ b/tests/nonmem/test_advan.py
@@ -189,8 +189,8 @@ def test_pheno(pheno, advan, trans, compmat, amounts, strodes, corrics):
     assert ics == corrics
 
 
-def test_advan5(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'DDMODEL00000130')
+def test_advan5(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'DDMODEL00000130')
     cm, ass = compartmental_model(model, 'ADVAN5', 'TRANS1')
     assert ass.symbol == S('F')
     assert ass.expression == S('A_CMS1')

--- a/tests/nonmem/test_advan.py
+++ b/tests/nonmem/test_advan.py
@@ -1,9 +1,6 @@
-from io import StringIO
-
 import pytest
 import sympy
 
-from pharmpy import Model
 from pharmpy.plugins.nonmem.advan import compartmental_model
 
 
@@ -212,7 +209,7 @@ def test_advan5(testdata, load_model_for_test):
     # assert cm.compartmental_matrix == compmat
 
 
-def test_rate_constants():
+def test_rate_constants(create_model_for_test):
     code = """$PROBLEM
 $INPUT ID VISI DAT1 DGRP DOSE FLAG ONO XIME DVO NEUY SCR AGE SEX
        NYHA WT COMP IACE DIG DIU NUMB TAD TIME VID CRCL AMT SS II
@@ -254,6 +251,6 @@ $OMEGA  0.001  ;    IIV_MAT
 $OMEGA  0.001 ; IIV_MDT
 $SIGMA  0.273617  ;   RUV_PROP
 """
-    model = Model.create_model(StringIO(code))
+    model = create_model_for_test(code)
     odes = model.statements.ode_system
     assert odes.get_flow(odes.central_compartment, odes.output_compartment) == sympy.Symbol('K100')

--- a/tests/nonmem/test_des.py
+++ b/tests/nonmem/test_des.py
@@ -3,7 +3,7 @@ from io import StringIO
 from pharmpy import Model
 
 
-def test_des(testdata):
+def test_des(load_model_for_test, testdata):
     code = """$PROBLEM
 $INPUT ID TIME DV AMT
 $DATA data.csv IGNORE=@
@@ -50,7 +50,7 @@ $OMEGA 0.1; IIV_KLO
 $OMEGA 0.1; IIV_VL
 $SIGMA 0.1; RUV_ADD
 """
-    pheno = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+    pheno = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     model = Model.create_model(StringIO(code))
     model.dataset = pheno.dataset
     cs = model.statements.ode_system.to_compartmental_system()

--- a/tests/nonmem/test_des.py
+++ b/tests/nonmem/test_des.py
@@ -1,9 +1,4 @@
-from io import StringIO
-
-from pharmpy import Model
-
-
-def test_des(load_model_for_test, testdata):
+def test_des(load_model_for_test, create_model_for_test, testdata):
     code = """$PROBLEM
 $INPUT ID TIME DV AMT
 $DATA data.csv IGNORE=@
@@ -51,7 +46,7 @@ $OMEGA 0.1; IIV_VL
 $SIGMA 0.1; RUV_ADD
 """
     pheno = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    model = Model.create_model(StringIO(code))
+    model = create_model_for_test(code)
     model.dataset = pheno.dataset
     cs = model.statements.ode_system.to_compartmental_system()
     assert len(cs) == 5

--- a/tests/nonmem/test_fcon.py
+++ b/tests/nonmem/test_fcon.py
@@ -1,12 +1,9 @@
-from pharmpy import Model
-
-
-def test_dataset(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'fcon' / 'FCON')
+def test_dataset(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'fcon' / 'FCON')
     assert model.code.startswith('FILE')
 
     df = model.dataset
 
-    nmtran = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+    nmtran = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
 
     assert list(df['WGT']) == list(nmtran.dataset['WGT'])

--- a/tests/nonmem/test_input.py
+++ b/tests/nonmem/test_input.py
@@ -1,8 +1,3 @@
-from io import StringIO
-
-import pharmpy
-
-
 def test_data_read(pheno):
     df = pheno.dataset
     # FIXME: should have numeric TIME
@@ -16,23 +11,19 @@ def test_read_raw_dataset(pheno):
     assert list(df.columns) == ['ID', 'TIME', 'AMT', 'WGT', 'APGR', 'DV', 'FA1', 'FA2']
 
 
-def test_ignore_with_synonym(pheno_data):
-    model = pharmpy.Model.create_model(
-        StringIO(
-            f"$PROBLEM dfs\n$INPUT ID TIME AMT WT APGR DV=CONC FA1 FA2\n"
-            f"$DATA {pheno_data} IGNORE=@ IGNORE=(CONC.EQN.0)"
-        )
+def test_ignore_with_synonym(create_model_for_test, pheno_data):
+    model = create_model_for_test(
+        f"$PROBLEM dfs\n$INPUT ID TIME AMT WT APGR DV=CONC FA1 FA2\n"
+        f"$DATA {pheno_data} IGNORE=@ IGNORE=(CONC.EQN.0)"
     )
     di = model.datainfo
     col = di['DV'].derive(name='CONC')
     model.datainfo = di[0:5] + col + di[6:]
     df = model.dataset
     assert len(df) == 155
-    model = pharmpy.Model.create_model(
-        StringIO(
-            f"$PROBLEM dfs\n$INPUT ID TIME AMT WT APGR DV=CONC FA1 FA2\n"
-            f"$DATA {pheno_data} IGNORE=@ IGNORE=(DV.EQN.0)"
-        )
+    model = create_model_for_test(
+        f"$PROBLEM dfs\n$INPUT ID TIME AMT WT APGR DV=CONC FA1 FA2\n"
+        f"$DATA {pheno_data} IGNORE=@ IGNORE=(DV.EQN.0)"
     )
     di = model.datainfo
     col = di['DV'].derive(name='CONC')
@@ -41,12 +32,9 @@ def test_ignore_with_synonym(pheno_data):
     assert len(df) == 155
 
 
-def test_idv_with_synonym(pheno_data):
-    model = pharmpy.Model.create_model(
-        StringIO(
-            f"$PROBLEM dfs\n$INPUT ID TIME=TAD AMT WT APGR DV FA1 FA2\n"
-            f"$DATA {pheno_data} IGNORE=@"
-        )
+def test_idv_with_synonym(create_model_for_test, pheno_data):
+    model = create_model_for_test(
+        f"$PROBLEM dfs\n$INPUT ID TIME=TAD AMT WT APGR DV FA1 FA2\n" f"$DATA {pheno_data} IGNORE=@"
     )
     di = model.datainfo
     col = di['TIME'].derive(name='TAD')

--- a/tests/nonmem/test_modelfit_results.py
+++ b/tests/nonmem/test_modelfit_results.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 
 import pharmpy.plugins.nonmem as nonmem
-from pharmpy import Model
 from pharmpy.config import ConfigurationContext
 from pharmpy.plugins.nonmem.results import NONMEMChainedModelfitResults, simfit_results
 from pharmpy.results import read_results
@@ -258,7 +257,9 @@ def test_runtime_total(testdata, load_model_for_test):
         ),
     ],
 )
-def test_runtime_different_formats(testdata, starttime, endtime, runtime_ref, tmp_path):
+def test_runtime_different_formats(
+    load_model_for_test, testdata, starttime, endtime, runtime_ref, tmp_path
+):
     with open(testdata / 'nonmem' / 'pheno_real.lst', encoding='utf-8') as lst_file:
         lst_file_str = lst_file.read()
 
@@ -288,7 +289,7 @@ def test_runtime_different_formats(testdata, starttime, endtime, runtime_ref, tm
         with open('pheno_real.lst', 'a') as f:
             f.write(lst_file_repl)
 
-        model = Model.create_model('pheno_real.mod')
+        model = load_model_for_test('pheno_real.mod')
         runtime = model.modelfit_results.runtime_total
         assert runtime == runtime_ref
 

--- a/tests/nonmem/test_modelfit_results.py
+++ b/tests/nonmem/test_modelfit_results.py
@@ -30,9 +30,9 @@ def test_tool_files(pheno):
     ]
 
 
-def test_special_models(testdata):
+def test_special_models(testdata, load_model_for_test):
     onePROB = testdata / 'nonmem' / 'modelfit_results' / 'onePROB'
-    withBayes = Model.create_model(onePROB / 'multEST' / 'noSIM' / 'withBayes.mod')
+    withBayes = load_model_for_test(onePROB / 'multEST' / 'noSIM' / 'withBayes.mod')
     assert (
         pytest.approx(withBayes.modelfit_results.standard_errors['THETA(1)'], 1e-13) == 2.51942e00
     )
@@ -43,61 +43,61 @@ def test_special_models(testdata):
     assert withBayes.modelfit_results[0].minimization_successful is False
     assert withBayes.modelfit_results[1].minimization_successful is False
 
-    maxeval0 = Model.create_model(onePROB / 'oneEST' / 'noSIM' / 'maxeval0.mod')
+    maxeval0 = load_model_for_test(onePROB / 'oneEST' / 'noSIM' / 'maxeval0.mod')
     assert maxeval0.modelfit_results.minimization_successful is None
 
-    maxeval3 = Model.create_model(onePROB / 'oneEST' / 'noSIM' / 'maxeval3.mod')
+    maxeval3 = load_model_for_test(onePROB / 'oneEST' / 'noSIM' / 'maxeval3.mod')
     assert maxeval3.modelfit_results.minimization_successful is False
 
 
-def test_covariance(pheno_path):
+def test_covariance(load_model_for_test, pheno_path):
     with ConfigurationContext(nonmem.conf, parameter_names=['basic']):
-        res = Model.create_model(pheno_path).modelfit_results
+        res = load_model_for_test(pheno_path).modelfit_results
         cov = res.covariance_matrix
         assert len(cov) == 6
         assert pytest.approx(cov.loc['THETA(1)', 'THETA(1)'], 1e-13) == 4.41151e-08
         assert pytest.approx(cov.loc['OMEGA(2,2)', 'THETA(2)'], 1e-13) == 7.17184e-05
     with ConfigurationContext(nonmem.conf, parameter_names=['comment', 'basic']):
-        res = Model.create_model(pheno_path).modelfit_results
+        res = load_model_for_test(pheno_path).modelfit_results
         cov = res.covariance_matrix
         assert len(cov) == 6
         assert pytest.approx(cov.loc['PTVCL', 'PTVCL'], 1e-13) == 4.41151e-08
         assert pytest.approx(cov.loc['IVV', 'PTVV'], 1e-13) == 7.17184e-05
 
 
-def test_information(pheno_path):
+def test_information(load_model_for_test, pheno_path):
     with ConfigurationContext(nonmem.conf, parameter_names=['basic']):
-        res = Model.create_model(pheno_path).modelfit_results
+        res = load_model_for_test(pheno_path).modelfit_results
         m = res.information_matrix
         assert len(m) == 6
         assert pytest.approx(m.loc['THETA(1)', 'THETA(1)'], 1e-13) == 2.99556e07
         assert pytest.approx(m.loc['OMEGA(2,2)', 'THETA(2)'], 1e-13) == -2.80082e03
     with ConfigurationContext(nonmem.conf, parameter_names=['comment', 'basic']):
-        res = Model.create_model(pheno_path).modelfit_results
+        res = load_model_for_test(pheno_path).modelfit_results
         m = res.information_matrix
         assert len(m) == 6
         assert pytest.approx(m.loc['PTVCL', 'PTVCL'], 1e-13) == 2.99556e07
         assert pytest.approx(m.loc['IVV', 'PTVV'], 1e-13) == -2.80082e03
 
 
-def test_correlation(pheno_path):
+def test_correlation(load_model_for_test, pheno_path):
     with ConfigurationContext(nonmem.conf, parameter_names=['basic']):
-        res = Model.create_model(pheno_path).modelfit_results
+        res = load_model_for_test(pheno_path).modelfit_results
         corr = res.correlation_matrix
         assert len(corr) == 6
         assert corr.loc['THETA(1)', 'THETA(1)'] == 1.0
         assert pytest.approx(corr.loc['OMEGA(2,2)', 'THETA(2)'], 1e-13) == 3.56662e-01
     with ConfigurationContext(nonmem.conf, parameter_names=['comment', 'basic']):
-        res = Model.create_model(pheno_path).modelfit_results
+        res = load_model_for_test(pheno_path).modelfit_results
         corr = res.correlation_matrix
         assert len(corr) == 6
         assert corr.loc['PTVCL', 'PTVV'] == 0.00709865
         assert pytest.approx(corr.loc['IVV', 'PTVV'], 1e-13) == 3.56662e-01
 
 
-def test_standard_errors(testdata, pheno_path):
+def test_standard_errors(load_model_for_test, pheno_path):
     with ConfigurationContext(nonmem.conf, parameter_names=['basic']):
-        res = Model.create_model(pheno_path).modelfit_results
+        res = load_model_for_test(pheno_path).modelfit_results
         ses = res.standard_errors
         assert len(ses) == 6
         assert pytest.approx(ses['THETA(1)'], 1e-13) == 2.10036e-04
@@ -116,7 +116,7 @@ def test_standard_errors(testdata, pheno_path):
         pd.testing.assert_series_equal(ses_sd, correct)
 
     with ConfigurationContext(nonmem.conf, parameter_names=['comment', 'basic']):
-        res = Model.create_model(pheno_path).modelfit_results
+        res = load_model_for_test(pheno_path).modelfit_results
         ses = res.standard_errors
         assert len(ses) == 6
         assert pytest.approx(ses['PTVCL'], 1e-13) == 2.10036e-04
@@ -168,9 +168,9 @@ def test_individual_estimates_covariance(pheno, pheno_lst):
     pd.testing.assert_frame_equal(cov[43], correct2)
 
 
-def test_parameter_estimates(pheno_path):
+def test_parameter_estimates(load_model_for_test, pheno_path):
     with ConfigurationContext(nonmem.conf, parameter_names=['basic']):
-        res = Model.create_model(pheno_path).modelfit_results
+        res = load_model_for_test(pheno_path).modelfit_results
         pe = res.parameter_estimates
         assert len(pe) == 6
         assert pe['THETA(1)'] == 4.69555e-3
@@ -190,23 +190,23 @@ def test_parameter_estimates(pheno_path):
         pd.testing.assert_series_equal(pe_sd, correct)
 
     with ConfigurationContext(nonmem.conf, parameter_names=['comment', 'basic']):
-        res = Model.create_model(pheno_path).modelfit_results
+        res = load_model_for_test(pheno_path).modelfit_results
         pe = res.parameter_estimates
         assert len(pe) == 6
         assert pe['PTVCL'] == 4.69555e-3
         assert pe['IVV'] == 2.7906e-2
 
 
-def test_simfit(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modelfit_results' / 'simfit' / 'sim-1.mod')
+def test_simfit(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'modelfit_results' / 'simfit' / 'sim-1.mod')
     results = simfit_results(model)
     assert len(results) == 3
     assert results[1].ofv == 565.84904364342981
     assert results[2].ofv == 570.73440114145342
 
 
-def test_residuals(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_residuals(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     df = model.modelfit_results.residuals
     assert len(df) == 155
     assert list(df.columns) == ['RES', 'CWRES']
@@ -214,16 +214,16 @@ def test_residuals(testdata):
     assert df['CWRES'][1.0, 2.0] == -0.401100
 
 
-def test_predictions(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_predictions(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     df = model.modelfit_results.predictions
     assert len(df) == 744
     assert list(df.columns) == ['IPRED', 'PRED']
     assert df['PRED'][1.0, 0.0] == 18.143
 
 
-def test_runtime_total(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_runtime_total(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     runtime = model.modelfit_results.runtime_total
     assert runtime == 4
 
@@ -293,14 +293,14 @@ def test_runtime_different_formats(testdata, starttime, endtime, runtime_ref, tm
         assert runtime == runtime_ref
 
 
-def test_estimation_runtime_steps(pheno_path, testdata):
-    model = Model.create_model(pheno_path)
+def test_estimation_runtime_steps(pheno_path, testdata, load_model_for_test):
+    model = load_model_for_test(pheno_path)
 
     res = model.modelfit_results
     assert res[0].estimation_runtime == 0.32
     assert res.runtime_total == 4
 
-    model = Model.create_model(
+    model = load_model_for_test(
         testdata
         / 'nonmem'
         / 'modelfit_results'
@@ -316,8 +316,8 @@ def test_estimation_runtime_steps(pheno_path, testdata):
     assert res.estimation_runtime == 0.33
 
 
-def test_evaluation(testdata):
-    model = Model.create_model(
+def test_evaluation(testdata, load_model_for_test):
+    model = load_model_for_test(
         testdata
         / 'nonmem'
         / 'modelfit_results'
@@ -333,8 +333,8 @@ def test_evaluation(testdata):
     assert not res.minimization_successful
 
 
-def test_serialization(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox_2comp.mod')
+def test_serialization(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox_2comp.mod')
     res = model.modelfit_results
     res_json = res.to_json()
     res_decode = read_results(res_json)

--- a/tests/nonmem/test_nonmem_model.py
+++ b/tests/nonmem/test_nonmem_model.py
@@ -32,21 +32,21 @@ def test_source(pheno):
     assert pheno.model_code.startswith('$PROBLEM PHENOBARB')
 
 
-def test_update_inits(pheno, pheno_path):
+def test_update_inits(load_model_for_test, pheno, pheno_path):
     from pharmpy.modeling import update_inits
 
     model = pheno.copy()
     update_inits(model)
 
     with ConfigurationContext(conf, parameter_names=['comment', 'basic']):
-        model = Model.create_model(pheno_path)
+        model = load_model_for_test(pheno_path)
         update_inits(model)
         model.update_source()
 
 
-def test_empty_ext_file(testdata):
+def test_empty_ext_file(load_model_for_test, testdata):
     # assert existing but empty ext-file does not give modelfit_results
-    model = Model.create_model(
+    model = load_model_for_test(
         testdata / 'nonmem' / 'modelfit_results' / 'onePROB' / 'noESTwithSIM' / 'onlysim.mod'
     )
     with pytest.raises(FileNotFoundError):
@@ -123,8 +123,8 @@ def test_set_parameters(pheno):
         set_initial_estimates(model, {'OMEGA(2,2)': 0.000001})
 
 
-def test_adjust_iovs(testdata):
-    model = Model.create_model(
+def test_adjust_iovs(load_model_for_test, testdata):
+    model = load_model_for_test(
         testdata / 'nonmem' / 'modelfit_results' / 'onePROB' / 'multEST' / 'noSIM' / 'withBayes.mod'
     )
     model.parameters
@@ -135,7 +135,7 @@ def test_adjust_iovs(testdata):
     assert rvs[4].level == 'IOV'
     assert rvs[6].level == 'IOV'
 
-    model = Model.create_model(testdata / 'nonmem' / 'qa' / 'iov.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'qa' / 'iov.mod')
     rvs = model.random_variables
     assert rvs[0].level == 'IIV'
     assert rvs[1].level == 'IIV'
@@ -341,18 +341,18 @@ def test_results(pheno):
     assert len(pheno.modelfit_results) == 1  # A chain of one estimation
 
 
-def test_minimal(datadir):
+def test_minimal(load_model_for_test, datadir):
     path = datadir / 'minimal.mod'
-    model = Model.create_model(path)
+    model = load_model_for_test(path)
     assert len(model.statements) == 1
     assert model.statements[0].expression == symbol('THETA(1)') + symbol('ETA(1)') + symbol(
         'EPS(1)'
     )
 
 
-def test_copy(datadir):
+def test_copy(load_model_for_test, datadir):
     path = datadir / 'minimal.mod'
-    model = Model.create_model(path)
+    model = load_model_for_test(path)
     copy = model.copy()
     assert id(model) != id(copy)
     assert model.statements[0].expression == symbol('THETA(1)') + symbol('ETA(1)') + symbol(
@@ -360,13 +360,13 @@ def test_copy(datadir):
     )
 
 
-def test_initial_individual_estimates(datadir):
+def test_initial_individual_estimates(load_model_for_test, datadir):
     path = datadir / 'minimal.mod'
-    model = Model.create_model(path)
+    model = load_model_for_test(path)
     assert model.initial_individual_estimates is None
 
     path = datadir / 'pheno_etas.mod'
-    model = Model.create_model(path)
+    model = load_model_for_test(path)
     inits = model.initial_individual_estimates
     assert len(inits) == 59
     assert len(inits.columns) == 2
@@ -424,9 +424,9 @@ def test_remove_eta(pheno):
     assert model.model_code.split('\n')[12] == 'V = TVV*EXP(ETA(1))'
 
 
-def test_symbol_names_in_comment(pheno_path):
+def test_symbol_names_in_comment(load_model_for_test, pheno_path):
     with ConfigurationContext(conf, parameter_names=['comment', 'basic']):
-        model = Model.create_model(pheno_path)
+        model = load_model_for_test(pheno_path)
         assert model.statements[2].expression == S('PTVCL') * S('WGT')
 
         code = """$PROBLEM base model
@@ -447,9 +447,9 @@ $ESTIMATION METHOD=1 INTER MAXEVALS=9990 PRINT=2 POSTHOC
             assert model.parameters.names == ['THETA(1)', 'OMEGA(1,1)', 'SIGMA(1,1)']
 
 
-def test_symbol_names_in_abbr(testdata):
+def test_symbol_names_in_abbr(load_model_for_test, testdata):
     with ConfigurationContext(conf, parameter_names=['abbr', 'basic']):
-        model = Model.create_model(testdata / 'nonmem' / 'pheno_abbr.mod')
+        model = load_model_for_test(testdata / 'nonmem' / 'pheno_abbr.mod')
         pset, rvs = model.parameters, model.random_variables
 
         assert 'THETA_CL' in pset.names
@@ -515,9 +515,11 @@ def test_symbol_names_in_abbr(testdata):
         ),
     ],
 )
-def test_symbol_names_priority(testdata, parameter_names, assignments, params, etas):
+def test_symbol_names_priority(
+    load_model_for_test, testdata, parameter_names, assignments, params, etas
+):
     with ConfigurationContext(conf, parameter_names=parameter_names):
-        model = Model.create_model(testdata / 'nonmem' / 'pheno_abbr_comments.mod')
+        model = load_model_for_test(testdata / 'nonmem' / 'pheno_abbr_comments.mod')
         sset, pset, rvs = model.statements, model.parameters, model.random_variables
 
         assert all(str(a) in [str(s) for s in sset] for a in assignments)
@@ -525,9 +527,9 @@ def test_symbol_names_priority(testdata, parameter_names, assignments, params, e
         assert all(eta in [rv.name for rv in rvs] for eta in etas)
 
 
-def test_clashing_parameter_names(datadir):
+def test_clashing_parameter_names(load_model_for_test, datadir):
     with ConfigurationContext(conf, parameter_names=['comment', 'basic']):
-        model = Model.create_model(datadir / 'pheno_clashing_symbols.mod')
+        model = load_model_for_test(datadir / 'pheno_clashing_symbols.mod')
         with pytest.warns(UserWarning):
             model.statements
         assert model.parameters.names == ['THETA(1)', 'TVV', 'IVCL', 'OMEGA(2,2)', 'SIGMA(1,1)']
@@ -564,15 +566,15 @@ $ESTIMATION METHOD=1 INTER MAXEVALS=9990 PRINT=2 POSTHOC
             assert model.parameters.names == ['TV', 'THETA(2)']
 
 
-def test_missing_parameter_names_settings(pheno_path):
+def test_missing_parameter_names_settings(load_model_for_test, pheno_path):
     with ConfigurationContext(conf, parameter_names=['comment']):
         with pytest.raises(ValueError):
-            Model.create_model(pheno_path)
+            load_model_for_test(pheno_path)
 
 
-def test_abbr_write(pheno_path):
+def test_abbr_write(load_model_for_test, pheno_path):
     with ConfigurationContext(conf, write_etas_in_abbr=True):
-        model = Model.create_model(pheno_path)
+        model = load_model_for_test(pheno_path)
         add_iiv(model, 'S1', 'add')
         model.update_source()
 
@@ -586,7 +588,7 @@ def test_abbr_write(pheno_path):
         assert 'ETA_S1' in [rv.name for rv in model.random_variables]
         assert S('ETA_S1') in model.statements.free_symbols
 
-        model = Model.create_model(pheno_path)
+        model = load_model_for_test(pheno_path)
         add_iiv(model, 'S1', 'add', eta_names='new_name')
 
         with pytest.warns(UserWarning, match='Not valid format of name new_name'):
@@ -594,11 +596,11 @@ def test_abbr_write(pheno_path):
             assert 'ETA(3)' in model.model_code
 
 
-def test_abbr_read_write(pheno_path):
+def test_abbr_read_write(load_model_for_test, pheno_path):
     with ConfigurationContext(
         conf, parameter_names=['abbr', 'comment', 'basic'], write_etas_in_abbr=True
     ):
-        model_write = Model.create_model(pheno_path)
+        model_write = load_model_for_test(pheno_path)
         add_iiv(model_write, 'S1', 'add')
         model_read = Model.create_model(StringIO(model_write.model_code))
         assert model_read.model_code == model_write.model_code
@@ -707,8 +709,8 @@ $ESTIMATION METHOD=1 MAXEVAL=9999 NONINFETA=1 MCETA=1
         ('nonmem/pheno.mod', set_zero_order_elimination),
     ],
 )
-def test_des(testdata, model_path, transformation):
-    model_ref = Model.create_model(testdata / model_path)
+def test_des(load_model_for_test, testdata, model_path, transformation):
+    model_ref = load_model_for_test(testdata / model_path)
     transformation(model_ref)
 
     model_des = Model.create_model(StringIO(model_ref.model_code))
@@ -716,8 +718,8 @@ def test_des(testdata, model_path, transformation):
     assert model_ref.statements.ode_system == model_des.statements.ode_system
 
 
-def test_cmt_warning(testdata):
-    model_original = Model.create_model(testdata / 'nonmem' / 'models' / 'mox1.mod')
+def test_cmt_warning(load_model_for_test, testdata):
+    model_original = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox1.mod')
 
     model_str = model_original.model_code.replace('CMT=DROP', 'CMT')
     model = Model.create_model(StringIO(model_str))
@@ -1004,8 +1006,8 @@ $ESTIMATION METHOD=1 INTER
     assert model.model_code == correct
 
 
-def test_parse_derivatives(testdata):
-    model = Model.create_model(
+def test_parse_derivatives(load_model_for_test, testdata):
+    model = load_model_for_test(
         testdata / "nonmem" / "linearize" / "linearize_dir1" / "scm_dir1" / "derivatives.mod"
     )
     assert model.estimation_steps[0].eta_derivatives == ['ETA(1)', 'ETA(2)']

--- a/tests/plugins/test_nlmixr.py
+++ b/tests/plugins/test_nlmixr.py
@@ -1,14 +1,13 @@
-from pharmpy import Model
 from pharmpy.plugins.nlmixr import convert_model
 
 
-def test_model(testdata):
-    nmmodel = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+def test_model(testdata, load_model_for_test):
+    nmmodel = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     model = convert_model(nmmodel)
     assert 'ini' in model.model_code
 
 
-def test_pheno_real(testdata):
-    nmmodel = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_pheno_real(testdata, load_model_for_test):
+    nmmodel = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     model = convert_model(nmmodel)
     assert '} else {' in model.model_code

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,10 @@ def test_read_config():
     assert len(conf.parameter_names) <= 3
 
 
-def test_str(pheno_path, datadir):
+def test_str():
+    assert str(conf) == ""
+
     with ConfigurationContext(conf, parameter_names=['abbr', 'basic']):
         assert str(conf) == "parameter_names:\t['abbr', 'basic']\n"
+
+    assert str(conf) == "parameter_names:\t['basic']\n"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,7 +4,6 @@ import pytest
 
 import pharmpy.data
 import pharmpy.model
-from pharmpy import Model
 from pharmpy.modeling import convert_model, create_symbol, load_example_model
 from pharmpy.plugins.nonmem.dataset import read_nonmem_dataset
 
@@ -19,16 +18,16 @@ lincorrect = read_nonmem_dataset(
 @pytest.mark.parametrize(
     'stem,force_numbering,symbol_name', [('DV', False, 'DV1'), ('X', False, 'X'), ('X', True, 'X1')]
 )
-def test_create_symbol(testdata, stem, force_numbering, symbol_name):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_create_symbol(load_model_for_test, testdata, stem, force_numbering, symbol_name):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     symbol = create_symbol(model, stem=stem, force_numbering=force_numbering)
 
     assert symbol.name == symbol_name
 
 
-def test_to_generic_model(testdata):
+def test_to_generic_model(load_model_for_test, testdata):
     path = testdata / 'nonmem' / 'pheno.mod'
-    nm_model = Model.create_model(path)
+    nm_model = load_model_for_test(path)
     model = convert_model(nm_model, 'generic')
 
     assert model.parameters == nm_model.parameters
@@ -39,7 +38,7 @@ def test_to_generic_model(testdata):
     assert type(model) == pharmpy.model.Model
 
 
-def test_model_equality(testdata):
+def test_model_equality():
     pheno1 = load_example_model("pheno")
     assert pheno1 == pheno1
 

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -1,7 +1,6 @@
 import pytest
 import sympy
 
-from pharmpy import Model
 from pharmpy.statements import (
     Assignment,
     Bolus,
@@ -18,7 +17,7 @@ def S(x):
     return sympy.Symbol(x)
 
 
-def test_str(testdata):
+def test_str(load_model_for_test, testdata):
     s1 = Assignment(S('KA'), S('X') + S('Y'))
     assert str(s1) == 'KA = X + Y'
     s2 = Assignment(S('X2'), sympy.exp('X'))
@@ -26,13 +25,13 @@ def test_str(testdata):
     assert a[0].startswith(' ')
     assert len(a) == 2
 
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     assert 'THETA(2)' in str(model.statements)
     assert 'THETA(2)' in repr(model.statements)
 
 
-def test_subs(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_subs(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     statements = model.statements
 
     s2 = statements.subs({'ETA(1)': 'ETAT1'})
@@ -51,14 +50,14 @@ def test_subs(testdata):
     assert s4.ode_system.free_symbols == {S('CL'), S('AMT'), S('t'), S('V2')}
 
 
-def test_ode_free_symbols(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_ode_free_symbols(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
 
     assert model.statements.ode_system.free_symbols == {S('V'), S('CL'), S('AMT'), S('t')}
 
 
-def test_find_assignment(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_find_assignment(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     statements = model.statements
 
     assert str(statements.find_assignment('CL').expression) == 'TVCL*exp(ETA(1))'
@@ -69,8 +68,8 @@ def test_find_assignment(testdata):
     assert str(statements.find_assignment('CL').expression) == 'TVCL + V'
 
 
-def test_eq_assignment(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_eq_assignment(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     statements = model.statements
     statement_btime = statements[0]
     statement_tad = statements[1]
@@ -79,9 +78,9 @@ def test_eq_assignment(testdata):
     assert statement_btime != statement_tad
 
 
-def test_eq_modelstatements(testdata):
-    model_min = Model.create_model(testdata / 'nonmem' / 'minimal.mod')
-    model_pheno = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_eq_modelstatements(load_model_for_test, testdata):
+    model_min = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
+    model_pheno = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
 
     assert model_min.statements == model_min.statements
     assert model_pheno.statements == model_pheno.statements
@@ -166,16 +165,16 @@ def test_reassign():
     assert snew == Statements([s1, s2, s3, Assignment(S('KA'), S('F'))])
 
 
-def test_find_compartment(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
+def test_find_compartment(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
     comp = model.statements.ode_system.find_compartment('CENTRAL')
     assert comp.name == 'CENTRAL'
     comp = model.statements.ode_system.find_compartment('NOTINMODEL')
     assert comp is None
 
 
-def test_output_compartment(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+def test_output_compartment(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     cb = CompartmentalSystemBuilder(model.statements.ode_system)
     cb.add_compartment("NEW")
     cm = CompartmentalSystem(cb)
@@ -183,58 +182,58 @@ def test_output_compartment(testdata):
         cm.output_compartment
 
 
-def test_dosing_compartment(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+def test_dosing_compartment(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     assert model.statements.ode_system.dosing_compartment.name == 'CENTRAL'
 
 
-def test_central_compartment(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
+def test_central_compartment(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
     assert model.statements.ode_system.central_compartment.name == 'CENTRAL'
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_nodepot.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_nodepot.mod')
     assert model.statements.ode_system.central_compartment.name == 'CENTRAL'
 
 
-def test_find_depot(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
+def test_find_depot(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
     assert model.statements.ode_system.find_depot(model.statements).name == 'DEPOT'
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     assert model.statements.ode_system.find_depot(model.statements) is None
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_depot.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_depot.mod')
     assert model.statements.ode_system.find_depot(model.statements).name == 'DEPOT'
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_nodepot.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan5_nodepot.mod')
     assert model.statements.ode_system.find_depot(model.statements) is None
 
 
-def test_peripheral_compartments(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
+def test_peripheral_compartments(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
     assert model.statements.ode_system.peripheral_compartments == []
 
 
-def test_find_transit_compartments(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
+def test_find_transit_compartments(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     assert model.statements.ode_system.find_transit_compartments(model.statements) == []
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan2.mod')
     assert model.statements.ode_system.find_transit_compartments(model.statements) == []
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_1transit.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_1transit.mod')
     transits = model.statements.ode_system.find_transit_compartments(model.statements)
     assert len(transits) == 1
     assert transits[0].name == 'TRANS1'
-    model = Model.create_model(testdata / 'nonmem' / 'modeling' / 'pheno_2transits.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_2transits.mod')
     transits = model.statements.ode_system.find_transit_compartments(model.statements)
     assert len(transits) == 2
     assert transits[0].name == 'TRANS1'
     assert transits[1].name == 'TRANS2'
 
 
-def test_before_odes(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_before_odes(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     before_ode = model.statements.before_odes
     assert before_ode[-1].symbol.name == 'S1'
 
 
-def test_full_expression(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_full_expression(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     expr = model.statements.before_odes.full_expression("CL")
     assert expr == sympy.Symbol("THETA(1)") * sympy.Symbol("WGT") * sympy.exp(
         sympy.Symbol("ETA(1)")
@@ -243,8 +242,8 @@ def test_full_expression(pheno_path):
         model.statements.full_expression("Y")
 
 
-def test_to_explicit_ode_system(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_to_explicit_ode_system(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     exodes = model.statements.ode_system.to_explicit_system(skip_output=True)
     odes, ics = exodes.odes, exodes.ics
     assert len(odes) == 1
@@ -289,16 +288,16 @@ def test_repr_html():
     assert type(stats._repr_html_()) == str
 
 
-def test_direct_dependencies(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_direct_dependencies(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     odes = model.statements.ode_system
     deps = model.statements.direct_dependencies(odes)
     assert deps[0].symbol.name == "CL"
     assert deps[1].symbol.name == "V"
 
 
-def test_dependencies(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_dependencies(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     depsy = model.statements.dependencies(S('Y'))
     assert depsy == {
         S('EPS(1)'),
@@ -329,11 +328,6 @@ def test_dependencies(pheno_path):
     }
     with pytest.raises(KeyError):
         model.statements.dependencies("NONEXISTING")
-
-
-def test_compartment_names(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    assert model.statements.ode_system.compartment_names == ['CENTRAL', 'OUTPUT']
 
 
 def test_builder():
@@ -377,3 +371,8 @@ def test_infusion_create():
 def test_compartment_repr():
     comp = Compartment("CENTRAL", lag_time='LT')
     assert repr(comp) == "Compartment(CENTRAL, lag_time=LT)"
+
+
+def test_compartment_names(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    assert model.statements.ode_system.compartment_names == ['CENTRAL', 'OUTPUT']

--- a/tests/tools/test_cdd.py
+++ b/tests/tools/test_cdd.py
@@ -3,7 +3,6 @@ import pandas as pd
 from pytest import approx
 
 import pharmpy.tools.cdd.results as cdd
-from pharmpy import Model
 from pharmpy.tools.psn_helpers import model_paths, options_from_command
 
 
@@ -27,10 +26,10 @@ def test_psn_options():
     }
 
 
-def test_cdd_psn(testdata):
+def test_cdd_psn(load_model_for_test, testdata):
     path = testdata / 'nonmem' / 'cdd' / 'pheno_real_bin10'
-    base_model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
-    cdd_models = [Model.create_model(p) for p in model_paths(path, 'cdd_*.mod')]
+    base_model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
+    cdd_models = [load_model_for_test(p) for p in model_paths(path, 'cdd_*.mod')]
     skipped_individuals = cdd.psn_cdd_skipped_individuals(path)
 
     cdd_bin_id = cdd.calculate_results(base_model, cdd_models, 'ID', skipped_individuals)
@@ -126,13 +125,13 @@ def test_cdd_psn(testdata):
     pd.testing.assert_frame_equal(cdd_bin_id.case_results, correct, rtol=1e-4)
 
 
-def test_cdd_calculate_results(testdata):
+def test_cdd_calculate_results(load_model_for_test, testdata):
     path = testdata / 'nonmem' / 'cdd' / 'pheno_real_bin10'
     skipped_individuals = cdd.psn_cdd_skipped_individuals(path)
-    base_model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+    base_model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     cdd_model_paths = model_paths(path, 'cdd_*.mod')
 
-    cdd_models = [Model.create_model(p) for p in cdd_model_paths]
+    cdd_models = [load_model_for_test(p) for p in cdd_model_paths]
 
     # Results for plain PsN run
     delta_ofv = cdd.compute_delta_ofv(base_model, cdd_models, skipped_individuals)
@@ -236,9 +235,9 @@ def test_cdd_calculate_results(testdata):
 
     # Replace three estimated cdd_models with fake models without estimates
     # and recompute results to verify handling of missing output
-    cdd_models[0] = Model.create_model(path / 'm1' / 'rem_1.mod')
-    cdd_models[1] = Model.create_model(path / 'm1' / 'rem_2.mod')
-    cdd_models[3] = Model.create_model(path / 'm1' / 'rem_4.mod')
+    cdd_models[0] = load_model_for_test(path / 'm1' / 'rem_1.mod')
+    cdd_models[1] = load_model_for_test(path / 'm1' / 'rem_2.mod')
+    cdd_models[3] = load_model_for_test(path / 'm1' / 'rem_4.mod')
 
     res = cdd.calculate_results(base_model, cdd_models, 'ID', skipped_individuals)
 

--- a/tests/tools/test_estmethod.py
+++ b/tests/tools/test_estmethod.py
@@ -1,6 +1,5 @@
 import pytest
 
-from pharmpy import Model
 from pharmpy.tools.estmethod.algorithms import _clear_estimation_steps, _create_est_model
 from pharmpy.tools.estmethod.tool import create_workflow
 
@@ -38,8 +37,8 @@ def test_algorithm(methods, solvers, no_of_models):
         ),
     ],
 )
-def test_create_est_model(pheno_path, method, est_rec, eval_rec):
-    model = Model.create_model(pheno_path)
+def test_create_est_model(load_model_for_test, pheno_path, method, est_rec, eval_rec):
+    model = load_model_for_test(pheno_path)
     assert len(model.estimation_steps) == 1
     est_model = _create_est_model(method, None, model=model)
     assert len(est_model.estimation_steps) == 2
@@ -47,8 +46,8 @@ def test_create_est_model(pheno_path, method, est_rec, eval_rec):
     assert est_model.model_code.split('\n')[-4] == eval_rec
 
 
-def test_clear_estimation_steps(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_clear_estimation_steps(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     assert len(model.estimation_steps) == 1
     _clear_estimation_steps(model)
     assert len(model.estimation_steps) == 0

--- a/tests/tools/test_frem.py
+++ b/tests/tools/test_frem.py
@@ -21,8 +21,8 @@ from pharmpy.tools.frem.tool import check_covariates
 from pharmpy.tools.psn_helpers import create_results
 
 
-def test_check_covariates(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_check_covariates(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     newcov = check_covariates(model, ['WGT', 'APGR'])
     assert newcov == ['WGT', 'APGR']
     newcov = check_covariates(model, ['APGR', 'WGT'])
@@ -39,16 +39,16 @@ def test_check_covariates(testdata):
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_check_covariates_mult_warns(testdata):
+def test_check_covariates_mult_warns(load_model_for_test, testdata):
     # These are separated because capturing the warnings did not work.
     # Possibly because more than one warning is issued
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     newcov = check_covariates(model, ['FA1', 'FA2'])
     assert newcov == []
 
 
-def test_parcov_inits(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_3.mod')
+def test_parcov_inits(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_3.mod')
     params = calculate_parcov_inits(model, 2)
     assert params == approx(
         {
@@ -60,9 +60,9 @@ def test_parcov_inits(testdata):
     )
 
 
-def test_create_model3b(testdata):
-    model3 = Model.create_model(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_3.mod')
-    model1b = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_create_model3b(load_model_for_test, testdata):
+    model3 = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_3.mod')
+    model1b = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     model3b = create_model3b(model1b, model3, 2)
     pset = model3b.parameters
     assert pset['OMEGA(3,1)'].init == approx(0.02560327)
@@ -70,15 +70,15 @@ def test_create_model3b(testdata):
     assert model3b.name == 'model_3b'
 
 
-def test_bipp_covariance(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
+def test_bipp_covariance(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
     np.random.seed(9532)
     res = calculate_results_using_bipp(model, continuous=['APGR', 'WGT'], categorical=[])
     assert res
 
 
-def test_frem_results_pheno(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
+def test_frem_results_pheno(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
     rng = np.random.default_rng(39)
     res = calculate_results(model, continuous=['APGR', 'WGT'], categorical=[], samples=10, rng=rng)
 
@@ -251,8 +251,8 @@ V,all,0.14572521381314374,0.11146577839548052,0.16976758171177983
     pd.testing.assert_frame_equal(res.covariate_statistics, correct)
 
 
-def test_frem_results_pheno_categorical(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'frem' / 'pheno_cat' / 'model_4.mod')
+def test_frem_results_pheno_categorical(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno_cat' / 'model_4.mod')
     rng = np.random.default_rng(8978)
     res = calculate_results(model, continuous=['WGT'], categorical=['APGRX'], samples=10, rng=rng)
 
@@ -424,8 +424,8 @@ V,all,0.1441532460182698,0.1294082747127788,0.16527164471815176
     pd.testing.assert_frame_equal(res.covariate_statistics, correct)
 
 
-def test_get_params(testdata):
-    model_frem = Model.create_model(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
+def test_get_params(load_model_for_test, testdata):
+    model_frem = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
     rvs, _ = model_frem.random_variables.etas.distributions()[-1]
     npars = 2
 

--- a/tests/tools/test_frem.py
+++ b/tests/tools/test_frem.py
@@ -9,7 +9,6 @@ from pytest import approx
 
 import pharmpy.modeling as modeling
 import pharmpy.tools as tools
-from pharmpy.model import Model
 from pharmpy.tools.frem.models import calculate_parcov_inits, create_model3b
 from pharmpy.tools.frem.results import (
     calculate_results,
@@ -424,7 +423,7 @@ V,all,0.1441532460182698,0.1294082747127788,0.16527164471815176
     pd.testing.assert_frame_equal(res.covariate_statistics, correct)
 
 
-def test_get_params(load_model_for_test, testdata):
+def test_get_params(load_model_for_test, create_model_for_test, testdata):
     model_frem = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
     rvs, _ = model_frem.random_variables.etas.distributions()[-1]
     npars = 2
@@ -436,7 +435,7 @@ def test_get_params(load_model_for_test, testdata):
         r'(V=TVV\*EXP\(ETA\(2\)\))', r'\1*EXP(ETA(3))', model_frem.model_code
     )
 
-    model = Model.create_model(StringIO(model_multiple_etas))
+    model = create_model_for_test(model_multiple_etas)
     model.dataset = model_frem.dataset
     rvs, _ = model.random_variables.etas.distributions()[-1]
     npars = 3
@@ -450,7 +449,7 @@ def test_get_params(load_model_for_test, testdata):
         model_frem.model_code,
     )
 
-    model = Model.create_model(StringIO(model_separate_declare))
+    model = create_model_for_test(model_separate_declare)
     model.dataset = model_frem.dataset
     rvs, _ = model.random_variables.etas.distributions()[-1]
     npars = 2

--- a/tests/tools/test_iivsearch.py
+++ b/tests/tools/test_iivsearch.py
@@ -1,8 +1,5 @@
-from io import StringIO
-
 import pytest
 
-from pharmpy import Model
 from pharmpy.modeling import (
     add_iiv,
     add_peripheral_compartment,
@@ -119,7 +116,7 @@ def test_create_joint_dist(load_model_for_test, testdata):
     assert len(model.random_variables.iiv.distributions()) == 3
 
 
-def test_get_param_names(load_model_for_test, testdata):
+def test_get_param_names(create_model_for_test, load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     param_dict = _iiv_param_dict(model)
@@ -130,7 +127,7 @@ def test_get_param_names(load_model_for_test, testdata):
     model_code = model.model_code.replace(
         'CL = THETA(1) * EXP(ETA(1))', 'ETA_1 = ETA(1)\nCL = THETA(1) * EXP(ETA_1)'
     )
-    model = Model.create_model(StringIO(model_code))
+    model = create_model_for_test(model_code)
 
     param_dict = _iiv_param_dict(model)
 

--- a/tests/tools/test_iivsearch.py
+++ b/tests/tools/test_iivsearch.py
@@ -22,8 +22,10 @@ from pharmpy.tools.iivsearch.algorithms import (
     'list_of_parameters, block_structure, no_of_models',
     [([], [], 4), (['QP1'], [], 14), ([], ['ETA(1)', 'ETA(2)'], 4)],
 )
-def test_brute_force_block_structure(testdata, list_of_parameters, block_structure, no_of_models):
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+def test_brute_force_block_structure(
+    load_model_for_test, testdata, list_of_parameters, block_structure, no_of_models
+):
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     add_peripheral_compartment(model)
     add_iiv(model, list_of_parameters, 'add')
     if block_structure:
@@ -35,8 +37,8 @@ def test_brute_force_block_structure(testdata, list_of_parameters, block_structu
     assert len(fit_tasks) == no_of_models
 
 
-def test_get_eta_combinations_4_etas(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_get_eta_combinations_4_etas(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     add_iiv(model, ['TVCL', 'TVV'], 'exp')
 
     eta_combos = _get_eta_combinations(model.random_variables.iiv)
@@ -57,8 +59,8 @@ def test_get_eta_combinations_4_etas(pheno_path):
     assert len_of_combos.count([1, 1, 1, 1]) == 1
 
 
-def test_get_eta_combinations_5_etas(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_get_eta_combinations_5_etas(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     add_iiv(model, ['TVCL', 'TVV', 'TAD'], 'exp')
 
     eta_combos = _get_eta_combinations(model.random_variables.iiv)
@@ -80,8 +82,8 @@ def test_get_eta_combinations_5_etas(pheno_path):
     assert len_of_combos.count([1, 1, 1, 1, 1]) == 1
 
 
-def test_is_current_block_structure(pheno_path):
-    model = Model.create_model(pheno_path)
+def test_is_current_block_structure(load_model_for_test, pheno_path):
+    model = load_model_for_test(pheno_path)
     add_iiv(model, ['TVCL', 'TVV'], 'exp')
     etas = model.random_variables.iiv
 
@@ -100,15 +102,15 @@ def test_is_current_block_structure(pheno_path):
     assert _is_current_block_structure(etas, eta_combos)
 
 
-def test_create_joint_dist(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+def test_create_joint_dist(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     add_peripheral_compartment(model)
     add_pk_iiv(model)
     eta_combos = [['ETA(1)', 'ETA(2)'], ['ETA_QP1'], ['ETA_VP1']]
     create_eta_blocks(eta_combos, model)
     assert len(model.random_variables.iiv.distributions()) == 4
 
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
     add_peripheral_compartment(model)
     add_pk_iiv(model)
     create_joint_distribution(model, ['ETA(1)', 'ETA(2)'])
@@ -117,8 +119,8 @@ def test_create_joint_dist(testdata):
     assert len(model.random_variables.iiv.distributions()) == 3
 
 
-def test_get_param_names(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'models' / 'mox2.mod')
+def test_get_param_names(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     param_dict = _iiv_param_dict(model)
     param_dict_ref = {'ETA(1)': 'CL', 'ETA(2)': 'VC', 'ETA(3)': 'MAT'}

--- a/tests/tools/test_iovsearch.py
+++ b/tests/tools/test_iovsearch.py
@@ -1,13 +1,12 @@
 from sympy import Symbol as S
 
-from pharmpy import Model
 from pharmpy.modeling import add_iov, remove_iov
 from pharmpy.tools.iovsearch.tool import _get_iiv_etas_with_corresponding_iov
 
 
-def test_iovsearch_github_issues_976(testdata):
+def test_iovsearch_github_issues_976(load_model_for_test, testdata):
 
-    m = Model.create_model(testdata / 'nonmem' / 'pheno_multivariate_piecewise.mod')
+    m = load_model_for_test(testdata / 'nonmem' / 'pheno_multivariate_piecewise.mod')
     assert not m.random_variables.iov
     assert set(_get_iiv_etas_with_corresponding_iov(m)) == set()
 

--- a/tests/tools/test_linearize.py
+++ b/tests/tools/test_linearize.py
@@ -3,15 +3,14 @@ from io import StringIO
 import pandas as pd
 import pytest
 
-from pharmpy import Model
 from pharmpy.tools.linearize.results import calculate_results, psn_linearize_results
 from pharmpy.tools.linearize.tool import create_linearized_model
 from pharmpy.tools.psn_helpers import create_results
 
 
-def test_ofv(testdata):
-    base = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    lin = Model.create_model(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+def test_ofv(load_model_for_test, testdata):
+    base = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    lin = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     res = calculate_results(base, lin)
     correct = """,ofv
 base,730.894727
@@ -22,9 +21,9 @@ lin_estimated,730.847272
     pd.testing.assert_frame_equal(res.ofv, correct, atol=1e-6)
 
 
-def test_iofv(testdata):
-    base = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    lin = Model.create_model(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+def test_iofv(load_model_for_test, testdata):
+    base = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    lin = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     res = calculate_results(base, lin)
     correct = """,base,linear,delta
 1,7.742852,7.722670,-0.020182
@@ -106,8 +105,8 @@ def test_create_results(testdata):
     assert res.ofv['ofv']['base'] == pytest.approx(730.894727)
 
 
-def test_create_linearized_model(testdata):
+def test_create_linearized_model(load_model_for_test, testdata):
     path = testdata / 'nonmem' / 'pheno_real.mod'
-    model = Model.create_model(path)
+    model = load_model_for_test(path)
     linbase = create_linearized_model(model)
     assert len(linbase.statements) == 8

--- a/tests/tools/test_mfl.py
+++ b/tests/tools/test_mfl.py
@@ -287,7 +287,8 @@ from pharmpy.tools.mfl.parse import parse
     ),
     ids=repr,
 )
-def test_all_funcs(pheno, source, expected):
+def test_all_funcs(load_model_for_test, pheno_path, source, expected):
+    pheno = load_model_for_test(pheno_path)
     statements = parse(source)
     funcs = all_funcs(pheno, statements)
     keys = funcs.keys()

--- a/tests/tools/test_modelfit.py
+++ b/tests/tools/test_modelfit.py
@@ -1,14 +1,13 @@
-from pharmpy import Model
 from pharmpy.tools.modelfit.results import calculate_results
 
 
-def test_modelfit(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno_real.mod')
+def test_modelfit(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     assert model
 
 
-def test_aggregate(testdata):
-    model = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
+def test_aggregate(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     res = calculate_results([model, model])
     pe = res.parameter_estimates
     assert len(pe) == 2

--- a/tests/tools/test_modelsearch.py
+++ b/tests/tools/test_modelsearch.py
@@ -1,9 +1,7 @@
 import functools
-from io import StringIO
 
 import pytest
 
-from pharmpy import Model
 from pharmpy.modeling import set_peripheral_compartments, set_zero_order_absorption
 from pharmpy.tools.mfl.parse import parse
 from pharmpy.tools.modelsearch.algorithms import (
@@ -109,7 +107,7 @@ def test_reduced_stepwise_algorithm(mfl, no_of_models):
     assert all(task.name == 'run0' for task in wf.output_tasks)
 
 
-def test_check_input(testdata):
+def test_check_input(create_model_for_test, testdata):
     model_code = '''$PROBLEM
 $INPUT ID VISI XAT2=DROP DGRP DOSE FLAG=DROP ONO=DROP
        XIME=DROP NEUY SCR AGE SEX NYH=DROP WT DROP ACE
@@ -131,7 +129,7 @@ $SIGMA 0.013241
 
 $ESTIMATION METHOD=1 INTERACTION
 '''
-    model = Model.create_model(StringIO(model_code))
+    model = create_model_for_test(model_code)
     model.datainfo = model.datainfo.derive(
         path=testdata / 'nonmem' / 'models' / 'mox_simulated_normal.csv'
     )

--- a/tests/tools/test_qa.py
+++ b/tests/tools/test_qa.py
@@ -4,16 +4,15 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pharmpy import Model
 from pharmpy.results import read_results
 from pharmpy.tools.qa.results import calculate_results, psn_qa_results
 from pharmpy.tools.ruvsearch.results import psn_resmod_results
 
 
-def test_add_etas(testdata):
-    orig = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    base = Model.create_model(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    add_etas = Model.create_model(testdata / 'nonmem' / 'qa' / 'add_etas_linbase.mod')
+def test_add_etas(load_model_for_test, testdata):
+    orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    add_etas = load_model_for_test(testdata / 'nonmem' / 'qa' / 'add_etas_linbase.mod')
     res = calculate_results(orig, base, add_etas_model=add_etas, etas_added_to=['CL', 'V'])
     correct = """added,new_sd,orig_sd
 ETA(1),True,0.338974,0.333246
@@ -30,10 +29,10 @@ V,False,0.010000,NaN
     assert res.dofv['df']['parameter_variability', 'add_etas', np.nan] == 2
 
 
-def test_fullblock(testdata):
-    orig = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    base = Model.create_model(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    fb = Model.create_model(testdata / 'nonmem' / 'qa' / 'fullblock.mod')
+def test_fullblock(load_model_for_test, testdata):
+    orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    fb = load_model_for_test(testdata / 'nonmem' / 'qa' / 'fullblock.mod')
     res = calculate_results(orig, base, fullblock_model=fb)
     correct = """,new,old
 "OMEGA(1,1)",0.486600,0.333246
@@ -52,10 +51,10 @@ def test_fullblock(testdata):
     assert res.fullblock_parameters is None
 
 
-def test_boxcox(testdata):
-    orig = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    base = Model.create_model(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    bc = Model.create_model(testdata / 'nonmem' / 'qa' / 'boxcox.mod')
+def test_boxcox(load_model_for_test, testdata):
+    orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    bc = load_model_for_test(testdata / 'nonmem' / 'qa' / 'boxcox.mod')
     res = calculate_results(orig, base, boxcox_model=bc)
     correct = """lambda,new_sd,old_sd
 ETA(1),-1.581460,0.296257,0.333246
@@ -73,10 +72,10 @@ ETA(2),0.645817,0.429369,0.448917
     assert res.boxcox_parameters is None
 
 
-def test_tdist(testdata):
-    orig = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    base = Model.create_model(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    td = Model.create_model(testdata / 'nonmem' / 'qa' / 'tdist.mod')
+def test_tdist(load_model_for_test, testdata):
+    orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    td = load_model_for_test(testdata / 'nonmem' / 'qa' / 'tdist.mod')
     res = calculate_results(orig, base, tdist_model=td)
     correct = """df,new_sd,old_sd
 ETA(1),3.77,0.344951,0.333246
@@ -93,10 +92,10 @@ ETA(2),3.77,0.400863,0.448917
     res = calculate_results(orig, base, tdist_model=None)
 
 
-def test_iov(testdata):
-    orig = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    base = Model.create_model(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    iov = Model.create_model(testdata / 'nonmem' / 'qa' / 'iov.mod')
+def test_iov(load_model_for_test, testdata):
+    orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    iov = load_model_for_test(testdata / 'nonmem' / 'qa' / 'iov.mod')
     res = calculate_results(orig, base, iov_model=iov)
     correct = """new_iiv_sd,orig_iiv_sd,iov_sd
 ETA(1),0.259560,0.333246,0.555607
@@ -109,9 +108,9 @@ ETA(2),0.071481,0.448917,0.400451
     assert res.dofv['df']['parameter_variability', 'iov', np.nan] == 2
 
 
-def test_scm(testdata):
-    orig = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    base = Model.create_model(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+def test_scm(load_model_for_test, testdata):
+    orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     scm_res = read_results(testdata / 'nonmem' / 'qa' / 'scm_results.json')
     res = calculate_results(orig, base, scm_results=scm_res)
     correct = """,,dofv,coeff
@@ -127,9 +126,9 @@ ETA(2),WGT,0.00887,-0.003273
     assert res.dofv['df']['covariates', 'ET1APGR-2', np.nan] == 1
 
 
-def test_resmod(testdata):
-    orig = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    base = Model.create_model(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+def test_resmod(load_model_for_test, testdata):
+    orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     resmod_res = read_results(testdata / 'nonmem' / 'qa' / 'resmod_results.json')
     res = calculate_results(orig, base, resmod_idv_results=resmod_res)
     assert list(res.residual_error['additional_parameters']) == [2, 2, 1, 1, 1, 1]
@@ -145,9 +144,9 @@ def test_resmod(testdata):
     assert res.dofv['dofv']['residual_error_model', 'dtbs', 1] == pytest.approx(13.91)
 
 
-def test_resmod_dvid(testdata):
-    orig = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    base = Model.create_model(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+def test_resmod_dvid(load_model_for_test, testdata):
+    orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     resmod_res = psn_resmod_results(testdata / 'psn' / 'resmod_dir2')
     res = calculate_results(orig, base, resmod_idv_results=resmod_res)
     assert res.residual_error.loc[("4", "tdist"), 'dOFV'] == 2.41
@@ -192,9 +191,9 @@ PRED,1,10,36.34,54.00,-0.47,9
     pd.testing.assert_frame_equal(res.structural_bias, correct, atol=1e-6)
 
 
-def test_simeval(testdata):
-    orig = Model.create_model(testdata / 'nonmem' / 'pheno.mod')
-    base = Model.create_model(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+def test_simeval(load_model_for_test, testdata):
+    orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     simeval_res = read_results(testdata / 'nonmem' / 'qa' / 'simeval_results.json')
     cdd_res = read_results(testdata / 'nonmem' / 'qa' / 'cdd_results.json')
     calculate_results(orig, base, simeval_results=simeval_res, cdd_results=cdd_res)


### PR DESCRIPTION
> Ready to MERGE @rikardn 

This PR speeds up model parsing in tests by caching the parsed model and
generate copies with `Model#copy` instead. Tests run significantly faster but
faster execution could still be achieved by improving the parsing speed: many
tests parse small pieces of NMTRAN code that are used nowhere else, so they
cannot be cached. So I have not made these tests use the caching mechanism.

Some caveats:
  - I had to make `Model#copy` work with models that do not have a name.
  - `Model.create_model`'s output depends on Pharmpy's configuration, so the
cache key is currently made to depend on the string representation of the
NONMEM part of the config. This could maybe made more generic. I also noticed
that the default config is represented by the empty string, but as soon as you
use a config context the representation changes to an explicit stringification
of the defaults (i.e. not the empty string).
  - Caching currently is path-based, not content-based, so an attempt is made
at resolving the given file path, and if that file path is a descendant of
pytest's basetemp directory, caching is skipped.
