### PR TITLE
[deps] Exclude pywin32 versions 301 and 304 because of incompatibilities with conda

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -78,6 +78,7 @@ pyreadr==0.4.7
 pyrsistent==0.18.1
 python-dateutil==2.8.2
 pytz==2022.4
+pywin32!=301,!=304; sys_platform == 'win32' and platform_python_implementation != 'PyPy'
 PyYAML==6.0
 pyzmq==24.0.1
 requests==2.28.1


### PR DESCRIPTION
Q: How do we ensure this is not reverted by dependabot?