### PR TITLE
[dev] Refactor tox configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,10 +42,13 @@ jobs:
         tox
       env:
         PLATFORM: ${{ matrix.platform }}
+        TOX_SUITE: unit
     - name: Build documentation
       run: |
         cd pharmpy
-        tox -e docs
+        tox
+      env:
+        TOX_SUITE: docs-build
     - name: Build wheel
       run: |
         cd pharmpy

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -127,9 +127,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
       - name: Run integration tests
-        run: tox -e integration
+        run: tox
         env:
           PLATFORM: ubuntu-latest
+          TOX_SUITE: integration
+          TOX_PYTEST_COVER: integration
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
@@ -183,9 +185,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
       - name: Run integration tests
-        run: tox -e integration
+        run: tox
         env:
           PLATFORM: macos-latest
+          TOX_SUITE: integration
+          TOX_PYTEST_COVER: integration
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
         with:
@@ -235,9 +239,11 @@ jobs:
             python -m pip install --upgrade pip
             pip install tox
         - name: Run integration tests
-          run: tox -e integration
+          run: tox
           env:
             PLATFORM: windows-2019
+            TOX_SUITE: integration
+            TOX_PYTEST_COVER: integration
         - name: Upload coverage to Codecov
           uses: codecov/codecov-action@v2
           with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         run: tox
         env:
           PLATFORM: ${{ matrix.platform }}
-          TOX_FACTOR: ${{ matrix.suite }}
+          TOX_SUITE: ${{ matrix.suite }}
 
       - name: Run tests with tox
         if: matrix.suite == 'unit' || matrix.suite == 'doctest'
@@ -68,7 +68,8 @@ jobs:
             echo "coverage=${{ matrix.suite }}" >> $GITHUB_ENV
         env:
           PLATFORM: ${{ matrix.platform }}
-          TOX_FACTOR: ${{ matrix.suite }}
+          TOX_SUITE: ${{ matrix.suite }}
+          TOX_PYTEST_COVER: ${{ matrix.suite }}
 
       - name: Upload coverage to Codecov
         if: env.coverage != ''
@@ -79,12 +80,18 @@ jobs:
 
       - name: Build docs
         if: matrix.suite == 'docs-build'
-        run: tox -e docs
+        run: tox
+        env:
+          TOX_SUITE: ${{ matrix.suite }}
 
       - name: Test docs
         if: matrix.suite == 'docs-test'
-        run: tox -e sphinxtest
+        run: tox
+        env:
+          TOX_SUITE: ${{ matrix.suite }}
 
       - name: Lint docs
         if: matrix.suite == 'docs-lint'
-        run: tox -e doccheck
+        run: tox
+        env:
+          TOX_SUITE: ${{ matrix.suite }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ debugpy==1.6.3
 decorator==5.1.1
 defusedxml==0.7.1
 distributed==2022.8.1
-docutils==0.17.1
+docutils==0.18.0
 entrypoints==0.4
 executing==0.10.0
 fastjsonschema==2.16.1

--- a/tox.ini
+++ b/tox.ini
@@ -13,10 +13,8 @@ envlist =
     py{38,39,310}-doctest{-cover,},
     py{38,39,310}{-check,-report},
     report,
-    sphinxtest,
-    docs,
+    {py38-,py39-,py310-,}{docs,sphinxtest,doccheck},
     spell,
-    doccheck,
     licenses
 
 [gh-actions]
@@ -127,7 +125,7 @@ deps =
     sphinxcontrib-spelling
     pyenchant
 
-[testenv:sphinxtest]
+[testenv:{py38-,py39-,py310-,}sphinxtest]
 skip_install = false
 deps =
     -rrequirements.txt
@@ -138,7 +136,7 @@ commands =
     pip install sphinx-tabs>=3.4.1
     sphinx-build {posargs:-E} -j auto -b doctest docs dist/docs
 
-[testenv:docs]
+[testenv:{py38-,py39-,py310-,}docs]
 skip_install = false
 deps =
     -rrequirements.txt
@@ -186,7 +184,7 @@ deps =
 commands =
     pip-licenses
 
-[testenv:doccheck]
+[testenv:{py38-,py39-,py310-,}doccheck]
 skip_install = false
 deps =
     darglint

--- a/tox.ini
+++ b/tox.ini
@@ -107,22 +107,6 @@ commands =
     flake8 src tests setup.py
     isort -m3 --tc src tests setup.py
 
-[testenv:coveralls]
-deps =
-    coveralls
-skip_install = true
-commands =
-    coveralls []
-
-[testenv:codecov]
-deps =
-    codecov
-skip_install = true
-commands =
-    coverage xml --ignore-errors
-    codecov []
-
-
 [testenv:{py38-,py39-,py310-,}report]
 deps = coverage
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -135,8 +135,8 @@ deps =
     -r{toxinidir}/docs/requirements.txt
 commands =
     pip install ipykernel==5.5.5  # Unable to build docs with newer version
-    pip install sphinx==4.5.0   # Cannot use >=5: blocked by sphinx-tabs
-    pip install sphinx-tabs==3.3.1
+    pip install sphinx>=5.1.1
+    pip install sphinx-tabs>=3.4.1
     sphinx-build {posargs:-E} -j auto -b doctest docs dist/docs
 
 [testenv:docs]
@@ -146,8 +146,8 @@ deps =
     -r{toxinidir}/docs/requirements.txt
 commands =
     pip install ipykernel==5.5.5  # Unable to build docs with newer version
-    pip install sphinx==4.5.0   # Cannot use >=5: blocked by sphinx-tabs
-    pip install sphinx-tabs==3.3.1
+    pip install sphinx>=5.1.1
+    pip install sphinx-tabs>=3.4.1
     rm -rf docs/api
     sphinx-build {posargs:-E} -j auto -b html docs dist/docs
     sphinx-build -j auto -b linkcheck docs dist/docs

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,7 @@ skip_missing_interpreters=True
 envlist =
     clean,
     check,
-    py{38,39,310}{-cover,}{-profile,}{-debug,},
-    {py38-,py39-,py310-,}{unit,integration}{-cover,}{-profile,}{-debug,},
+    {py38-,py39-,py310-,}{unit,integration}{-cover,}
     py{38,39,310}-doctest{-cover,},
     py{38,39,310}{-check,-report},
     report,

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,16 @@ skip_missing_interpreters=True
 envlist =
     clean,
     check,
-    py{38,39,310}{,-check,-unit,-doctest,-report},
+    py{38,39,310}{-cover,}{-profile,}{-debug,},
+    {py38-,py39-,py310-,}{unit,integration}{-cover,}{-profile,}{-debug,},
+    py{38,39,310}-doctest{-cover,},
+    py{38,39,310}{-check,-report},
     report,
     sphinxtest,
-    docs
+    docs,
+    spell,
+    doccheck,
+    licenses
 
 [gh-actions]
 python =
@@ -21,13 +27,22 @@ python =
     3.10: py310
 
 [gh-actions:env]
-TOX_FACTOR =
-    unit: unit
+TOX_SUITE =
     doctest: doctest
+    unit: unit
+    integration: integration
     lint: check
+    docs-build: docs
+    docs-test: sphinxtest
+    docs-lint: doccheck
+TOX_PYTEST_COVER =
+    doctest: cover
+    unit: cover
+    integration: cover
 
 [testenv]
 basepython = {env:TOXPYTHON:python3.9}
+skip_install = true
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -36,20 +51,71 @@ setenv =
 passenv =
     *
 usedevelop = false
+allowlist_externals =
+    rm
+    printf
+    false
+commands =
+    printf "ERROR: unknown environment '%s'\n" {envname}
+    printf "Maybe factors where given in the wrong order?\n"
+    false
+
+[base]
 deps =
-    setuptools>=47.1.1
-    -rrequirements.txt
     pytest>5.3.5
     pytest-asyncio>=0.17.0
-    pytest-cov
     pytest-xdist>1.34.0
-    pytest-profiling
-    gprof2dot==2019.11.30
-    pdbpp
-commands =
-    {posargs:pytest -n auto --asyncio-mode=auto --cov --cov-report=term-missing --cov-report xml:.coverage.xml -vv tests}
-whitelist_externals = rm
+    cover: pytest-cov
+    profile: pytest-profiling
+    profile: gprof2dot==2019.11.30
+    debug: pdbpp
 
+[flags]
+cover = --cov --cov-report=term-missing --cov-report xml:.coverage.xml
+profile = --profile-svg
+debug = --pdb
+
+[testenv:{py38,py39,py310,py38-unit,py39-unit,py310-unit,unit}{-cover,}{-profile,}{-debug,}]
+skip_install = false
+deps =
+    -rrequirements.txt
+    {[base]deps}
+commands = pytest -n auto -vv \
+    profile: {[flags]profile} \
+    cover: {[flags]cover} \
+    debug: {[flags]debug} \
+    {posargs:tests}
+
+[testenv:py{38,39,310}-doctest{-cover,}]
+skip_install = false
+deps =
+    -rrequirements.txt
+    {[base]deps}
+commands = pytest -W ignore::UserWarning -n auto -vv \
+    profile: {[flags]profile} \
+    cover: {[flags]cover} \
+    debug: {[flags]debug} \
+    --doctest-modules {posargs:src}
+
+[testenv:{py38-,py39-,py310-,}integration{-cover,}{-profile,}{-debug,}]
+skip_install = false
+deps =
+    -rrequirements.txt
+    {[base]deps}
+setenv =
+    PHARMPYNOCONFIGFILE=0
+commands = pytest -vv \
+    profile: {[flags]profile} \
+    cover: {[flags]cover} \
+    debug: {[flags]debug} \
+    {posargs:tests/integration}
+
+[testenv:run]
+setenv =
+    PHARMPYNOCONFIGFILE=0
+skip_install = false
+deps =
+    -rrequirements.txt
 
 [testenv:spell]
 basepython = {env:TOXPYTHON:python2.7}
@@ -57,17 +123,13 @@ setenv =
     SPELLCHECK=1
 commands =
     sphinx-build -j auto -b spelling docs dist/docs
-skip_install = true
 deps =
     -r{toxinidir}/docs/requirements.txt
     sphinxcontrib-spelling
     pyenchant
 
-[testenv:py{38,39,310}-doctest]
-commands =
-    pytest -W ignore::UserWarning -n auto --asyncio-mode=auto --cov --cov-report=term-missing --cov-report xml:.coverage.xml -vv --doctest-modules src
-
 [testenv:sphinxtest]
+skip_install = false
 deps =
     -rrequirements.txt
     -r{toxinidir}/docs/requirements.txt
@@ -78,6 +140,7 @@ commands =
     sphinx-build {posargs:-E} -j auto -b doctest docs dist/docs
 
 [testenv:docs]
+skip_install = false
 deps =
     -rrequirements.txt
     -r{toxinidir}/docs/requirements.txt
@@ -100,7 +163,6 @@ deps =
     twine
     black
     flake8-black
-skip_install = true
 commands =
     check-manifest -v {toxinidir}
     black src tests setup.py
@@ -109,34 +171,16 @@ commands =
 
 [testenv:{py38-,py39-,py310-,}report]
 deps = coverage
-skip_install = true
 commands =
     coverage report
     coverage html
 
 [testenv:clean]
 commands = coverage erase
-skip_install = true
 deps = coverage
 
-[testenv:run]
-deps =
-    -rrequirements.txt
-setenv =
-    PHARMPYNOCONFIGFILE=0
-
-[testenv:integration]
-deps =
-    pytest>5.3.5
-    pytest-asyncio>=0.17.0
-    pytest-cov
-    -rrequirements.txt
-setenv =
-    PHARMPYNOCONFIGFILE=0
-commands =
-    {posargs:pytest -vv --cov --cov-report=term-missing --cov-report xml:.coverage.xml tests/integration}
-
 [testenv:licenses]
+skip_install = false
 deps =
     -rrequirements.txt
     pip-licenses
@@ -144,6 +188,7 @@ commands =
     pip-licenses
 
 [testenv:doccheck]
+skip_install = false
 deps =
     darglint
 commands =


### PR DESCRIPTION
> @rikardn REVIEW

  - [x] GHA runs unit tests, doctest tests, and integration tests with coverage without knowing much about `tox`'s configuration
  - [x] `tox -e pyXY` and `tox -e unit` and `tox -e pyXY-unit` runs unit tests without coverage
  - [x] `tox -e doctest` and `tox -e pyXY-doctest` runs integration tests without coverage
  - [x] `tox -e integration` and `tox -e pyXY-integration` runs integration tests without coverage
  - [x] `tox -e abracdabra` crashes after 1/4 of a second 
  - [x] `tox -e doctest-pyXY` crashes after 1 second 
  - [x] `tox -e ...-cover` runs with coverage 
  - [x] `tox -e ...-profile` runs with profiling 
  - [x] `tox -e ...-debug` runs with debugging
  - [x] `tox -e ... -- -n8` runs with 8 workers
  - [x] `tox -e ... -- path1 path2 path3` runs tests found in `path1`, `path2`, and `path3`.