### PR TITLE
[fix] Correct model selection in COVsearch

### DIFF
--- a/src/pharmpy/modeling/lrt.py
+++ b/src/pharmpy/modeling/lrt.py
@@ -38,5 +38,11 @@ def best_of_two(parent: Model, child: Model, parent_ofv, child_ofv, alpha: float
 def best_of_many(
     parent: Model, models: Iterable[Model], parent_ofv, model_ofvs, alpha: float
 ) -> Model:
-    best_index = np.argmax(model_ofvs)
+    # NOTE numpy.nanargmin ignores NaN values and raises a ValueError when all
+    # values are NaN.
+    # See https://numpy.org/doc/stable/reference/generated/numpy.nanargmin.html
+    try:
+        best_index = np.nanargmin(model_ofvs)
+    except ValueError:
+        return parent
     return best_of_two(parent, list(models)[best_index], parent_ofv, model_ofvs[best_index], alpha)

--- a/tests/modeling/test_lrt.py
+++ b/tests/modeling/test_lrt.py
@@ -1,0 +1,160 @@
+import numpy as np
+import pytest
+
+from pharmpy.modeling import add_allometry, add_covariate_effect
+from pharmpy.modeling.lrt import best_of_many, best_of_two, cutoff, degrees_of_freedom, p_value
+from pharmpy.modeling.lrt import test as lrt_test
+
+
+@pytest.mark.parametrize(
+    ('model_path', 'effects', 'expected', 'allow_nested'),
+    [
+        (
+            ('nonmem', 'pheno.mod'),
+            [],
+            0,
+            False,
+        ),
+        (
+            ('nonmem', 'pheno.mod'),
+            [('CL', 'WGT', 'exp', '*')],
+            1,
+            False,
+        ),
+        (
+            ('nonmem', 'pheno.mod'),
+            [('CL', 'APGR', 'cat', '*')],
+            9,
+            False,
+        ),
+        (
+            ('nonmem', 'pheno_real.mod'),
+            [('CL', 'WGT', 'piece_lin', '*')],
+            2,
+            True,
+        ),
+        (
+            ('nonmem', 'pheno_real.mod'),
+            [('CL', 'WGT', 'theta1 * (cov/median)**theta2', '*')],
+            2,
+            True,
+        ),
+        (
+            ('nonmem', 'pheno_real.mod'),
+            [('CL', 'WGT', '((cov/std) - median) * theta', '*')],
+            1,
+            True,
+        ),
+        (
+            ('nonmem', 'pheno_real.mod'),
+            [
+                ('CL', 'WGT', 'exp', '+'),
+                ('V', 'WGT', 'exp', '+'),
+            ],
+            2,
+            True,
+        ),
+    ],
+    ids=repr,
+)
+def test_degrees_of_freedom(
+    load_model_for_test, testdata, model_path, effects, expected, allow_nested
+):
+    parent = load_model_for_test(testdata.joinpath(*model_path))
+    child = parent.copy()
+
+    for effect in effects:
+        add_covariate_effect(child, *effect, allow_nested=allow_nested)
+
+    assert degrees_of_freedom(parent, child) == expected
+
+
+def test_cutoff(load_model_for_test, testdata):
+    parent = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    assert cutoff(parent, parent, 0.05) == 0
+
+    child = parent.copy()
+
+    add_allometry(
+        child,
+        allometric_variable='WGT',
+        reference_value=70,
+        parameters=['CL'],
+        initials=[0.7],
+        lower_bounds=[0],
+        upper_bounds=[2],
+        fixed=True,
+    )
+
+    assert cutoff(parent, child, 0.05) == pytest.approx(3.8414588206941285)
+    assert cutoff(child, parent, 0.05) == -cutoff(parent, child, 0.05)
+
+
+def test_p_value(load_model_for_test, testdata):
+    parent = load_model_for_test(testdata / 'nonmem' / 'pheno_abbr.mod')
+    child = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
+
+    alpha = 0.05
+    parent_ofv = 10
+    child_ofv = parent_ofv - cutoff(parent, child, alpha)
+
+    assert p_value(parent, child, parent_ofv, child_ofv) == pytest.approx(alpha)
+
+
+def test_test(load_model_for_test, testdata):
+    parent = load_model_for_test(testdata / 'nonmem' / 'pheno_abbr.mod')
+    child = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
+
+    alpha = 0.05
+    parent_ofv = 10
+    child_ofv = parent_ofv - cutoff(parent, child, alpha) - 0.01
+
+    assert lrt_test(parent, child, parent_ofv, child_ofv, alpha)
+
+
+def test_best_of_two(load_model_for_test, testdata):
+    parent = load_model_for_test(testdata / 'nonmem' / 'pheno_abbr.mod')
+    child = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
+
+    alpha = 0.05
+    parent_ofv = 10
+    child_ofv = parent_ofv - cutoff(parent, child, alpha) - 0.01
+
+    assert best_of_two(parent, child, parent_ofv, child_ofv, alpha) is child
+
+
+def test_best_of_many(load_model_for_test, testdata):
+    parent = load_model_for_test(testdata / 'nonmem' / 'pheno_abbr.mod')
+    child = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
+
+    alpha = 0.05
+    parent_ofv = 10
+    child_ofv = parent_ofv - cutoff(parent, child, alpha) - 0.01
+
+    assert (
+        best_of_many(parent, [parent, child], parent_ofv, [parent_ofv, child_ofv], alpha) is child
+    )
+
+
+def test_best_of_many_nan(load_model_for_test, testdata):
+    parent = load_model_for_test(testdata / 'nonmem' / 'pheno_abbr.mod')
+    child = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
+
+    alpha = 0.05
+    parent_ofv = 10
+    child_ofv = parent_ofv - cutoff(parent, child, alpha) - 0.01
+
+    assert (
+        best_of_many(parent, [child, child, child], parent_ofv, [np.nan, np.nan, np.nan], alpha)
+        is parent
+    )
+    assert (
+        best_of_many(parent, [child, child, child], parent_ofv, [np.nan, child_ofv, np.nan], alpha)
+        is child
+    )
+    assert (
+        best_of_many(
+            parent, [child, child, child], parent_ofv, [np.nan, child_ofv + 0.02, np.nan], alpha
+        )
+        is parent
+    )


### PR DESCRIPTION
Two problems are fixed:
  - [x] A typo was the cause for selection of the maximum OFV instead of minimum OFV. We replaced `np.argmax` by `np.argmin`. Fixes #1377.
  - [x] Models with `NaN` ofvs were not ignored. We replaced `np.argmin` by `np.nanargmin`. Fixes #1381.
  - [x] Integation tests: https://github.com/pharmpy-dev-123/pharmpy/actions/workflows/integration.yml?query=branch%3Afix-tool-covsearch-model-selection-1

The next step would be to integrate the NONMEM error filtering that was already implemented in tool summaries.