### PR TITLE
Verification of conversion from nonmem to nlmixr2

### DIFF
--- a/src/pharmpy/modeling/write_csv.py
+++ b/src/pharmpy/modeling/write_csv.py
@@ -51,6 +51,10 @@ def write_csv(model: Model, path: Optional[Union[str, Path]] = None, force: bool
         raise FileExistsError(f'File at {path} already exists.')
 
     path = path_absolute(path)
-    model.dataset.to_csv(path, na_rep=data.conf.na_rep, index=False)
+    if "nlmixr" in str(type(model)):
+    	model.dataset.columns = model.dataset.columns.str.lower()
+    	model.dataset.to_csv(path, na_rep=data.conf.na_rep, index=False)
+    else: 
+    	model.dataset.to_csv(path, na_rep=data.conf.na_rep, index=False)
     model.datainfo = model.datainfo.replace(path=path)
     return path

--- a/src/pharmpy/modeling/write_csv.py
+++ b/src/pharmpy/modeling/write_csv.py
@@ -52,8 +52,10 @@ def write_csv(model: Model, path: Optional[Union[str, Path]] = None, force: bool
 
     path = path_absolute(path)
     if "nlmixr" in str(type(model)):
-    	model.dataset.columns = model.dataset.columns.str.lower()
-    	model.dataset.to_csv(path, na_rep=data.conf.na_rep, index=False)
+        model.dataset.columns = model.dataset.columns.str.lower()
+        if "evid" not in model.dataset.columns:
+            model.dataset["evid"] = [1 if x == 0 else 0 for x in model.dataset["dv"]]
+        model.dataset.to_csv(path, na_rep=data.conf.na_rep, index=False)
     else: 
     	model.dataset.to_csv(path, na_rep=data.conf.na_rep, index=False)
     model.datainfo = model.datainfo.replace(path=path)

--- a/src/pharmpy/modeling/write_csv.py
+++ b/src/pharmpy/modeling/write_csv.py
@@ -51,12 +51,6 @@ def write_csv(model: Model, path: Optional[Union[str, Path]] = None, force: bool
         raise FileExistsError(f'File at {path} already exists.')
 
     path = path_absolute(path)
-    if "nlmixr" in str(type(model)):
-        model.dataset.columns = model.dataset.columns.str.lower()
-        if "evid" not in model.dataset.columns:
-            model.dataset["evid"] = [1 if x == 0 else 0 for x in model.dataset["dv"]]
-        model.dataset.to_csv(path, na_rep=data.conf.na_rep, index=False)
-    else: 
-    	model.dataset.to_csv(path, na_rep=data.conf.na_rep, index=False)
+    model.dataset.to_csv(path, na_rep=data.conf.na_rep, index=False)
     model.datainfo = model.datainfo.replace(path=path)
     return path

--- a/src/pharmpy/plugins/nlmixr/model.py
+++ b/src/pharmpy/plugins/nlmixr/model.py
@@ -79,6 +79,7 @@ class ExpressionPrinter(sympy_printing.str.StrPrinter):
 def create_dataset(cg, model, path=None):
     """Create dataset for nlmixr"""
     dataname = f'{model.name}.csv'
+    #TODO lower case for time and amt
     if path is None:
         path = ""
     path = Path(path) / dataname
@@ -163,7 +164,10 @@ def create_model(cg, model):
 
 def create_fit(cg, model):
     """Create the call to fit"""
-    cg.add(f'fit <- nlmixr({model.name}, dataset, "focei")')
+    if [s.evaluation for s in model.estimation_steps._steps][0] == False:
+        cg.add(f'fit <- nlmixr2({model.name}, dataset, "focei")')
+    else:
+        cg.add(f'fit <- nlmixr2({model.name}, dataset, "posthoc")')
 
 
 @dataclass
@@ -178,7 +182,7 @@ class Model(pharmpy.model.Model):
 
     def update_source(self, path=None):
         cg = CodeGenerator()
-        cg.add('library(nlmixr)')
+        cg.add('library(nlmixr2)')
         cg.empty_line()
         create_dataset(cg, self, path)
         cg.empty_line()

--- a/src/pharmpy/plugins/nlmixr/model.py
+++ b/src/pharmpy/plugins/nlmixr/model.py
@@ -262,7 +262,7 @@ def execute_model(model, db):
     # TODO add the variables from fit holding the predicted values as well
     # --> Could be in a dataframe with all predicted values and the time / id
     # FIXME the path variable cannot be handled by R so the code does not work here
-    cg.add(f'save(file="{path}\{model.name}.RDATA", ofv, thetas, omega, sigma)')
+    cg.add(f'save(file="{path}/{model.name}.RDATA", ofv, thetas, omega, sigma)')
     code += f'\n{str(cg)}'
     with open(path / f'{model.name}.R', 'w') as fh:
         fh.write(code)

--- a/src/pharmpy/plugins/nlmixr/model.py
+++ b/src/pharmpy/plugins/nlmixr/model.py
@@ -11,12 +11,16 @@ import pharmpy.model
 from pharmpy.deps import pandas as pd
 from pharmpy.deps import sympy, sympy_printing
 from pharmpy.model import Assignment
-from pharmpy.modeling import write_csv
+from pharmpy.modeling import (
+    get_evid,
+    get_sigmas,
+    get_thetas,
+    set_evaluation_step,
+    update_inits,
+    write_csv,
+)
 from pharmpy.results import ModelfitResults
-from pharmpy.modeling import update_inits
-from pharmpy.modeling import set_evaluation_step
-from pharmpy.modeling import get_evid, get_thetas, get_sigmas
-import pandas as pd
+
 
 class CodeGenerator:
     def __init__(self):
@@ -51,10 +55,10 @@ def convert_model(model):
     nlmixr_model.__dict__ = generic_model.__dict__
     nlmixr_model.internals = NLMIXRModelInternals()
     nlmixr_model.filename_extension = '.R'
-    
+
     # Update dataset to lowercase and add evid
     nlmixr_model = modify_dataset(nlmixr_model)
-    
+
     nlmixr_model.update_source()
     return nlmixr_model
 
@@ -170,7 +174,7 @@ def create_model(cg, model):
 
 def create_fit(cg, model):
     """Create the call to fit"""
-    if [s.evaluation for s in model.estimation_steps._steps][0] == False:
+    if [s.evaluation for s in model.estimation_steps._steps][0] is False:
         cg.add(f'fit <- nlmixr2({model.name}, dataset, "focei")')
     else:
         cg.add(f'fit <- nlmixr2({model.name}, dataset, "posthoc")')
@@ -202,7 +206,9 @@ class Model(pharmpy.model.Model):
         create_fit(cg, self)
         # Create lowercase id, time and amount symbols for nlmixr to be able
         # to run
-        self.internals.src = str(cg).replace("AMT", "amt").replace("TIME", "time").replace("ID", "id")
+        self.internals.src = (
+            str(cg).replace("AMT", "amt").replace("TIME", "time").replace("ID", "id")
+        )
         self.internals.path = None
 
     @property
@@ -223,10 +229,10 @@ def parse_modelfit_results(model, path):
         rdata = pyreadr.read_r(rdata_path)
     except (FileNotFoundError, OSError):
         return None
-    
+
     rdata["thetas"] = rdata["thetas"].loc[get_thetas(model).names]
     rdata["sigma"] = rdata["sigma"].loc[get_sigmas(model).names]
-    
+
     ofv = rdata['ofv']['ofv'][0]
     omegas_sigmas = {}
     omega = model.random_variables.etas.covariance_matrix
@@ -248,23 +254,18 @@ def parse_modelfit_results(model, path):
         else:
             pe[param.name] = rdata['thetas']['fit$theta'][thetas_index]
             thetas_index += 1
-    
+
     name = model.name
     description = model.description
-    estimation_steps = model.estimation_steps
-    parameters = model.parameters
-    etas = model.random_variables.etas
     pe = pd.Series(pe)
-    predictions = rdata['pred'].set_index(["ID","TIME"])
-    predictions.index = predictions.index.set_levels(predictions.index.levels[0].astype("float64"), level=0)
-    
-    
+    predictions = rdata['pred'].set_index(["ID", "TIME"])
+    predictions.index = predictions.index.set_levels(
+        predictions.index.levels[0].astype("float64"), level=0
+    )
+
     res = ModelfitResults(
-        name = name,
-        description = description,    
-        ofv=ofv,
-        parameter_estimates=pe,
-        predictions = predictions)
+        name=name, description=description, ofv=ofv, parameter_estimates=pe, predictions=predictions
+    )
     return res
 
 
@@ -291,8 +292,10 @@ def execute_model(model, db):
     cg.add('log_likelihood <- fit$objDf$`Log-likelihood`')
     cg.add('runtime_total <- sum(fit$time)')
     cg.add('pred <- as.data.frame(fit[c("ID", "TIME", "PRED")])')
-    
-    cg.add(f'save(file="{path}/{model.name}.RDATA",ofv, thetas, omega, sigma, log_likelihood, runtime_total, pred)')
+
+    cg.add(
+        f'save(file="{path}/{model.name}.RDATA",ofv, thetas, omega, sigma, log_likelihood, runtime_total, pred)'
+    )
     code += f'\n{str(cg)}'
     with open(path / f'{model.name}.R', 'w') as fh:
         fh.write(code)
@@ -300,7 +303,7 @@ def execute_model(model, db):
     from pharmpy.plugins.nlmixr import conf
 
     rpath = conf.rpath / 'bin' / 'Rscript'
-    
+
     newenv = os.environ
     # Reset environment variables incase started from R
     # and calling other R version.
@@ -355,58 +358,56 @@ def execute_model(model, db):
     model.modelfit_results = res
     return model
 
-def verification(model, db_name, error = 10**-3, return_comp = False):
-    
+
+def verification(model, db_name, error=10**-3, return_comp=False):
+
     nonmem_model = model.copy()
-    
+
     # Save results from the nonmem model
-    nonmem_results = nonmem_model.modelfit_results.predictions.iloc[:,[0]]
-    
+    nonmem_results = nonmem_model.modelfit_results.predictions.iloc[:, [0]]
+
     # Check that evaluation step is set to True
-    if [s.evaluation for s in nonmem_model.estimation_steps._steps][0] == False:
+    if [s.evaluation for s in nonmem_model.estimation_steps._steps][0] is False:
         set_evaluation_step(nonmem_model)
-    
+
     # Update the nonmem model with new estimates
     # and convert to nlmixr
     nlmixr_model = convert_model(
-        update_inits(nonmem_model, 
-                     nonmem_model.modelfit_results.parameter_estimates)
-                                 )
+        update_inits(nonmem_model, nonmem_model.modelfit_results.parameter_estimates)
+    )
     # Execute the nlmixr model
     import pharmpy.workflows
+
     db = pharmpy.workflows.LocalDirectoryToolDatabase(db_name)
     nlmixr_model = execute_model(nlmixr_model, db)
-        
+
     nlmixr_results = nlmixr_model.modelfit_results.predictions
-    
+
     with warnings.catch_warnings():
         # Supress a numpy deprecation warning
         warnings.simplefilter("ignore")
-        nonmem_results.rename(columns={"PRED":"PRED_NONMEM"}, inplace = True)
-        nlmixr_results.rename(columns={"PRED":"PRED_NLMIXR"}, inplace = True)
-    
-    #Combine the two based on ID and time
-    combined_result = pd.merge(nonmem_results, 
-                               nlmixr_results,
-                               left_index=True,
-                               right_index=True
-                               )
-    
+        nonmem_results.rename(columns={"PRED": "PRED_NONMEM"}, inplace=True)
+        nlmixr_results.rename(columns={"PRED": "PRED_NLMIXR"}, inplace=True)
+
+    # Combine the two based on ID and time
+    combined_result = pd.merge(nonmem_results, nlmixr_results, left_index=True, right_index=True)
+
     # Add difference between the models
     combined_result["DIFF"] = abs(combined_result["PRED_NONMEM"] - combined_result["PRED_NLMIXR"])
 
     combined_result["PASS/FAIL"] = "PASS"
     combined_result.loc[combined_result["DIFF"] > error, "PASS/FAIL"] = "FAIL"
-    
-    if return_comp == True:
+
+    if return_comp is True:
         return combined_result
     else:
         if all(combined_result["PASS/FAIL"] == "PASS"):
             return True
         else:
             return False
-    
+
+
 def modify_dataset(model):
-    temp_model = model.copy()    
+    temp_model = model.copy()
     temp_model.dataset["evid"] = get_evid(temp_model)
     return temp_model


### PR DESCRIPTION
New function in pharmpy.plugin.nlmixr.model called verification(). Takes a nonmem model and a tool database name as input. Convert nonmem to nlmixr and compute predicted values to be compared to that of the nonmem model. If all predictions are within the margin of error (default to 10^-3), return True, otherwise False. If argument return_comp is True, instead return pd.dataframe with comparison of predictions from both models. Also added function modify_dataset() which takes in a model and returns a model with "evid" added to the dataset (mandatory for runnning nlmixr).

Some changes have also been made to convert_model() in order to achieve the wanted predictions and comparison.