### PR TITLE
Support power residual error models for multiple dvs 

### DIFF
--- a/src/pharmpy/modeling/error.py
+++ b/src/pharmpy/modeling/error.py
@@ -907,6 +907,10 @@ def set_power_on_ruv(
     Initial estimates for new thetas are 1 if the error
     model is proportional, otherwise they are 0.1.
 
+    NOTE : If no DVs or epsilons are specified, all epsilons with the same name
+    will be connected to the same theta. Running the function per DV will give
+    each epsilon a specific theta.
+
     Parameters
     ----------
     model : Model
@@ -975,6 +979,20 @@ def set_power_on_ruv(
         )
     ):
         warnings.warn(f'Some provided epsilons are not connected to the supplied DV ({dv_symb})')
+    elif dv is not None and any(
+        [
+            sympy.Symbol(e.names[0])
+            not in model.statements.after_odes.full_expression(dv_symb).free_symbols
+            for e in eps
+        ]
+    ):
+        # Only analyze epsilons connected to the given DV
+        eps = [
+            e
+            for e in eps
+            if sympy.Symbol(e.names[0])
+            in model.statements.after_odes.full_expression(dv_symb).free_symbols
+        ]
 
     # Check for used DV, not just the first one
     if has_proportional_error_model(model, dv=dv_symb):


### PR DESCRIPTION
Solution to the power model from issue #1589 (adding power model for multiple DVs)
This function can take in either a nothing at all or a specific DV and/or a list of epsilons to perform the transformation on. 

If nothing is specified, the function will perform the transformation on all epsilons that are available, regardless of the affected DV. I was unsure if this should be the case or if only the first (or only) DV should be affected instead, but I decided to follow the same principle as applied to set_iiv_on_ruv().

If a DV is specified, the model will only transform the epsilons connected to said DV (or the ones specified in the list of epsilons). 

If only a list of epsilons is provided, these will all be transformed, regardless of the connected DV.

Please let me know if there are any comments or changes to be made!