### PR TITLE
Return empty results when base proxy model fail in each iteration (fixes #1179)

### DIFF
--- a/src/pharmpy/tools/ruvsearch/results.py
+++ b/src/pharmpy/tools/ruvsearch/results.py
@@ -36,7 +36,12 @@ def calculate_results(models):
     for iteration in range(min(iterations), max(iterations) + 1):
         base_index = names.index(f'base_{iteration}')
         base_model = models[base_index]
-        base_ofv = base_model.modelfit_results.ofv
+        if base_model.modelfit_results is not None and base_model.modelfit_results.ofv is not None:
+            base_ofv = base_model.modelfit_results.ofv
+        else:
+            warnings.warn(f'base CWRES model of iteration {iteration} failed.')
+            res = RUVSearchResults()
+            return res
 
         iteration_models = [
             model


### PR DESCRIPTION
Hi Rikard, 

This PR is to solve the problem: ruvsearch terminated due to base CWRES model failure. I implemented the easiest way (I thought ) to solve it. But I am not sure if it is suitable or not. I couldn't add a test for it because I didn't have models for this situation. 

Best regards,
Zhe