### PR TITLE
[perf] Restore dynamic `pharmpy.tools` attributes

### DIFF
--- a/src/pharmpy/tools/__init__.py
+++ b/src/pharmpy/tools/__init__.py
@@ -47,3 +47,7 @@ def __getattr__(key):
             _tool_cache[key] = wrap(key[4:])
 
     return _tool_cache[key]
+
+
+def __dir__():
+    return __all__

--- a/src/pharmpy/tools/__init__.py
+++ b/src/pharmpy/tools/__init__.py
@@ -1,15 +1,6 @@
-from .amd.run import run_amd
-from .run import create_results, fit, read_results, retrieve_models, run_tool
-from .wrap import wrap
+from threading import Lock
 
-run_allometry = wrap('allometry')
-run_covsearch = wrap('covsearch')
-run_iivsearch = wrap('iivsearch')
-run_iovsearch = wrap('iovsearch')
-run_modelsearch = wrap('modelsearch')
-run_ruvsearch = wrap('ruvsearch')
-
-__all__ = [
+__all__ = (
     'create_results',
     'fit',
     'read_results',
@@ -22,4 +13,37 @@ __all__ = [
     'run_modelsearch',
     'run_ruvsearch',
     'run_tool',
-]
+)
+
+
+_allowed = set(__all__)
+
+_run_keys = {'create_results', 'fit', 'read_results', 'retrieve_models', 'run_tool'}
+
+_tool_cache = {}
+_tool_lock = Lock()
+
+
+def __getattr__(key):
+    if key not in _allowed:
+        raise AttributeError(key)
+
+    import importlib
+
+    if key == 'run_amd':
+        module = importlib.import_module('.amd.run', __name__)
+        return getattr(module, 'run_amd')
+
+    if key in _run_keys:
+        module = importlib.import_module('.run', __name__)
+        return getattr(module, key)
+
+    assert key[:4] == 'run_'
+
+    with _tool_lock:
+        if key not in _tool_cache:
+            module = importlib.import_module('.wrap', __name__)
+            wrap = getattr(module, 'wrap')
+            _tool_cache[key] = wrap(key[4:])
+
+    return _tool_cache[key]


### PR DESCRIPTION
The definition of `__dir__` was missing in the previous implementation. It broke tab completion and `pharmr` code generation.