### PR TITLE
[feature] Add stdout and stderr keys to plugin-specific metadata

### DIFF
--- a/src/pharmpy/plugins/nlmixr/model.py
+++ b/src/pharmpy/plugins/nlmixr/model.py
@@ -288,6 +288,8 @@ def execute_model(model, db):
             {
                 'args': args,
                 'returncode': result.returncode,
+                'stdout': 'stdout',
+                'stderr': 'stderr',
             }
         ],
     }

--- a/src/pharmpy/plugins/nonmem/run.py
+++ b/src/pharmpy/plugins/nonmem/run.py
@@ -99,6 +99,8 @@ def execute_model(model, db):
             {
                 'args': args,
                 'returncode': result.returncode,
+                'stdout': 'stdout',
+                'stderr': 'stderr',
             }
         ]
     }


### PR DESCRIPTION
> @rikardn Ready to MERGE

This is a very small addition to allow a generic access to `stdout` and `stderr` via the plugin metadata. In the future, this would allow, for instance, to create a plugin that spawn multiple subprocesses and still make sense of the captured outputs in a generic way.