### PR TITLE
[feature] Error early on invalid occasion in `run_amd`

### DIFF
--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -164,7 +164,7 @@ def run_amd(
             func = _subfunc_iiv(path=db.path)
             run_subfuncs['iivsearch'] = func
         elif section == 'iovsearch':
-            func = _subfunc_iov(occasion=occasion, path=db.path)
+            func = _subfunc_iov(amd_start_model=model, occasion=occasion, path=db.path)
             run_subfuncs['iovsearch'] = func
         elif section == 'residual':
             func = _subfunc_ruvsearch(path=db.path)
@@ -365,15 +365,20 @@ def _subfunc_allometry(allometric_variable, path) -> SubFunc:
     return _run_allometry
 
 
-def _subfunc_iov(occasion, path) -> SubFunc:
+def _subfunc_iov(amd_start_model, occasion, path) -> SubFunc:
     if occasion is None:
         warnings.warn('IOVsearch will be skipped because occasion is None.')
         return noop_subfunc
 
+    if occasion not in amd_start_model.dataset:
+        raise ValueError(
+            f'Invalid `occasion`: got `{occasion}`,'
+            f' must be one of {sorted(amd_start_model.datainfo.names)}.'
+        )
+
     def _run_iov(model):
 
         if occasion not in model.dataset:
-            # TODO Check this upstream and raise instead of warn
             warnings.warn(f'Skipping IOVsearch because dataset is missing column "{occasion}".')
             return None
 

--- a/tests/tools/test_amd.py
+++ b/tests/tools/test_amd.py
@@ -105,12 +105,15 @@ def test_skip_iovsearch_one_occasion(tmp_path, testdata):
         assert res.final_model == 'start'
 
 
-def test_skip_iovsearch_missing_occasion(tmp_path, testdata):
+def test_skip_iovsearch_missing_occasion_raises(tmp_path, testdata):
     with chdir(tmp_path):
         db, model = _load_model(testdata)
 
-        with _record_warnings() as record:
-            res = run_amd(
+        with pytest.raises(
+            ValueError,
+            match='Invalid `occasion`',
+        ):
+            run_amd(
                 model,
                 results=model.modelfit_results,
                 modeltype='pk_oral',
@@ -119,20 +122,6 @@ def test_skip_iovsearch_missing_occasion(tmp_path, testdata):
                 path=db.path,
                 resume=True,
             )
-
-        _validate_record(
-            record,
-            [
-                'Skipping IOVsearch because dataset is missing column "XYZ"',
-                'AMDResults.summary_models is None',
-                'AMDResults.summary_individuals_count is None',
-            ],
-        )
-
-        assert len(res.summary_tool) == 1
-        assert res.summary_models is None
-        assert res.summary_individuals_count is None
-        assert res.final_model == 'start'
 
 
 def _load_model(testdata: Path, with_datainfo: bool = False):


### PR DESCRIPTION
> @rikardn Ready to MERGE

Since we do not change the dataset during AMD, we can check this upfront.

  - [x] Integration tests: https://github.com/pharmpy-dev-123/pharmpy/actions/workflows/integration.yml?query=branch%3Afeature-tool-amd-error-early-on-invalid-iovsearch