### PR TITLE
[feature] Clarify error message when `search_space` cannot be parsed in `run_amd`

### DIFF
--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -119,7 +119,10 @@ def run_amd(
     if order is None:
         order = default_order
 
-    input_search_space_features = [] if search_space is None else mfl_parse(search_space)
+    try:
+        input_search_space_features = [] if search_space is None else mfl_parse(search_space)
+    except:  # noqa E722
+        raise ValueError(f'Invalid `search_space`, could not be parsed: "{search_space}"')
 
     modelsearch_features = tuple(
         filter(

--- a/tests/tools/test_amd.py
+++ b/tests/tools/test_amd.py
@@ -11,6 +11,23 @@ from pharmpy.tools import run_amd
 from pharmpy.workflows import default_tool_database
 
 
+def test_invalid_search_space_raises(tmp_path, testdata):
+    with chdir(tmp_path):
+        db, model = _load_model(testdata)
+
+        with pytest.raises(
+            ValueError,
+            match='Invalid `search_space`, could not be parsed:',
+        ):
+            run_amd(
+                model,
+                results=model.modelfit_results,
+                search_space='XYZ',
+                path=db.path,
+                resume=True,
+            )
+
+
 def test_skip_most(tmp_path, testdata):
     with chdir(tmp_path):
         db, model = _load_model(testdata)


### PR DESCRIPTION
> @rikardn Ready to MERGE

  - [x] Integration tests: https://github.com/pharmpy-dev-123/pharmpy/actions/workflows/integration.yml?query=branch%3Afeature-tool-amd-error-early-on-invalid-search-space