### PR TITLE
Add documentation about cwres_models in ruvsearch

### DIFF
--- a/docs/ruvsearch.rst
+++ b/docs/ruvsearch.rst
@@ -112,8 +112,8 @@ Selection is done using the likelihood ratio test and a default p-value of 0.05.
 The RUVsearch results
 ~~~~~~~~~~~~~~~~~~~~~
 
-The results object contains the candidate models, the start model, and the selected best model (based on the input
-selection criteria). The tool also creates various summary tables which can be accessed in the results object,
+The results object contains the start model, the residual error models based on the conditional weighted residual(CWRES) of the start model,
+the candidate models, and the selected best model (based on the input selection criteria). The tool also creates various summary tables which can be accessed in the results object,
 as well as files in .csv/.json format.
 
 Consider a standard ruvsearch run:
@@ -122,14 +122,21 @@ Consider a standard ruvsearch run:
 
     res = run_ruvsearch(model=start_model)
 
-The ``summary_tool`` table contains information such as which feature each model candidate has, the difference to the
-start model, and final ranking:
+The ``cwres_models`` table contains information on the residual error models, such as the iteration times, the changes of OFV compared to the base CWRES model and some key parameter estimates.
 
 .. pharmpy-execute::
     :hide-code:
 
     from pharmpy.results import read_results
     res = read_results('tests/testdata/results/resmod_results.json')
+    res.cwres_models
+
+The ``summary_tool`` table contains information such as which feature each model candidate has, the difference to the
+start model, and final ranking:
+
+.. pharmpy-execute::
+    :hide-code:
+
     res.summary_tool
 
 


### PR DESCRIPTION
Hi Rikard,

This PR is to add documentation about the cwres_models in ruvsearch, so that users can distinguish between CWRES models and NLME models.

Best regards,
Zhe