### PR TITLE
[feature] Error and warn early on invalid or missing covariates in `run_amd`

### DIFF
--- a/src/pharmpy/modeling/covariate_effect.py
+++ b/src/pharmpy/modeling/covariate_effect.py
@@ -6,7 +6,7 @@ import math
 import re
 import warnings
 from operator import add, mul
-from typing import List, Literal, Union
+from typing import List, Literal, Set, Union
 
 from pharmpy.deps import numpy as np
 from pharmpy.deps import sympy
@@ -633,3 +633,17 @@ class CovariateEffect:
     def __str__(self):
         """String representation of class."""
         return str(self.template)
+
+
+def get_covariates_allowed_in_covariate_effect(model: Model) -> Set[str]:
+    try:
+        di_covariate = model.datainfo.typeix['covariate'].names
+    except IndexError:
+        di_covariate = []
+
+    try:
+        di_unknown = model.datainfo.typeix['unknown'].names
+    except IndexError:
+        di_unknown = []
+
+    return set(di_covariate).union(di_unknown)

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -280,7 +280,7 @@ def noop_subfunc(_: Model):
     return None
 
 
-def _subfunc_modelsearch(search_space: Tuple[Statement], path) -> SubFunc:
+def _subfunc_modelsearch(search_space: Tuple[Statement, ...], path) -> SubFunc:
     def _run_modelsearch(model):
         res = run_tool(
             'modelsearch',

--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -9,6 +9,7 @@ from pharmpy.internals.fn.signature import with_same_arguments_as
 from pharmpy.internals.fn.type import with_runtime_arguments_type_check
 from pharmpy.model import Model
 from pharmpy.modeling import add_covariate_effect, copy_model, get_pk_parameters
+from pharmpy.modeling.covariate_effect import get_covariates_allowed_in_covariate_effect
 from pharmpy.modeling.lrt import best_of_many as lrt_best_of_many
 from pharmpy.modeling.lrt import p_value as lrt_p_value
 from pharmpy.modeling.lrt import test as lrt_test
@@ -575,17 +576,7 @@ def validate_input(effects, p_forward, p_backward, algorithm, model):
 
         candidate_effects = map(lambda x: Effect(*x), sorted(set(parse_spec(effect_spec))))
 
-        try:
-            di_covariate = model.datainfo.typeix['covariate'].names
-        except IndexError:
-            di_covariate = []
-
-        try:
-            di_unknown = model.datainfo.typeix['unknown'].names
-        except IndexError:
-            di_unknown = []
-
-        allowed_covariates = set(di_covariate).union(di_unknown)
+        allowed_covariates = get_covariates_allowed_in_covariate_effect(model)
         allowed_parameters = set(get_pk_parameters(model)).union(
             str(statement.symbol) for statement in model.statements.before_odes
         )

--- a/tests/tools/test_amd.py
+++ b/tests/tools/test_amd.py
@@ -30,6 +30,7 @@ def test_skip_most(tmp_path, testdata):
             record,
             [
                 'IOVsearch will be skipped because occasion is None',
+                'COVsearch will most likely be skipped',
                 'Skipping Allometry',
                 'Skipping COVsearch',
                 'AMDResults.summary_models is None',
@@ -61,6 +62,7 @@ def test_skip_covsearch(tmp_path, testdata):
         _validate_record(
             record,
             [
+                'COVsearch will most likely be skipped',
                 'NONMEM .mod and dataset .datainfo disagree on DROP',
                 'NONMEM .mod and dataset .datainfo disagree on DROP',
                 'Skipping COVsearch',

--- a/tests/tools/test_amd.py
+++ b/tests/tools/test_amd.py
@@ -44,6 +44,25 @@ def test_skip_most(tmp_path, testdata):
         assert res.final_model == 'start'
 
 
+def test_raise_covsearch(tmp_path, testdata):
+    with chdir(tmp_path):
+        db, model = _load_model(testdata, with_datainfo=True)
+
+        with pytest.raises(
+            ValueError,
+            match='Invalid `search_space` because of invalid covariate .* got `SJDLKSDJ`',
+        ):
+            run_amd(
+                model,
+                results=model.modelfit_results,
+                search_space='LET(CONTINUOUS, [AGE, SJDLKSDJ]); LET(CATEGORICAL, [SEX])',
+                modeltype='pk_oral',
+                order=['covariates'],
+                path=db.path,
+                resume=True,
+            )
+
+
 def test_skip_covsearch(tmp_path, testdata):
     with chdir(tmp_path):
         db, model = _load_model(testdata, with_datainfo=True)


### PR DESCRIPTION
> @rikardn Ready to MERGE

These changes make `run_amd` error on covariates missing from the `model.datainfo` and warn when `covsearch` is planned for execution but no covariates could be derived from the `search_space`.

  - [x] Fixes #1355 by erroring early, while https://github.com/pharmpy/pharmr/issues/105 will attack the problem from another angle by allowing passing in a single element vector.
  - [x] It also fixes the problem more generally in case someone includes an invalid covariate in the search space independently of the `reticulate` issue.
  - [x] Integration tests: https://github.com/pharmpy-dev-123/pharmpy/actions/workflows/integration.yml?query=branch%3Afeature-tool-amd-error-early-on-invalid-covariates