### PR TITLE
[deps] Upgrade pandas to 1.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ notebook==6.5.1
 numexpr==2.8.3
 numpy==1.23.4
 packaging==21.3
-pandas==1.4.4
+pandas==1.5.0
 pandocfilters==1.5.0
 parso==0.8.3
 partd==1.3.0

--- a/src/pharmpy/math.py
+++ b/src/pharmpy/math.py
@@ -56,7 +56,7 @@ def round_and_keep_sum(x, s):
     """
     sorted_fractions = x.apply(lambda x: math.modf(x)[0]).sort_values(ascending=False)
     rounded_sample_sizes = x.apply(lambda x: math.modf(x)[1])
-    for (group_index, _) in sorted_fractions.iteritems():
+    for (group_index, _) in sorted_fractions.items():
         num_samples = rounded_sample_sizes.sum()
         diff = s - num_samples
         if diff == 0:

--- a/src/pharmpy/model/results.py
+++ b/src/pharmpy/model/results.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from lzma import open as lzma_open
 from pathlib import Path
 from typing import Any, Dict
@@ -165,7 +166,14 @@ class ResultsJSONEncoder(json.JSONEncoder):
             d['__class__'] = 'Series'
             return d
         elif obj.__class__.__module__.startswith('altair.'):
-            d = obj.to_dict()
+            with warnings.catch_warnings():
+                # FIXME Remove filter once altair stops relying on deprecated APIs
+                warnings.filterwarnings(
+                    "ignore",
+                    message=".*iteritems is deprecated and will be removed in a future version. Use .items instead.",
+                    category=FutureWarning,
+                )
+                d = obj.to_dict()
             d['__class__'] = 'vega-lite'
             return d
         elif isinstance(obj, Model):

--- a/src/pharmpy/modeling/data.py
+++ b/src/pharmpy/modeling/data.py
@@ -621,7 +621,7 @@ def expand_additional_doses(model, flag=False):
     df = df.apply(fn, axis=1)
     df = df.apply(lambda x: x.explode() if x.name in ['_TIMES', '_EXPANDED'] else x)
     df = df.astype({'_EXPANDED': np.bool_})
-    df = df.groupby([idcol, '_RESETGROUP']).apply(
+    df = df.groupby([idcol, '_RESETGROUP'], group_keys=False).apply(
         lambda x: x.sort_values(by='_TIMES', kind='stable')
     )
     df[idv] = df['_TIMES']
@@ -900,7 +900,7 @@ def add_time_after_dose(model):
                     df.loc[i, 'TAD'] = ii_time
             return df
 
-        df = df.groupby([idlab, idv, '_DOSEID']).apply(fn)
+        df = df.groupby([idlab, idv, '_DOSEID'], group_keys=False).apply(fn)
 
     df.drop(columns=['_NEWTIME', '_DOSEID'], inplace=True)
 

--- a/src/pharmpy/tools/qa/results.py
+++ b/src/pharmpy/tools/qa/results.py
@@ -114,7 +114,7 @@ def outliers(simeval_res, cdd_res):
     cases.reset_index(inplace=True)
     cases.set_index('skipped_individuals', inplace=True)
     dofv = cases.loc[outliers].delta_ofv
-    top_three = dofv.sort_values(ascending=False)[:3]
+    top_three = dofv.sort_values(ascending=False).iloc[:3]
     dofv_tab = pd.DataFrame(
         {
             'section': ['outliers'] * len(top_three),

--- a/src/pharmpy/tools/scm/results.py
+++ b/src/pharmpy/tools/scm/results.py
@@ -57,7 +57,9 @@ def candidate_summary_dataframe(steps):
             ],
             index=forward_steps.index,
         )
-        return df.groupby(level=['parameter', 'covariate', 'extended_state']).sum(min_count=1)
+        return df.groupby(level=['parameter', 'covariate', 'extended_state']).sum(
+            numeric_only=True, min_count=1
+        )
 
 
 def ofv_summary_dataframe(steps, final_included=True, iterations=True):


### PR DESCRIPTION
Needed some changes due to FutureWarnings. Some could be fixed, others had to be filtered out because of upstream usage in altair.

Note that all changes are compatible with the current `setup.py` constraint on `pandas` (`>=1.4`).

Replaces #1177. Fixes #1223.