### PR TITLE
Add function get_rvs_with_same_dist

### DIFF
--- a/src/pharmpy/model/random_variables.py
+++ b/src/pharmpy/model/random_variables.py
@@ -729,6 +729,27 @@ class RandomVariables(Sequence):
                     )
         return newdict
 
+    def get_rvs_with_same_dist(self, rv):
+        """Gets random variables with the same distribution as input random variable
+
+        The resulting RandomVariables objects includes the input random variable.
+
+        Parameters
+        ----------
+        rv : str
+            Name of random variable
+
+        Returns
+        -------
+        RandomVariables
+            RandomVariables object with all distributions as input random variable (including input)
+        """
+        _, dist_input = self._lookup_rv(rv)
+
+        rvs = [dist for dist in self if dist.variance == dist_input.variance]
+
+        return RandomVariables.create(rvs)
+
 
 def _sample_from_distributions(distributions, expr, parameters, nsamples, rng):
     random_variable_symbols = expr.free_symbols.difference(parameters.keys())

--- a/tests/test_random_variables.py
+++ b/tests/test_random_variables.py
@@ -575,3 +575,27 @@ def test_covariance_matrix():
             [0, 0, 0, symbol('OMEGA(2,2)')],
         ]
     )
+
+
+def test_get_rvs_with_same_dist():
+    var1 = symbol('OMEGA(1,1)')
+
+    dist1 = NormalDistribution.create('ETA1', 'iov', 0, var1)
+    dist2 = NormalDistribution.create('ETA2', 'iov', 0, var1)
+    dist3 = NormalDistribution.create('ETA3', 'iov', 0, 1)
+
+    rvs = RandomVariables.create([dist1, dist2, dist3])
+    same_dist = rvs.get_rvs_with_same_dist('ETA1')
+    assert same_dist == RandomVariables.create([dist1, dist2])
+
+    var2 = symbol('OMEGA(2,2)')
+    cov = symbol('OMEGA(1,2)')
+    cov_matrix = [[var1, cov], [cov, var2]]
+
+    dist1 = JointNormalDistribution.create(['ETA1', 'ETA2'], 'iov', [0, 0], cov_matrix)
+    dist2 = JointNormalDistribution.create(['ETA3', 'ETA4'], 'iov', [0, 0], cov_matrix)
+    dist3 = NormalDistribution.create('ETA5', 'iov', 0, var1)
+
+    rvs = RandomVariables.create([dist1, dist2, dist3])
+    same_dist = rvs.get_rvs_with_same_dist('ETA1')
+    assert same_dist == RandomVariables.create([dist1, dist2])


### PR DESCRIPTION
Function to get random variables that have the same variance matrix (relevant for IOVs). Currently includes the input RV in the resulting RVs object. It also looks through all dists, does it make sense to do so or should it only look at IOVs?