### PR TITLE
Skip unsuccessful proxy models in ruvsearch (fixes #1097)

### DIFF
--- a/src/pharmpy/tools/ruvsearch/tool.py
+++ b/src/pharmpy/tools/ruvsearch/tool.py
@@ -332,7 +332,7 @@ def _time_after_dose(model):
 
 
 def _create_best_model(model, res, current_iteration, groups=4, cutoff=3.84):
-    if any(res.cwres_models['dofv'] > cutoff):
+    if not res.cwres_models.empty and any(res.cwres_models['dofv'] > cutoff):
         model = model.copy()
         update_initial_estimates(model)
         model.name = f'best_ruvsearch_{current_iteration}'


### PR DESCRIPTION
Hi Rikard,

This PR is to skip the proxy models which didn't have ofvs and only do the comparison between successful proxy models and the base model for each iteration. It would be great if we can have a test for this situation but I feel like it is really hard to have a failed proxy model as an example.

Best regards,
Zhe  