### PR TITLE
Add kwargs to tool wrappers

### DIFF
--- a/tests/tools/test_wrap.py
+++ b/tests/tools/test_wrap.py
@@ -8,6 +8,8 @@ def _is_iivsearch(obj):
     assert 'algorithm' in params.keys()
     assert 'rank_type' in params.keys()
     assert params['rank_type'].default == 'bic'
+    assert 'kwargs' in params.keys()
+    assert 'kwargs' in obj.__doc__
     return True
 
 
@@ -16,6 +18,8 @@ def _is_modelsearch(obj):
     assert 'search_space' in params.keys()
     assert 'rank_type' in params.keys()
     assert params['rank_type'].default == 'bic'
+    assert 'kwargs' in params.keys()
+    assert 'kwargs' in obj.__doc__
     return True
 
 


### PR DESCRIPTION
Appends `kwargs` to wrapper signature, needed in order for pharmr to add the R equivalence of `kwargs`.