### PR TITLE
Check ruvsearch input (fixes #845)

### DIFF
--- a/tests/integration/test_ruvsearch.py
+++ b/tests/integration/test_ruvsearch.py
@@ -1,5 +1,7 @@
 import shutil
 
+import pytest
+
 from pharmpy.model import Model
 from pharmpy.modeling import remove_covariance_step
 from pharmpy.tools import run_tool
@@ -30,3 +32,46 @@ def test_ruvsearch(tmp_path, testdata):
         )
         assert res.best_model.model_code.split('\n')[19] == '$THETA  1.15573 ; time_varying'
         assert res.best_model.model_code.split('\n')[25] == '$OMEGA  0.0396751 ; IIV_RUV1'
+
+
+def test_ruvsearch_input(tmp_path, testdata):
+    with TemporaryDirectoryChanger(tmp_path):
+        for path in (testdata / 'nonmem' / 'ruvsearch').glob('mox3.*'):
+            shutil.copy2(path, tmp_path)
+        shutil.copy2(testdata / 'nonmem' / 'ruvsearch' / 'moxo_simulated_resmod.csv', tmp_path)
+        shutil.copy2(testdata / 'nonmem' / 'ruvsearch' / 'mytab', tmp_path)
+
+        model = Model.create_model('mox3.mod')
+        remove_covariance_step(model)
+        model.datainfo = model.datainfo.derive(path=tmp_path / 'moxo_simulated_resmod.csv')
+
+        with pytest.raises(TypeError) as e:
+            run_tool('ruvsearch', model, groups=4.5, p_value=0.05, skip=[])
+        assert (
+            str(e.value)
+            == '4.5 is not an integer. Please input an integer for groups and try again.'
+        )
+
+        with pytest.raises(ValueError) as e:
+            run_tool('ruvsearch', model, groups=4, p_value=1.2, skip=[])
+        assert (
+            str(e.value)
+            == '1.2 is not a float number between (0, 1). Please input correct p-value and try again.'
+        )
+
+        with pytest.raises(ValueError) as e:
+            run_tool(
+                'ruvsearch',
+                model,
+                groups=4,
+                p_value=0.05,
+                skip=['tume_varying', 'RUV_IIV', 'powder'],
+            )
+        assert str(e.value) == "Please correct ['tume_varying', 'RUV_IIV', 'powder'] and try again."
+
+        with pytest.raises(ValueError) as e:
+            del model.modelfit_results.residuals['CWRES']
+            run_tool('ruvsearch', model, groups=4, p_value=0.05, skip=[])
+        assert (
+            str(e.value) == 'Please check mox3.mod file to make sure ID, TIME, CWRES are in $TABLE.'
+        )


### PR DESCRIPTION
Hi Rikard,

This PR is to check the input options of ruvsearch. For `modelfit_results`, I only check the residuals and predictions. I am not sure if I should check the ofv or not.?

Best regards,
Zhe