### PR TITLE
Do not print significant digits

### DIFF
--- a/src/pharmpy/modeling/results.py
+++ b/src/pharmpy/modeling/results.py
@@ -647,7 +647,6 @@ def rank_models(
             if errors_allowed:
                 if model.modelfit_results.termination_cause not in errors_allowed:
                     continue
-                print(model.modelfit_results.significant_digits)
                 if np.isnan(model.modelfit_results.significant_digits):
                     continue
             else:


### PR DESCRIPTION
Hi Rikard,

@pharmpy-dev-123  and I found the significant digits would be printed after running the tool, e.g. iivsearch, so we thought it should be removed

Best regards,
Zhe 