### PR TITLE
Set zero_protection=True as default in set_proportional_error_model (fixes #969)

### DIFF
--- a/src/pharmpy/modeling/error.py
+++ b/src/pharmpy/modeling/error.py
@@ -162,7 +162,7 @@ def _get_prop_init(model):
         return (dv_min / 2) ** 2
 
 
-def set_proportional_error_model(model, data_trans=None, zero_protection=False):
+def set_proportional_error_model(model, data_trans=None, zero_protection=True):
     r"""Set a proportional error model. Initial estimate for new sigma is 0.09.
 
     The error function being applied depends on the data transformation.
@@ -196,14 +196,26 @@ def set_proportional_error_model(model, data_trans=None, zero_protection=False):
     >>> model = remove_error_model(load_example_model("pheno"))
     >>> set_proportional_error_model(model)    # doctest: +ELLIPSIS
     <...>
-    >>> model.statements.find_assignment("Y")
-    Y = F⋅εₚ + F
+    >>> model.statements.after_odes
+        A_CENTRAL
+        ─────────
+    F =     S₁
+    W = F
+               ⎧2.225e-16  for F = 0
+               ⎨
+    IPREDADJ = ⎩    F      otherwise
+    Y = F + IPREDADJ⋅εₚ
+    IPRED = F
+    IRES = DV - IPRED
+            IRES
+            ────
+    IWRES =  W
 
     >>> from pharmpy.modeling import *
     >>> model = remove_error_model(load_example_model("pheno"))
     >>> set_proportional_error_model(
     ...     model,
-    ...     data_trans="log(Y)", zero_protection=True
+    ...     data_trans="log(Y)"
     ... )    # doctest: +ELLIPSIS
     <...>
     >>> model.statements.after_odes

--- a/src/pharmpy/tools/amd/funcs.py
+++ b/src/pharmpy/tools/amd/funcs.py
@@ -86,7 +86,7 @@ def create_start_model(dataset_path, modeltype='pk_oral', cl_init=0.01, vc_init=
     model.estimation_steps = eststeps
     model.filename_extension = '.mod'  # Should this really be needed?
 
-    set_proportional_error_model(model, zero_protection=True)
+    set_proportional_error_model(model)
     create_joint_distribution(
         model,
         [eta_cl_name, eta_vc_name],

--- a/tests/modeling/test_error.py
+++ b/tests/modeling/test_error.py
@@ -43,12 +43,12 @@ def test_set_additive_error_model_logdv(testdata, load_model_for_test):
 def test_set_proportional_error_model_nolog(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     model.statements = model.statements[0:5] + Assignment.create('Y', 'F') + model.statements[6:]
-    set_proportional_error_model(model, zero_protection=True)
+    set_proportional_error_model(model)
     assert model.model_code.split('\n')[16] == 'Y = F + EPS(1)*IPREDADJ'
     assert model.model_code.split('\n')[22] == '$SIGMA  0.09 ; sigma'
 
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    set_proportional_error_model(model)
+    set_proportional_error_model(model, zero_protection=False)
     assert model.model_code.split('\n')[11] == 'Y=F+F*EPS(1)'
     assert model.model_code.split('\n')[17] == '$SIGMA 0.013241'
 
@@ -56,7 +56,7 @@ def test_set_proportional_error_model_nolog(load_model_for_test, testdata):
 def test_set_proportional_error_model_log(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     model.statements = model.statements[0:5] + Assignment.create('Y', 'F') + model.statements[6:]
-    set_proportional_error_model(model, data_trans='log(Y)', zero_protection=True)
+    set_proportional_error_model(model, data_trans='log(Y)')
     correct = """$PROBLEM PHENOBARB SIMPLE MODEL
 $DATA pheno.dta IGNORE=@
 $INPUT ID TIME AMT WGT APGR DV


### PR DESCRIPTION
Hi Rikard, 

This PR is to fix #969 by setting zero_protection = True as default.

Best regards,
Zhe 