### PR TITLE
[fix] Make dataset deduplication independent of Python's hash seed

### DIFF
--- a/src/pharmpy/internals/df.py
+++ b/src/pharmpy/internals/df.py
@@ -1,6 +1,31 @@
+from __future__ import annotations
+
+from hashlib import sha256
+from typing import Iterator, Union
+
 from pharmpy.deps import pandas as pd
 
 
-def hash_df(df) -> int:
-    values = pd.util.hash_pandas_object(df, index=True).values
-    return hash(tuple(values))
+def _pd_hash_values(obj: Union[pd.Index, pd.Series, pd.DataFrame]) -> pd.Series:
+    # NOTE We explicit all arguments for future-proofing
+    return pd.util.hash_pandas_object(
+        obj, index=False, encoding='utf8', hash_key='0123456789123456', categorize=True
+    )
+
+
+def _df_hash_values(df: pd.DataFrame) -> Iterator[pd.Series]:
+    yield _pd_hash_values(df.columns)
+    yield _pd_hash_values(df.index)
+    yield _pd_hash_values(df.dtypes)
+    yield _pd_hash_values(df)
+
+
+def hash_df_runtime(df: pd.DataFrame) -> int:
+    return hash(tuple(map(lambda series: tuple(series.values), _df_hash_values(df))))
+
+
+def hash_df_fs(df: pd.DataFrame) -> str:
+    h = sha256()
+    for series in _df_hash_values(df):
+        h.update(series.to_numpy())
+    return h.hexdigest()

--- a/src/pharmpy/workflows/model_database/local_directory.py
+++ b/src/pharmpy/workflows/model_database/local_directory.py
@@ -5,7 +5,7 @@ from os import stat
 from pathlib import Path
 from typing import Union
 
-from pharmpy.internals.df import hash_df
+from pharmpy.internals.df import hash_df_fs
 from pharmpy.internals.fs.lock import path_lock
 from pharmpy.internals.fs.path import path_absolute
 from pharmpy.model import DataInfo, Model
@@ -206,8 +206,8 @@ class LocalModelDirectoryDatabaseTransaction(ModelTransaction):
 
         # NOTE Get the hash of the dataset and list filenames with contents
         # matching this hash only
-        h = hash_df(model.dataset)
-        h_dir = datasets_path / DIRECTORY_INDEX / str(h)
+        h = hash_df_fs(model.dataset)
+        h_dir = datasets_path / DIRECTORY_INDEX / h
         h_dir.mkdir(parents=True, exist_ok=True)
         for hpath in h_dir.iterdir():
             # NOTE This variable holds a string similar to "run1.csv"


### PR DESCRIPTION
This implementation takes data, dtypes, columns, and index into account for hash computation.