### PR TITLE
[dev] Add type checking tox environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,5 @@ include_trailing_comma = true
 
 [tool.pyright]
 venvPath = ".tox"
-venv = "py38"
+venv = "py38-type-check"
+reportUnnecessaryTypeIgnoreComment = true

--- a/src/pharmpy/plugins/nonmem/results_file.py
+++ b/src/pharmpy/plugins/nonmem/results_file.py
@@ -341,8 +341,11 @@ class NONMEMResultsFile:
                 message_trimmed = '\n'.join([m.strip() for m in message_split])
                 errors.append(message_trimmed.strip())
 
-        [self.log.log_warning(message) for message in warnings]
-        [self.log.log_error(message) for message in errors]
+        if self.log is not None:
+            for message in warnings:
+                self.log.log_warning(message)
+            for message in errors:
+                self.log.log_error(message)
 
     def tag_items(self, path):
         nmversion = re.compile(r'1NONLINEAR MIXED EFFECTS MODEL PROGRAM \(NONMEM\) VERSION\s+(\S+)')

--- a/src/pharmpy/tools/__init__.py
+++ b/src/pharmpy/tools/__init__.py
@@ -1,19 +1,19 @@
 from threading import Lock
 
 __all__ = (
-    'create_results',
-    'fit',
-    'read_results',
-    'retrieve_final_model',
-    'retrieve_models',
-    'run_allometry',
-    'run_amd',
-    'run_covsearch',
-    'run_iivsearch',
-    'run_iovsearch',
-    'run_modelsearch',
-    'run_ruvsearch',
-    'run_tool',
+    'create_results',  # pyright: ignore [reportUnsupportedDunderAll]
+    'fit',  # pyright: ignore [reportUnsupportedDunderAll]
+    'read_results',  # pyright: ignore [reportUnsupportedDunderAll]
+    'retrieve_final_model',  # pyright: ignore [reportUnsupportedDunderAll]
+    'retrieve_models',  # pyright: ignore [reportUnsupportedDunderAll]
+    'run_allometry',  # pyright: ignore [reportUnsupportedDunderAll]
+    'run_amd',  # pyright: ignore [reportUnsupportedDunderAll]
+    'run_covsearch',  # pyright: ignore [reportUnsupportedDunderAll]
+    'run_iivsearch',  # pyright: ignore [reportUnsupportedDunderAll]
+    'run_iovsearch',  # pyright: ignore [reportUnsupportedDunderAll]
+    'run_modelsearch',  # pyright: ignore [reportUnsupportedDunderAll]
+    'run_ruvsearch',  # pyright: ignore [reportUnsupportedDunderAll]
+    'run_tool',  # pyright: ignore [reportUnsupportedDunderAll]
 )
 
 

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -155,11 +155,11 @@ def run_amd(
             if subresults.final_model_name != next_model.name:
                 next_model = retrieve_final_model(subresults)
             if hasattr(subresults, 'summary_tool'):
-                sum_tools.append(subresults.summary_tool.reset_index()),
+                sum_tools.append(subresults.summary_tool.reset_index())
             else:
                 sum_tools.append(None)
-            sum_models.append(subresults.summary_models.reset_index()),
-            sum_inds_counts.append(subresults.summary_individuals_count.reset_index()),
+            sum_models.append(subresults.summary_models.reset_index())
+            sum_inds_counts.append(subresults.summary_individuals_count.reset_index())
 
     for sums in [sum_tools, sum_models, sum_inds_counts]:
         filtered_results = list(

--- a/src/pharmpy/tools/estmethod/__init__.py
+++ b/src/pharmpy/tools/estmethod/__init__.py
@@ -2,4 +2,4 @@ from .tool import EstMethodResults, create_workflow
 
 results_class = EstMethodResults
 
-__all__ = [EstMethodResults, 'create_workflow']
+__all__ = ('EstMethodResults', 'create_workflow')

--- a/src/pharmpy/tools/modelfit/__init__.py
+++ b/src/pharmpy/tools/modelfit/__init__.py
@@ -25,4 +25,4 @@ class ModelfitConfiguration(config.Configuration):
 conf = ModelfitConfiguration()
 
 
-__all__ = [create_workflow, create_fit_workflow]
+__all__ = ('create_workflow', 'create_fit_workflow')

--- a/tox.ini
+++ b/tox.ini
@@ -140,6 +140,13 @@ commands =
     src tests setup.py
     bash scripts/lint_deps_imports.sh
 
+[testenv:{py38-,py39-,py310-,}{type-check}]
+deps =
+    -rrequirements.txt
+    pyright
+commands =
+    pyright src/pharmpy
+
 [testenv:{py38-,py39-,py310-,}report]
 deps = coverage
 commands =


### PR DESCRIPTION
The new environment can be used as `tox -e py38-type-check`.