### PR TITLE
Fix string representation in EstimationStep.__repr__()

### DIFF
--- a/src/pharmpy/model/estimation.py
+++ b/src/pharmpy/model/estimation.py
@@ -333,14 +333,16 @@ class EstimationStep(Immutable):
         return cls(**d)
 
     def __repr__(self):
+        cov = f"'{self.cov}'" if self.cov is not None else self.cov
+        solver = f"'{self.solver}'" if self.solver is not None else self.solver
         return (
-            f'EstimationStep("{self.method}", interaction={self.interaction}, '
-            f'cov={self.cov}, evaluation={self.evaluation}, '
-            f'maximum_evaluations={self.maximum_evaluations}, laplace={self.laplace}, '
-            f'isample={self.isample}, niter={self.niter}, auto={self.auto}, '
-            f'keep_every_nth_iter={self.keep_every_nth_iter}, solver={self.solver}, '
-            f'solver_rtol={self.solver_rtol}, solver_atol={self.solver_atol}, '
-            f'tool_options={self.tool_options})'
+            f"EstimationStep('{self.method}', interaction={self.interaction}, "
+            f"cov={cov}, evaluation={self.evaluation}, "
+            f"maximum_evaluations={self.maximum_evaluations}, laplace={self.laplace}, "
+            f"isample={self.isample}, niter={self.niter}, auto={self.auto}, "
+            f"keep_every_nth_iter={self.keep_every_nth_iter}, solver={solver}, "
+            f"solver_rtol={self.solver_rtol}, solver_atol={self.solver_atol}, "
+            f"tool_options={self.tool_options})"
         )
 
 

--- a/src/pharmpy/modeling/estimation_steps.py
+++ b/src/pharmpy/modeling/estimation_steps.py
@@ -31,9 +31,9 @@ def set_estimation_step(model: Model, method: str, idx: int = 0, **kwargs):
     >>> from pharmpy.modeling import *
     >>> model = load_example_model("pheno")
     >>> opts = {'NITER': 1000, 'ISAMPLE': 100}
-    >>> model = set_estimation_step(model, "IMP", evaluation=True, tool_options=opts)
+    >>> model = set_estimation_step(model, 'IMP', evaluation=True, tool_options=opts)
     >>> model.estimation_steps[0]   # doctest: +ELLIPSIS
-    EstimationStep("IMP", interaction=True, cov=SANDWICH, evaluation=True, ..., tool_options=...
+    EstimationStep('IMP', interaction=True, cov='SANDWICH', evaluation=True, ..., tool_options=...
 
     See also
     --------
@@ -86,12 +86,12 @@ def add_estimation_step(model: Model, method: str, idx: Optional[int] = None, **
     >>> from pharmpy.modeling import *
     >>> model = load_example_model("pheno")
     >>> opts = {'NITER': 1000, 'ISAMPLE': 100}
-    >>> model = add_estimation_step(model, "IMP", tool_options=opts)
+    >>> model = add_estimation_step(model, 'IMP', tool_options=opts)
     >>> ests = model.estimation_steps
     >>> len(ests)
     2
     >>> ests[1]   # doctest: +ELLIPSIS
-    EstimationStep("IMP", interaction=False, cov=None, ..., tool_options={'NITER': 1000,...
+    EstimationStep('IMP', interaction=False, cov=None, ..., tool_options={'NITER': 1000,...
 
     See also
     --------
@@ -238,7 +238,7 @@ def add_covariance_step(model: Model):
     >>> model = add_covariance_step(model)
     >>> ests = model.estimation_steps
     >>> ests[0]   # doctest: +ELLIPSIS
-    EstimationStep("FOCE", interaction=True, cov=SANDWICH, ...)
+    EstimationStep('FOCE', interaction=True, cov='SANDWICH', ...)
 
     See also
     --------
@@ -251,7 +251,7 @@ def add_covariance_step(model: Model):
 
     """
     steps = model.estimation_steps
-    newstep = steps[-1].replace(cov="SANDWICH")
+    newstep = steps[-1].replace(cov='SANDWICH')
     newsteps = steps[0:-1] + newstep
     model = model.replace(estimation_steps=newsteps)
     return model.update_source()
@@ -277,7 +277,7 @@ def remove_covariance_step(model: Model):
     >>> model = remove_covariance_step(model)
     >>> ests = model.estimation_steps
     >>> ests[0]   # doctest: +ELLIPSIS
-    EstimationStep("FOCE", interaction=True, cov=None, ...)
+    EstimationStep('FOCE', interaction=True, cov=None, ...)
 
     See also
     --------
@@ -320,7 +320,7 @@ def set_evaluation_step(model: Model, idx: int = -1):
     >>> model = load_example_model("pheno")
     >>> model = set_evaluation_step(model)
     >>> model.estimation_steps[0]   # doctest: +ELLIPSIS
-    EstimationStep("FOCE", interaction=True, cov=SANDWICH, evaluation=True, ...
+    EstimationStep('FOCE', interaction=True, cov='SANDWICH', evaluation=True, ...
 
     See also
     --------

--- a/tests/model/test_estimation.py
+++ b/tests/model/test_estimation.py
@@ -28,10 +28,10 @@ def test_estimation_method():
 
     assert a == EstimationStep.create('fo', interaction=False, cov='sandwich')
     assert (
-        repr(a) == 'EstimationStep("FO", interaction=False, cov=SANDWICH, evaluation=False, '
-        'maximum_evaluations=None, laplace=False, isample=None, niter=None, auto=None, '
-        'keep_every_nth_iter=None, solver=None, solver_rtol=None, solver_atol=None, '
-        'tool_options={})'
+        repr(a) == "EstimationStep('FO', interaction=False, cov='SANDWICH', evaluation=False, "
+        "maximum_evaluations=None, laplace=False, isample=None, niter=None, auto=None, "
+        "keep_every_nth_iter=None, solver=None, solver_rtol=None, solver_atol=None, "
+        "tool_options={})"
     )
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
Ensure strings for method, solver, and cov are correctly enclosed within single quotation marks