### PR TITLE
Multiple doses per compartment and parsing updates for IV+ORAL

### DIFF
--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -305,6 +305,7 @@ def _compartmental_model(
         cs = to_compartmental_system(func_to_name, eqs)
         central_comp_name = cs.central_compartment.name
         cb = CompartmentalSystemBuilder(cs)
+        doses = dosing(di, dataset, 1)
         for i, comp_name in enumerate(comps, start=1):
             comp = cs.find_compartment(comp_name)
             if comp is None:  # Compartments can be in $MODEL but not used in $DES
@@ -315,7 +316,6 @@ def _compartmental_model(
                 central = True
             else:
                 central = False
-            doses = dosing(di, dataset, i)
             cb.set_dose(comp, find_dose(doses, i, admid=admid, central=central))
             comp = cb.find_compartment(comp_name)
             f = _get_bioavailability(control_stream, i)

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -38,13 +38,18 @@ def _compartmental_model(
     trans,
     des=None,
 ):
+    print("TJA")
+    print(advan)
+    print(advan == "ADVAN1")
     if advan == 'ADVAN1':
         # FIXME : Require multiple doses per comp before IV+ORAL
+        print()
         doses = dosing(di, dataset, 1)
+        print(doses)
         cb = CompartmentalSystemBuilder()
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=1, admid=2),
+            dose=find_dose(doses, comp_number=1, admid=2, central=True),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
@@ -79,7 +84,7 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=1, admid=2),
+            dose=find_dose(doses, comp_number=1, admid=2, central=True),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
@@ -102,13 +107,13 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         depot = Compartment.create(
             'DEPOT',
-            dose=find_dose(doses, comp_number=1, admid=1),
+            dose=find_dose(doses, comp_number=1, admid=1, depot=True),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=2, admid=2),
+            dose=find_dose(doses, comp_number=2, admid=2, central=True),
             lag_time=_get_alag(control_stream, 2),
             bioavailability=_get_bioavailability(control_stream, 2),
         )
@@ -196,7 +201,7 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=1, admid=2),
+            dose=find_dose(doses, comp_number=1, admid=2, central=True),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
@@ -212,7 +217,7 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=1, admid=2),
+            dose=find_dose(doses, comp_number=1, admid=2, central=True),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
@@ -244,13 +249,13 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         depot = Compartment.create(
             'DEPOT',
-            dose=find_dose(doses, comp_number=1, admid=1),
+            dose=find_dose(doses, comp_number=1, admid=1, depot=True),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=2, admid=2),
+            dose=find_dose(doses, comp_number=2, admid=2, central=True),
             lag_time=_get_alag(control_stream, 2),
             bioavailability=_get_bioavailability(control_stream, 2),
         )
@@ -312,8 +317,9 @@ def _compartmental_model(
             admid = 1
             if comp.name == central_comp_name:
                 admid = 2
+                central = True
             doses = dosing(di, dataset, i)
-            cb.set_dose(comp, find_dose(doses, i, admid=admid))
+            cb.set_dose(comp, find_dose(doses, i, admid=admid, central=central))
             comp = cb.find_compartment(comp_name)
             f = _get_bioavailability(control_stream, i)
             cb.set_bioavailability(comp, f)
@@ -628,6 +634,7 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
                  },
             )
     else:
+        print("JORÅ^")
         # CMT column present
         cmt = dataset['CMT']
         if len(cmt.unique()) == 1:
@@ -678,16 +685,25 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
             doses = tuple()
             for comp_number in cmt.unique():
                 cmt_dataset = dataset[dataset['CMT'] == comp_number]
+                print("CMT",comp_number)
                 if 'ADMID' in di.names:
                     # Go through all dose types to the same compartment
                     for admid in cmt_dataset['ADMID'].unique():
+                        if admid == 1:
+                            central = False
+                            depot = True
+                        elif admid == 2:
+                            central = True
+                            depot = False
+                        else:
+                            raise ValueError(f'Administration ID : {admid} not supported')
                         doses += (
                             {
                                 'comp_number': None,
                                 'dose': _dosing(di, cmt_dataset, comp_number),
                                 'admid': admid,
-                                'central': False,
-                                'depot': False,
+                                'central': central,
+                                'depot': depot,
                             },
                         )
                 else:

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -600,7 +600,9 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
     cmt_loop = False
     admid_loop = False
     return_dose = False
-    if 'ADMID' in di.names:
+    if dataset is None:
+        return_dose = True
+    elif 'ADMID' in di.names:
         for admid in dataset['ADMID'].unique():
             if admid not in [1, 2]:
                 raise ValueError(f'Administration ID : {admid} not supported')

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -44,7 +44,7 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=1, admid=2, central=True),
+            doses=find_dose(doses, comp_number=1),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
@@ -57,13 +57,13 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         depot = Compartment.create(
             'DEPOT',
-            dose=find_dose(doses, comp_number=1, admid=1),
+            doses=find_dose(doses, comp_number=1),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=2, admid=2, central=True),
+            doses=find_dose(doses, comp_number=2),
             lag_time=_get_alag(control_stream, 2),
             bioavailability=_get_bioavailability(control_stream, 2),
         )
@@ -79,13 +79,13 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=1, admid=2, central=True),
+            doses=find_dose(doses, comp_number=1),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
         peripheral = Compartment.create(
             'PERIPHERAL',
-            dose=None,
+            doses=tuple(),
             lag_time=_get_alag(control_stream, 2),
             bioavailability=_get_bioavailability(control_stream, 2),
         )
@@ -102,19 +102,19 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         depot = Compartment.create(
             'DEPOT',
-            dose=find_dose(doses, comp_number=1, admid=1),
+            doses=find_dose(doses, comp_number=1),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=2, admid=2, central=True),
+            doses=find_dose(doses, comp_number=2),
             lag_time=_get_alag(control_stream, 2),
             bioavailability=_get_bioavailability(control_stream, 2),
         )
         peripheral = Compartment.create(
             'PERIPHERAL',
-            dose=None,
+            doses=tuple(),
             lag_time=_get_alag(control_stream, 3),
             bioavailability=_get_bioavailability(control_stream, 3),
         )
@@ -169,16 +169,11 @@ def _compartmental_model(
 
         doses = dosing(di, dataset, defdose[1])
         obscomp = None
-        for i, name in enumerate(comp_names):
-            if name == defdose[0]:
-                curdose = find_dose(doses, defdose[1])
-            elif defcentral and name == defcentral[0]:
-                curdose = find_dose(doses, defcentral[1], admid=2, central=True)
-            else:
-                curdose = None
+        for i, name in enumerate(comp_names, start=1):
+            curdose = find_dose(doses, i)
             comp = Compartment.create(
                 name,
-                dose=curdose,
+                doses=curdose,
                 lag_time=_get_alag(control_stream, i),
                 bioavailability=_get_bioavailability(control_stream, i),
             )
@@ -198,7 +193,7 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=1, admid=2, central=True),
+            doses=find_dose(doses, comp_number=1),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
@@ -214,19 +209,19 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=1, admid=2, central=True),
+            doses=find_dose(doses, comp_number=1),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
         per1 = Compartment.create(
             'PERIPHERAL1',
-            dose=None,
+            doses=tuple(),
             lag_time=_get_alag(control_stream, 2),
             bioavailability=_get_bioavailability(control_stream, 2),
         )
         per2 = Compartment.create(
             'PERIPHERAL2',
-            dose=None,
+            doses=tuple(),
             lag_time=_get_alag(control_stream, 3),
             bioavailability=_get_bioavailability(control_stream, 3),
         )
@@ -246,25 +241,25 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         depot = Compartment.create(
             'DEPOT',
-            dose=find_dose(doses, comp_number=1, admid=1),
+            doses=find_dose(doses, comp_number=1),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=2, admid=2, central=True),
+            doses=find_dose(doses, comp_number=2),
             lag_time=_get_alag(control_stream, 2),
             bioavailability=_get_bioavailability(control_stream, 2),
         )
         per1 = Compartment.create(
             'PERIPHERAL1',
-            dose=None,
+            doses=tuple(),
             lag_time=_get_alag(control_stream, 3),
             bioavailability=_get_bioavailability(control_stream, 3),
         )
         per2 = Compartment.create(
             'PERIPHERAL2',
-            dose=None,
+            doses=tuple(),
             lag_time=_get_alag(control_stream, 4),
             bioavailability=_get_bioavailability(control_stream, 4),
         )
@@ -305,20 +300,13 @@ def _compartmental_model(
         eqs = [sympy.Eq(s.symbol, s.expression) for s in sset if not s.symbol.is_Symbol]
 
         cs = to_compartmental_system(func_to_name, eqs)
-        central_comp_name = cs.central_compartment.name
         cb = CompartmentalSystemBuilder(cs)
         doses = dosing(di, dataset, 1)
         for i, comp_name in enumerate(comps, start=1):
             comp = cs.find_compartment(comp_name)
             if comp is None:  # Compartments can be in $MODEL but not used in $DES
                 continue
-            admid = 1
-            if comp.name == central_comp_name:
-                admid = 2
-                central = True
-            else:
-                central = False
-            cb.set_dose(comp, find_dose(doses, i, admid=admid, central=central))
+            cb.set_dose(comp, find_dose(doses, i))
             comp = cb.find_compartment(comp_name)
             f = _get_bioavailability(control_stream, i)
             cb.set_bioavailability(comp, f)
@@ -604,26 +592,16 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
     return_dose = False
     if dataset is None:
         return_dose = True
-    elif 'ADMID' in di.names:
-        for admid in dataset['ADMID'].unique():
-            if admid not in [1, 2]:
-                raise ValueError(f'Administration ID : {admid} not supported')
-
+    elif 'admid' in di.types:
+        admid_name = di.typeix["admid"][0].name
         if 'CMT' in di.names and not di['CMT'].drop:
             if len(dataset['CMT']) == 1:
-                warnings.warn(
-                    "CMT column present with only one value" "Using admid column to determine dose"
-                )
+                warnings.warn("CMT column present with only one value")
             cmt_loop = True
-            admid_loop = True
-        else:
-            admid_loop = True
+        admid_loop = True
     elif 'CMT' in di.names and not di['CMT'].drop:
         if len(dataset['CMT']) == 1:
-            warnings.warn(
-                "CMT column present with only one value"
-                "Need ADMID column to determine doses (if multiple)"
-            )
+            warnings.warn("CMT column present with only one value")
             return_dose = True
         else:
             cmt_loop = True
@@ -643,22 +621,20 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
     if admid_loop and cmt_loop:
         for comp_number in dataset['CMT'].unique():
             cmt_dataset = dataset[dataset['CMT'] == comp_number]
-            for admid in cmt_dataset['ADMID'].unique():
+            for admid in cmt_dataset[admid_name].unique():
                 doses += (
                     {
                         'comp_number': comp_number,
-                        'dose': _dosing(
-                            di, cmt_dataset[cmt_dataset['ADMID'] == admid], comp_number
-                        ),
+                        'dose': _dosing(di, dataset.loc[dataset[admid_name] == admid], comp_number),
                         'admid': admid,
                     },
                 )
     elif admid_loop:
-        for admid in dataset['ADMID'].unique():
+        for admid in dataset[admid_name].unique():
             doses += (
                 {
                     'comp_number': dose_comp,
-                    'dose': _dosing(di, dataset['ADMID'] == admid, dose_comp),
+                    'dose': _dosing(di, dataset.loc[dataset[admid_name] == admid], dose_comp),
                     'admid': admid,
                 },
             )
@@ -694,19 +670,10 @@ def _dosing(di, dataset, dose_comp):
         return Infusion(sympy.Symbol('AMT'), rate=sympy.Symbol('RATE'))
 
 
-def find_dose(doses, comp_number, admid=1, central=False):
+def find_dose(doses, comp_number, admid=1):
     comp_doses = tuple()
     for dose in doses:
-        # FIRST check if admid == 2
-        if (
-            dose['admid'] == 2
-            and central  # Currently on central compartment with IV dose
-            or (
-                dose['comp_number']
-                == comp_number  # Comp number match and we are not on central compartment
-                and not dose['admid'] == 2
-            )
-        ):
+        if dose['comp_number'] == comp_number:
             comp_dose = dose['dose']
             if dose['admid'] is not None:
                 admid = dose['admid']

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -591,22 +591,27 @@ def _advan12_trans(trans: str):
 
 def dosing(di: DataInfo, dataset, dose_comp: int):
     # Only check doses
-    dataset = dataset[dataset['AMT'] != 0]
-    
+    if dataset is not None:
+        dataset = dataset[dataset['AMT'] != 0]
+
     if 'CMT' not in di.names or di['CMT'].drop or dataset is None:
         if 'ADMID' in di.names:
             # Go through all dose types to the same compartment
             doses = tuple()
             for admid in dataset['ADMID'].unique():
-                doses += ({'comp_number': dose_comp, 
-                           'dose': _dosing(di, dataset, dose_comp),
-                           'admid': admid},)
+                doses += (
+                    {
+                        'comp_number': dose_comp,
+                        'dose': _dosing(di, dataset, dose_comp),
+                        'admid': admid,
+                    },
+                )
             return doses
         else:
             # No ADMID or CMT
-            return ({'comp_number': dose_comp, 
-                     'dose': _dosing(di, dataset, dose_comp),
-                     'admid': None},)
+            return (
+                {'comp_number': dose_comp, 'dose': _dosing(di, dataset, dose_comp), 'admid': None},
+            )
     else:
         # CMT column present
         cmt = dataset['CMT']
@@ -615,9 +620,13 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
             if 'ADMID' in di.names:
                 # Go through all dose types to the same compartment
                 for admid in dataset['ADMID'].unique():
-                    doses += ({'comp_number': dose_comp, 
-                               'dose': _dosing(di, dataset, dose_comp),
-                               'admid': admid},)
+                    doses += (
+                        {
+                            'comp_number': dose_comp,
+                            'dose': _dosing(di, dataset, dose_comp),
+                            'admid': admid,
+                        },
+                    )
                 return doses
             else:
                 warnings.warn(
@@ -626,9 +635,13 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
                 )
                 # Change comp number to match dataset
                 comp_number = cmt[0]
-                return ({'comp_number': comp_number, 
-                         'dose': _dosing(di, dataset, comp_number),
-                         'admid': None},)
+                return (
+                    {
+                        'comp_number': comp_number,
+                        'dose': _dosing(di, dataset, comp_number),
+                        'admid': None,
+                    },
+                )
         else:
             # Multiple different compartments
             doses = tuple()
@@ -637,13 +650,21 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
                 if 'ADMID' in di.names:
                     # Go through all dose types to the same compartment
                     for admid in cmt_dataset['ADMID'].unique():
-                        doses += ({'comp_number': comp_number, 
-                                   'dose': _dosing(di, cmt_dataset, comp_number),
-                                   'admid': admid},)
+                        doses += (
+                            {
+                                'comp_number': comp_number,
+                                'dose': _dosing(di, cmt_dataset, comp_number),
+                                'admid': admid,
+                            },
+                        )
                 else:
-                    doses += ({'comp_number': comp_number, 
-                               'dose': _dosing(di, cmt_dataset, comp_number),
-                               'admid': None},)
+                    doses += (
+                        {
+                            'comp_number': comp_number,
+                            'dose': _dosing(di, cmt_dataset, comp_number),
+                            'admid': None,
+                        },
+                    )
             return doses
 
 

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -630,6 +630,7 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
                 warnings.warn(
                     "CMT column present with only one value" "Using ADMID to determine dose type"
                 )
+                doses = tuple()
                 # Go through all dose types to the same compartment
                 for admid in dataset['ADMID'].unique():
                     if admid not in [1, 2]:

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -313,6 +313,8 @@ def _compartmental_model(
             if comp.name == central_comp_name:
                 admid = 2
                 central = True
+            else:
+                central = False
             doses = dosing(di, dataset, i)
             cb.set_dose(comp, find_dose(doses, i, admid=admid, central=central))
             comp = cb.find_compartment(comp_name)

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -616,7 +616,7 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
             admid_loop = True
         else:
             admid_loop = True
-    elif 'CMT' in di.names:
+    elif 'CMT' in di.names and not di['CMT'].drop:
         if len(dataset['CMT']) == 1:
             warnings.warn(
                 "CMT column present with only one value"
@@ -709,7 +709,7 @@ def find_dose(doses, comp_number, admid=1, central=False):
             if dose['admid'] is not None:
                 admid = dose['admid']
             comp_doses += (comp_dose.replace(admid=admid),)
-    return comp_doses if comp_doses else None
+    return comp_doses
 
 
 def _get_alag(control_stream: NMTranControlStream, n: int):

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -172,6 +172,8 @@ def _compartmental_model(
         for i, name in enumerate(comp_names):
             if name == defdose[0]:
                 curdose = find_dose(doses, defdose[1])
+            elif defcentral and name == defcentral[0]:
+                curdose = find_dose(doses, defcentral[1], admid=2, central=True)
             else:
                 curdose = None
             comp = Compartment.create(

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -303,14 +303,14 @@ def _compartmental_model(
         eqs = [sympy.Eq(s.symbol, s.expression) for s in sset if not s.symbol.is_Symbol]
 
         cs = to_compartmental_system(func_to_name, eqs)
+        central_comp_name = cs.central_compartment.name
         cb = CompartmentalSystemBuilder(cs)
         for i, comp_name in enumerate(comps, start=1):
             comp = cs.find_compartment(comp_name)
             if comp is None:  # Compartments can be in $MODEL but not used in $DES
                 continue
             admid = 1
-            if i == len(comps) and len(comps) != 1:
-                # FIXME : Always assume last comp to be CENTRAL and IV?
+            if comp.name == central_comp_name:
                 admid = 2
             doses = dosing(di, dataset, i)
             cb.set_dose(comp, find_dose(doses, i, admid=admid))

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -63,7 +63,7 @@ def _compartmental_model(
         )
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=2, admid=2, central = True),
+            dose=find_dose(doses, comp_number=2, admid=2, central=True),
             lag_time=_get_alag(control_stream, 2),
             bioavailability=_get_bioavailability(control_stream, 2),
         )
@@ -602,7 +602,7 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
             # Go through all dose types to the same compartment
             doses = tuple()
             for admid in dataset['ADMID'].unique():
-                if admid not in [1,2]:
+                if admid not in [1, 2]:
                     raise ValueError(f'Administration ID : {admid} not supported')
                 doses += (
                     {
@@ -615,10 +615,11 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
         else:
             # No ADMID or CMT
             return (
-                {'comp_number': dose_comp,
-                 'dose': _dosing(di, dataset, dose_comp),
-                 'admid': None,
-                 },
+                {
+                    'comp_number': dose_comp,
+                    'dose': _dosing(di, dataset, dose_comp),
+                    'admid': None,
+                },
             )
     else:
         # CMT column present
@@ -627,12 +628,11 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
             # All doses to same compartment
             if 'ADMID' in di.names:
                 warnings.warn(
-                    "CMT column present with only one value"
-                    "Using ADMID to determine dose type"
+                    "CMT column present with only one value" "Using ADMID to determine dose type"
                 )
                 # Go through all dose types to the same compartment
                 for admid in dataset['ADMID'].unique():
-                    if admid not in [1,2]:
+                    if admid not in [1, 2]:
                         raise ValueError(f'Administration ID : {admid} not supported')
                     doses += (
                         {
@@ -664,7 +664,7 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
                 if 'ADMID' in di.names:
                     # Go through all dose types to the same compartment
                     for admid in cmt_dataset['ADMID'].unique():
-                        if admid not in [1,2]:
+                        if admid not in [1, 2]:
                             raise ValueError(f'Administration ID : {admid} not supported')
                         doses += (
                             {
@@ -706,10 +706,15 @@ def find_dose(doses, comp_number, admid=1, central=False):
     comp_doses = tuple()
     for dose in doses:
         # FIRST check if admid == 2
-        if (dose['admid'] == 2 and central # Currently on central compartment with IV dose
-            or (dose['comp_number'] == comp_number # Comp number match and we are not on central compartment
-                and not dose['admid'] == 2)
-            ):
+        if (
+            dose['admid'] == 2
+            and central  # Currently on central compartment with IV dose
+            or (
+                dose['comp_number']
+                == comp_number  # Comp number match and we are not on central compartment
+                and not dose['admid'] == 2
+            )
+        ):
             comp_dose = dose['dose']
             if dose['admid'] is not None:
                 admid = dose['admid']

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -598,6 +598,7 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
                 doses += ({'comp_number': dose_comp, 
                            'dose': _dosing(di, dataset, dose_comp),
                            'admid': admid},)
+            return doses
         else:
             return ({'comp_number': dose_comp, 
                      'dose': _dosing(di, dataset, dose_comp),
@@ -605,7 +606,7 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
     else:
         # CMT column present
         cmt = dataset['CMT']
-        if len(cmt.unique()) < 1:
+        if len(cmt.unique()) == 1:
             # Single compartment dose
             # Overwrite dose_comp
             if 'ADMID' in di.names:
@@ -662,7 +663,7 @@ def find_dose(doses, comp_number, admid=1):
     for dose in doses:
         if dose['comp_number'] == comp_number:
             comp_dose = dose['dose']
-            if dose['admid']:
+            if dose['admid'] is not None:
                 admid = dose['admid']
             comp_doses += (comp_dose.replace(admid=admid),)
     return comp_doses if comp_doses else None

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -590,9 +590,12 @@ def _advan12_trans(trans: str):
 
 
 def dosing(di: DataInfo, dataset, dose_comp: int):
+    # Only check doses
+    dataset = dataset[dataset['AMT'] != 0]
+    
     if 'CMT' not in di.names or di['CMT'].drop or dataset is None:
         if 'ADMID' in di.names:
-            # Add multiple doses with different ADMID
+            # Go through all dose types to the same compartment
             doses = tuple()
             for admid in dataset['ADMID'].unique():
                 doses += ({'comp_number': dose_comp, 
@@ -600,6 +603,7 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
                            'admid': admid},)
             return doses
         else:
+            # No ADMID or CMT
             return ({'comp_number': dose_comp, 
                      'dose': _dosing(di, dataset, dose_comp),
                      'admid': None},)
@@ -607,28 +611,31 @@ def dosing(di: DataInfo, dataset, dose_comp: int):
         # CMT column present
         cmt = dataset['CMT']
         if len(cmt.unique()) == 1:
-            # Single compartment dose
-            # Overwrite dose_comp
+            # All doses to same compartment
             if 'ADMID' in di.names:
-                # Add multiple doses to the same compartment based on 
-                # the admid column (to the compartment in the cmt column)
-                pass
+                # Go through all dose types to the same compartment
+                for admid in dataset['ADMID'].unique():
+                    doses += ({'comp_number': dose_comp, 
+                               'dose': _dosing(di, dataset, dose_comp),
+                               'admid': admid},)
+                return doses
             else:
                 warnings.warn(
                     "CMT column present with only one value"
                     "Need ADMID column to determine doses (if multiple)"
                 )
+                # Change comp number to match dataset
                 comp_number = cmt[0]
                 return ({'comp_number': comp_number, 
                          'dose': _dosing(di, dataset, comp_number),
                          'admid': None},)
         else:
-            # FIXME : what if admid is present???
             # Multiple different compartments
             doses = tuple()
             for comp_number in cmt.unique():
-                cmt_dataset = dataset[dataset['CMT'] == dose_comp]
-                if 'ADMID' in di.names:   
+                cmt_dataset = dataset[dataset['CMT'] == comp_number]
+                if 'ADMID' in di.names:
+                    # Go through all dose types to the same compartment
                     for admid in cmt_dataset['ADMID'].unique():
                         doses += ({'comp_number': comp_number, 
                                    'dose': _dosing(di, cmt_dataset, comp_number),

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -44,7 +44,7 @@ def _compartmental_model(
         cb = CompartmentalSystemBuilder()
         central = Compartment.create(
             'CENTRAL',
-            dose=find_dose(doses, comp_number=1, admid=1),
+            dose=find_dose(doses, comp_number=1, admid=2),
             lag_time=_get_alag(control_stream, 1),
             bioavailability=_get_bioavailability(control_stream, 1),
         )

--- a/src/pharmpy/model/external/nonmem/advan.py
+++ b/src/pharmpy/model/external/nonmem/advan.py
@@ -637,7 +637,7 @@ def find_dose(doses, comp_number, admid=1):
     for dose in doses:
         if dose['comp_number'] == comp_number:
             comp_dose = dose['dose']
-            return comp_dose.replace(admid=admid)
+            return (comp_dose.replace(admid=admid),)
     return None
 
 

--- a/src/pharmpy/model/external/nonmem/records/code_record.py
+++ b/src/pharmpy/model/external/nonmem/records/code_record.py
@@ -116,7 +116,14 @@ class NMTranPrinter(sympy_printing.str.StrPrinter):
         if expr.exp == sympy.Rational(1, 2):
             return f"SQRT({self.doprint(expr.base)})"
         elif expr.exp == -1:
-            return f"1/{expr.base}"
+            if (
+                isinstance(expr.base, sympy.Expr)
+                and not isinstance(expr.base, sympy.Symbol)
+                and len(expr.base.make_args(expr.base)) > 1
+            ):
+                return f"1/({expr.base})"
+            else:
+                return f"1/{expr.base}"
         else:
             return super()._print_Pow(expr)
 

--- a/src/pharmpy/model/external/nonmem/update.py
+++ b/src/pharmpy/model/external/nonmem/update.py
@@ -493,7 +493,7 @@ def update_infusion(model: Model, old: ODESystem):
             # FIXME: Not always D1 here!
             ass = Assignment(sympy.Symbol('D1'), dose.duration)
             cb = CompartmentalSystemBuilder(new)
-            cb.set_dose(new.first_dosing_compartment, Infusion(dose.amount, duration=ass.symbol))
+            cb.set_dose(new.first_dosing_compartment, Infusion(dose.amount, admid = dose.admid, duration=ass.symbol))
             statements = statements.before_odes + CompartmentalSystem(cb) + statements.after_odes
         else:
             raise NotImplementedError("First order infusion rate is not yet supported")

--- a/src/pharmpy/model/external/nonmem/update.py
+++ b/src/pharmpy/model/external/nonmem/update.py
@@ -781,7 +781,7 @@ def update_bio(model, old, new):
     """
     newmap = new_compartmental_map(new)
     for dose in new.dosing_compartment:
-        # If the dose is not already correctly set (i.e dose numbering has 
+        # If the dose is not already correctly set (i.e dose numbering has
         # changed), it should be update to match the new number.
         if (
             not isinstance(dose.bioavailability, sympy.Number)

--- a/src/pharmpy/model/external/nonmem/update.py
+++ b/src/pharmpy/model/external/nonmem/update.py
@@ -781,7 +781,7 @@ def update_bio(model, old, new):
     """
     newmap = new_compartmental_map(new)
     for dose in new.dosing_compartment:
-        # If the dose is not already correctly set (i.e dose numbering has
+        # If the dose is not already correctly set (i.e dose numbering has 
         # changed), it should be update to match the new number.
         if (
             not isinstance(dose.bioavailability, sympy.Number)

--- a/src/pharmpy/model/external/nonmem/update.py
+++ b/src/pharmpy/model/external/nonmem/update.py
@@ -494,7 +494,7 @@ def update_infusion(model: Model, old: ODESystem):
             # FIXME: Not always D1 here!
             ass = Assignment(sympy.Symbol('D1'), dose.duration)
             cb = CompartmentalSystemBuilder(new)
-            cb.set_dose(new.first_dosing_compartment, Infusion(dose.amount, admid = dose.admid, duration=ass.symbol))
+            cb.replace_dose(new.first_dosing_compartment, dose, Infusion(dose.amount, admid = dose.admid, duration=ass.symbol))
             statements = statements.before_odes + CompartmentalSystem(cb) + statements.after_odes
         else:
             raise NotImplementedError("First order infusion rate is not yet supported")

--- a/src/pharmpy/model/external/nonmem/update.py
+++ b/src/pharmpy/model/external/nonmem/update.py
@@ -434,6 +434,7 @@ def update_cmt_column(model, old, new):
 
             # Make sure column is a number and not string
             dataset["CMT"] = pd.to_numeric(dataset["CMT"])
+            model = model.replace(dataset = dataset)
 
             # Differ in amount of compartment -> Change cmt numbering
             # The cmt number should be the same as the dosing compartment

--- a/src/pharmpy/model/external/nonmem/update.py
+++ b/src/pharmpy/model/external/nonmem/update.py
@@ -434,7 +434,7 @@ def update_cmt_column(model, old, new):
 
             # Make sure column is a number and not string
             dataset["CMT"] = pd.to_numeric(dataset["CMT"])
-            model = model.replace(dataset = dataset)
+            model = model.replace(dataset=dataset)
 
             # Differ in amount of compartment -> Change cmt numbering
             # The cmt number should be the same as the dosing compartment
@@ -494,7 +494,11 @@ def update_infusion(model: Model, old: ODESystem):
             # FIXME: Not always D1 here!
             ass = Assignment(sympy.Symbol('D1'), dose.duration)
             cb = CompartmentalSystemBuilder(new)
-            cb.replace_dose(new.first_dosing_compartment, dose, Infusion(dose.amount, admid = dose.admid, duration=ass.symbol))
+            cb.replace_dose(
+                new.first_dosing_compartment,
+                dose,
+                Infusion(dose.amount, admid=dose.admid, duration=ass.symbol),
+            )
             statements = statements.before_odes + CompartmentalSystem(cb) + statements.after_odes
         else:
             raise NotImplementedError("First order infusion rate is not yet supported")

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -445,7 +445,7 @@ class CompartmentalSystemBuilder:
         mapping = {compartment: new_comp}
         nx.relabel_nodes(self._g, mapping, copy=False)
         return new_comp
-    
+
     def remove_dose(self, compartment, dose_to_remove):
         """
         Remove specified dose.

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -1557,7 +1557,7 @@ class Compartment:
 
     def __repr__(self):
         lag = '' if self.lag_time == 0 else f', lag_time={self._lag_time}'
-        dose = '' if self.dose is None else f', dose={self._dose}'
+        dose = '' if self.dose is None else f', dose={self._dose[0] if len(self._dose) == 1 else self._dose}'
         input = '' if self.input == 0 else f', input={self._input}'
         bioavailability = (
             '' if self.bioavailability == 1 else f', bioavailability={self._bioavailability}'

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -348,7 +348,7 @@ class CompartmentalSystemBuilder:
         nx.relabel_nodes(self._g, mapping, copy=False)
 
     def set_dose(self, compartment, dose):
-        """Set dose of compartment
+        """Set dose of compartment, replacing the previous if existing
 
         Parameters
         ----------
@@ -363,6 +363,31 @@ class CompartmentalSystemBuilder:
             The new updated compartment
         """
         new_comp = compartment.replace(dose=dose)
+        mapping = {compartment: new_comp}
+        nx.relabel_nodes(self._g, mapping, copy=False)
+        return new_comp
+    
+    def add_dose(self, compartment, dose):
+        """
+        Add a dose to the compartment, without replacing existing one(s)
+
+        Parameters
+        ----------
+        compartment : Compartment
+            Compartment for which to add the dose to.
+        dose : Dose
+            New dose.
+
+        Returns
+        -------
+        Compartment
+            The new updated compartment
+
+        """
+        if compartment.dose is None:
+            new_comp = compartment.replace(dose=(dose,))
+        else:
+            new_comp = compartment.replace(dose=compartment.dose + (dose,))
         mapping = {compartment: new_comp}
         nx.relabel_nodes(self._g, mapping, copy=False)
         return new_comp

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -759,7 +759,7 @@ class CompartmentalSystem(ODESystem):
         >>> from pharmpy.modeling import load_example_model
         >>> model = load_example_model("pheno")
         >>> model.statements.ode_system.subs({'AMT': 'DOSE'})
-        Bolus(DOSE, admid=1)
+        Bolus(DOSE, admid=2) --> CENTRAL
         ┌───────┐
         │CENTRAL│──CL/V→
         └───────┘
@@ -924,7 +924,7 @@ class CompartmentalSystem(ODESystem):
         >>> from pharmpy.modeling import load_example_model
         >>> model = load_example_model("pheno")
         >>> model.statements.ode_system.get_compartment_inflows(output)
-        [(Compartment(CENTRAL, amount=A_CENTRAL, dose=Bolus(AMT, admid=1)), CL/V)]
+        [(Compartment(CENTRAL, amount=A_CENTRAL, dose=Bolus(AMT, admid=2)), CL/V)]
         """
         if isinstance(compartment, str):
             compartment = self.find_compartment(compartment)
@@ -982,7 +982,7 @@ class CompartmentalSystem(ODESystem):
         >>> model = load_example_model("pheno")
         >>> central = model.statements.ode_system.find_compartment("CENTRAL")
         >>> central
-        Compartment(CENTRAL, amount=A_CENTRAL, dose=Bolus(AMT, admid=1))
+        Compartment(CENTRAL, amount=A_CENTRAL, dose=Bolus(AMT, admid=2))
         """
         for comp in _comps(self._g):
             if comp.name == name:
@@ -1032,7 +1032,7 @@ class CompartmentalSystem(ODESystem):
         >>> from pharmpy.modeling import load_example_model
         >>> model = load_example_model("pheno")
         >>> model.statements.ode_system.dosing_compartments
-        (Compartment(CENTRAL, amount=A_CENTRAL, dose=Bolus(AMT, admid=1)),)
+        (Compartment(CENTRAL, amount=A_CENTRAL, dose=Bolus(AMT, admid=2)),)
         """
         dosing_comps = tuple()
         for node in _comps(self._g):
@@ -1067,7 +1067,7 @@ class CompartmentalSystem(ODESystem):
         >>> from pharmpy.modeling import load_example_model
         >>> model = load_example_model("pheno")
         >>> model.statements.ode_system.first_dosing_compartment
-        Compartment(CENTRAL, amount=A_CENTRAL, dose=Bolus(AMT, admid=1))
+        Compartment(CENTRAL, amount=A_CENTRAL, dose=Bolus(AMT, admid=2))
 
         """
         return self.dosing_compartments[0]
@@ -1089,7 +1089,7 @@ class CompartmentalSystem(ODESystem):
         >>> from pharmpy.modeling import load_example_model
         >>> model = load_example_model("pheno")
         >>> model.statements.ode_system.central_compartment
-        Compartment(CENTRAL, amount=A_CENTRAL, dose=Bolus(AMT, admid=1))
+        Compartment(CENTRAL, amount=A_CENTRAL, dose=Bolus(AMT, admid=2))
         """
         try:
             # E.g. TMDD models have more than one input
@@ -2073,7 +2073,7 @@ class Statements(Sequence, Immutable):
         >>> from pharmpy.modeling import load_example_model
         >>> model = load_example_model("pheno")
         >>> model.statements.ode_system
-        Bolus(AMT, admid=1)
+        Bolus(AMT, admid=2) --> CENTRAL
         ┌───────┐
         │CENTRAL│──CL/V→
         └───────┘

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -1426,7 +1426,7 @@ class Compartment:
     @property
     def dose(self):
         if self._dose is not None:
-            return sorted(self._dose, key=lambda d: d.admid)
+            return tuple(sorted(self._dose, key=lambda d: d.admid))
         else:
             return self._dose
     

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -445,6 +445,37 @@ class CompartmentalSystemBuilder:
         mapping = {compartment: new_comp}
         nx.relabel_nodes(self._g, mapping, copy=False)
         return new_comp
+    
+    def remove_dose(self, compartment, dose_to_remove):
+        """
+        Remove specified dose.
+
+        Parameters
+        ----------
+        compartment : Compartment
+            Compartment for which to remove dose from.
+        dose_to_remove : Dose
+            Dose to remove.
+
+        Returns
+        -------
+        Compartment
+            The new updated compartment
+
+        """
+        comp_dose = compartment.dose
+        new_comp_dose = tuple()
+        for dose in comp_dose:
+            if dose != dose_to_remove:
+                new_comp_dose += (dose,)
+        if new_comp_dose == comp_dose:
+            raise ValueError("Specified dose was not found")
+        if len(new_comp_dose) == 0:
+            new_comp_dose = None
+        new_comp = compartment.replace(dose=new_comp_dose)
+        mapping = {compartment: new_comp}
+        nx.relabel_nodes(self._g, mapping, copy=False)
+        return new_comp
 
     def set_lag_time(self, compartment, lag_time):
         """Set lag time of compartment

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -382,6 +382,37 @@ class CompartmentalSystemBuilder:
         mapping = {compartment: new_comp}
         nx.relabel_nodes(self._g, mapping, copy=False)
         return new_comp
+    
+    def replace_dose(self, compartment, old_dose, new_dose):
+        """
+        Replace and existing dose to a compartment
+
+        Parameters
+        ----------
+        compartment : Compartment
+            Compartment for which to replace dose to.
+        old_dose : Dose
+            Dose to be replaces.
+        new_dose : Dose
+            New Dose
+
+        Returns
+        -------
+        Compartment
+            The new updated compartment
+
+        """
+        comp_dose = compartment.dose
+        new_comp_dose = tuple()
+        for dose in comp_dose:
+            if dose == old_dose:
+                new_comp_dose += (new_dose,)
+            else:
+                new_comp_dose += (dose,)
+        new_comp = compartment.replace(dose=new_comp_dose)
+        mapping = {compartment: new_comp}
+        nx.relabel_nodes(self._g, mapping, copy=False)
+        return new_comp
 
     def add_dose(self, compartment, dose):
         """
@@ -403,7 +434,8 @@ class CompartmentalSystemBuilder:
         if compartment.dose is None:
             new_comp = compartment.replace(dose=(dose,))
         else:
-            new_comp = compartment.replace(dose=compartment.dose + (dose,))
+            new_dose = compartment.dose + (dose,)
+            new_comp = compartment.replace(dose=tuple(sorted(new_dose, key=lambda d: d.admid)))
         mapping = {compartment: new_comp}
         nx.relabel_nodes(self._g, mapping, copy=False)
         return new_comp
@@ -1506,6 +1538,18 @@ class Compartment:
             iv_dose = tuple([dose for dose in self.dose if dose.admid == 2])
             return iv_dose if iv_dose else None
         return None
+
+    @property
+    def number_of_doses(self):
+        return len(self._dose)
+    
+    @property
+    def number_of_oral_doses(self):
+        return len(self.oral_dose)
+    
+    @property
+    def number_of_iv_doses(self):
+        return len(self.iv_dose)
 
     @property
     def first_dose(self):

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -1496,10 +1496,6 @@ class Compartment:
             return self._dose
 
     @property
-    def number_of_doses(self):
-        return len(self._dose)
-
-    @property
     def input(self):
         return self._input
 

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -1305,9 +1305,12 @@ class CompartmentalSystem(ODESystem):
             current = next_comp
             if not current:
                 break
-
-        dose = self.dosing_compartment[0].dose
-        s = str(dose) + '\n' + str(grid).rstrip()
+        
+        all_doses = ""
+        for dose_comp in self.dosing_compartment:
+            for dose in dose_comp.dose:
+                    all_doses += f'{str(dose)} --> {dose_comp.name} \n'
+        s = all_doses + str(grid).rstrip()
         return s
 
 

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -1522,14 +1522,14 @@ class Compartment:
 
     def to_dict(self):
         if self._dose is None:
-            dose = None
+            all_doses = None
         else:
-            dose = self._dose.to_dict()
+            all_doses = tuple(dose.to_dict() for dose in self._dose)
         return {
             'class': 'Compartment',
             'name': self._name,
             'amount': sympy.srepr(self._amount),
-            'dose': dose,
+            'dose': all_doses,
             'input': sympy.srepr(self._input),
             'lag_time': sympy.srepr(self._lag_time),
             'bioavailability': sympy.srepr(self._bioavailability),
@@ -1538,15 +1538,18 @@ class Compartment:
     @classmethod
     def from_dict(cls, d):
         if d['dose'] is None:
-            dose = None
-        elif d['dose']['class'] == 'Bolus':
-            dose = Bolus.from_dict(d['dose'])
+            all_doses = None
         else:
-            dose = Infusion.from_dict(d['dose'])
+            all_doses = tuple()
+            for dose in d['dose']:
+                if dose['class'] == 'Bolus':
+                    all_doses += (Bolus.from_dict(dose),)
+                else:
+                    all_doses += (Infusion.from_dict(dose),)
         return cls(
             name=d['name'],
             amount=sympy.parse_expr(d['amount']),
-            dose=dose,
+            dose=all_doses,
             input=sympy.parse_expr(d['input']),
             lag_time=sympy.parse_expr(d['lag_time']),
             bioavailability=sympy.parse_expr(d['bioavailability']),

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -346,6 +346,22 @@ class CompartmentalSystemBuilder:
         new_dest = destination.replace(dose=source.dose)
         mapping = {source: new_source, destination: new_dest}
         nx.relabel_nodes(self._g, mapping, copy=False)
+        
+    def move_oral_dose(self, source, destination):
+        """If present, move oral dose(s) (admid = 1) from one compartment to another
+        
+        Parameters
+        ----------
+        source : Compartment
+            Source compartment
+        destination : Compartment
+            Destination compartment
+
+        """
+        new_source = source.replace(dose=source.iv_dose)
+        new_dest = destination.replace(dose=source.oral_dose)
+        mapping = {source: new_source, destination: new_dest}
+        nx.relabel_nodes(self._g, mapping, copy=False)
 
     def set_dose(self, compartment, dose):
         """Set dose of compartment, replacing the previous if existing
@@ -1476,6 +1492,20 @@ class Compartment:
             return tuple(sorted(self._dose, key=lambda d: d.admid))
         else:
             return self._dose
+    
+    @property
+    def oral_dose(self):
+        if self._dose is not None:
+            oral_dose = tuple([dose for dose in self.dose if dose.admid == 1])
+            return oral_dose if oral_dose else None
+        return None
+
+    @property
+    def iv_dose(self):
+        if self._dose is not None:
+            iv_dose = tuple([dose for dose in self.dose if dose.admid == 2])
+            return iv_dose if iv_dose else None
+        return None
 
     @property
     def first_dose(self):

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -331,7 +331,7 @@ class CompartmentalSystemBuilder:
         """
         self._g.remove_edge(source, destination)
 
-    def move_dose(self, source, destination):
+    def move_dose(self, source, destination, admid=None, replace=True):
         """Move a dose input from one compartment to another
 
         Parameters
@@ -340,32 +340,23 @@ class CompartmentalSystemBuilder:
             Source compartment
         destination : Compartment
             Destination compartment
+        admid : int
+            Move dose with specified admid, move all if None. Default is None.
+        replace : bool
+            Replace dose of destination or add to. Default to True
 
         """
-        new_source = source.replace(dose=None)
-        new_dest = destination.replace(dose=source.dose)
-        mapping = {source: new_source, destination: new_dest}
-        nx.relabel_nodes(self._g, mapping, copy=False)
-
-    def move_oral_dose(self, source, destination, single_dose=True):
-        """If present, move oral dose(s) (admid = 1) from one compartment to another.
-        If a only a single dose is present, there is option to move this regardless
-        of type.
-
-        Parameters
-        ----------
-        source : Compartment
-            Source compartment
-        destination : Compartment
-            Destination compartment
-
-        """
-        if source.number_of_doses == 1 and single_dose:
-            new_source = source.replace(dose=None)
+        if admid:
+            new_source_dose = tuple([dose for dose in source.dose if dose.admid != admid])
+            new_dest_dose = tuple([dose for dose in source.dose if dose.admid == admid])
+        else:
+            new_source_dose = None
+            new_dest_dose = source.dose
+        new_source = source.replace(dose=new_source_dose)
+        if replace:
             new_dest = destination.replace(dose=source.dose)
         else:
-            new_source = source.replace(dose=source.iv_dose)
-            new_dest = destination.replace(dose=source.oral_dose)
+            new_dest = destination.replace(dose=destination.dose + new_dest_dose)
         mapping = {source: new_source, destination: new_dest}
         nx.relabel_nodes(self._g, mapping, copy=False)
 

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -1305,11 +1305,11 @@ class CompartmentalSystem(ODESystem):
             current = next_comp
             if not current:
                 break
-        
+
         all_doses = ""
         for dose_comp in self.dosing_compartment:
             for dose in dose_comp.dose:
-                    all_doses += f'{str(dose)} --> {dose_comp.name} \n'
+                all_doses += f'{str(dose)} --> {dose_comp.name} \n'
         s = all_doses + str(grid).rstrip()
         return s
 
@@ -1429,7 +1429,7 @@ class Compartment:
             return tuple(sorted(self._dose, key=lambda d: d.admid))
         else:
             return self._dose
-    
+
     @property
     def first_dose(self):
         if self._dose is not None:
@@ -1557,7 +1557,11 @@ class Compartment:
 
     def __repr__(self):
         lag = '' if self.lag_time == 0 else f', lag_time={self._lag_time}'
-        dose = '' if self.dose is None else f', dose={self._dose[0] if len(self._dose) == 1 else self._dose}'
+        dose = (
+            ''
+            if self.dose is None
+            else f', dose={self._dose[0] if len(self._dose) == 1 else self._dose}'
+        )
         input = '' if self.input == 0 else f', input={self._input}'
         bioavailability = (
             '' if self.bioavailability == 1 else f', bioavailability={self._bioavailability}'

--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -346,10 +346,12 @@ class CompartmentalSystemBuilder:
         new_dest = destination.replace(dose=source.dose)
         mapping = {source: new_source, destination: new_dest}
         nx.relabel_nodes(self._g, mapping, copy=False)
-        
-    def move_oral_dose(self, source, destination):
-        """If present, move oral dose(s) (admid = 1) from one compartment to another
-        
+
+    def move_oral_dose(self, source, destination, single_dose=True):
+        """If present, move oral dose(s) (admid = 1) from one compartment to another.
+        If a only a single dose is present, there is option to move this regardless
+        of type.
+
         Parameters
         ----------
         source : Compartment
@@ -358,8 +360,12 @@ class CompartmentalSystemBuilder:
             Destination compartment
 
         """
-        new_source = source.replace(dose=source.iv_dose)
-        new_dest = destination.replace(dose=source.oral_dose)
+        if source.number_of_doses == 1 and single_dose:
+            new_source = source.replace(dose=None)
+            new_dest = destination.replace(dose=source.dose)
+        else:
+            new_source = source.replace(dose=source.iv_dose)
+            new_dest = destination.replace(dose=source.oral_dose)
         mapping = {source: new_source, destination: new_dest}
         nx.relabel_nodes(self._g, mapping, copy=False)
 
@@ -382,7 +388,7 @@ class CompartmentalSystemBuilder:
         mapping = {compartment: new_comp}
         nx.relabel_nodes(self._g, mapping, copy=False)
         return new_comp
-    
+
     def replace_dose(self, compartment, old_dose, new_dose):
         """
         Replace and existing dose to a compartment
@@ -1524,7 +1530,7 @@ class Compartment:
             return tuple(sorted(self._dose, key=lambda d: d.admid))
         else:
             return self._dose
-    
+
     @property
     def oral_dose(self):
         if self._dose is not None:
@@ -1542,11 +1548,11 @@ class Compartment:
     @property
     def number_of_doses(self):
         return len(self._dose)
-    
+
     @property
     def number_of_oral_doses(self):
         return len(self.oral_dose)
-    
+
     @property
     def number_of_iv_doses(self):
         return len(self.iv_dose)

--- a/src/pharmpy/modeling/basic_models.py
+++ b/src/pharmpy/modeling/basic_models.py
@@ -95,7 +95,7 @@ def create_basic_pk_model(
     vc_ass = Assignment(VC, pop_vc.symbol * sympy.exp(sympy.Symbol(eta_vc_name)))
 
     cb = CompartmentalSystemBuilder()
-    central = Compartment.create('CENTRAL', dose=dosing(di, df, 1))
+    central = Compartment.create('CENTRAL', doses=(dosing(di, df, 1),))
     cb.add_compartment(central)
     cb.add_flow(central, output, CL / VC)
 

--- a/src/pharmpy/modeling/common.py
+++ b/src/pharmpy/modeling/common.py
@@ -417,7 +417,7 @@ def get_model_covariates(model: Model, strings: bool = False):
 
     # Consider statements that are dependencies of the ode system and y
     if odes:
-        dose_comp = odes.first_dosing_compartment
+        dose_comp = odes.dosing_compartments[0]
         cb = CompartmentalSystemBuilder(odes)
         cb.set_dose(dose_comp, None)
         cs = CompartmentalSystem(cb)

--- a/src/pharmpy/modeling/common.py
+++ b/src/pharmpy/modeling/common.py
@@ -358,7 +358,7 @@ def load_example_model(name: str):
              ETA₂
     V = TVV⋅ℯ
     S₁ = V
-    Bolus(AMT, admid=1)
+    Bolus(AMT, admid=2) --> CENTRAL
     ┌───────┐
     │CENTRAL│──CL/V→
     └───────┘

--- a/src/pharmpy/modeling/common.py
+++ b/src/pharmpy/modeling/common.py
@@ -358,7 +358,7 @@ def load_example_model(name: str):
              ETA₂
     V = TVV⋅ℯ
     S₁ = V
-    Bolus(AMT, admid=2) --> CENTRAL
+    Bolus(AMT, admid=1) → CENTRAL
     ┌───────┐
     │CENTRAL│──CL/V→
     └───────┘

--- a/src/pharmpy/modeling/common.py
+++ b/src/pharmpy/modeling/common.py
@@ -417,7 +417,7 @@ def get_model_covariates(model: Model, strings: bool = False):
 
     # Consider statements that are dependencies of the ode system and y
     if odes:
-        dose_comp = odes.dosing_compartment[0]
+        dose_comp = odes.first_dosing_compartment
         cb = CompartmentalSystemBuilder(odes)
         cb.set_dose(dose_comp, None)
         cs = CompartmentalSystem(cb)

--- a/src/pharmpy/modeling/covariate_effect.py
+++ b/src/pharmpy/modeling/covariate_effect.py
@@ -640,8 +640,13 @@ def get_covariates_allowed_in_covariate_effect(model: Model) -> Set[str]:
         di_covariate = []
 
     try:
+        di_admid = model.datainfo.typeix['admid'].names
+    except IndexError:
+        di_admid = []
+
+    try:
         di_unknown = model.datainfo.typeix['unknown'].names
     except IndexError:
         di_unknown = []
 
-    return set(di_covariate).union(di_unknown)
+    return set(di_covariate).union(di_unknown, di_admid)

--- a/src/pharmpy/modeling/data.py
+++ b/src/pharmpy/modeling/data.py
@@ -883,7 +883,7 @@ def get_admid(model: Model):
     adm = get_cmt(model)
     adm = adm.replace(remap)
     adm.name = "ADMID"
-    
+
     # Replace all observations with the previous admid type
     # FIXME : Replace with the last dose instead for all observations?
     current_admin = adm[0]
@@ -970,7 +970,7 @@ def get_cmt(model: Model):
         pass
     else:
         return cmtcols
-    
+
     # See if admid exist
     try:
         admidcols = di.typeix["admid"]

--- a/src/pharmpy/modeling/data.py
+++ b/src/pharmpy/modeling/data.py
@@ -900,6 +900,7 @@ def get_admid(model: Model):
                     adm[i] = current_admin
         else:
             current_subject = subject
+            current_admin = admin
     return adm
 
 

--- a/src/pharmpy/modeling/data.py
+++ b/src/pharmpy/modeling/data.py
@@ -875,7 +875,7 @@ def get_admid(model: Model):
     odes = model.statements.ode_system
     names = odes.compartment_names
     if isinstance(odes, CompartmentalSystem):
-        for dosing in odes.dosing_compartment:
+        for dosing in odes.dosing_compartments:
             if dosing == odes.central_compartment:
                 iv = names.index(dosing.name) + 1
             else:
@@ -946,7 +946,7 @@ def get_cmt(model: Model):
         return model.dataset[cmtcols[0].name]
     odes = model.statements.ode_system
     if isinstance(odes, CompartmentalSystem):
-        dosing = odes.dosing_compartment[0]
+        dosing = odes.first_dosing_compartment
         names = odes.compartment_names
         dose_cmt = names.index(dosing.name) + 1
     else:

--- a/src/pharmpy/modeling/data.py
+++ b/src/pharmpy/modeling/data.py
@@ -883,6 +883,17 @@ def get_admid(model: Model):
     adm = get_cmt(model)
     adm = adm.replace(remap)
     adm.name = "ADMID"
+    
+    # Replace all observations with the previous admid type
+    current = None
+    for i, data in enumerate(zip(get_evid(model), adm)):
+        event = data[0]
+        admin = data[1]
+        if event == 1:
+            current = admin
+        if event != 1:
+            if current is not None:
+                adm[i] = current
     return adm
 
 

--- a/src/pharmpy/modeling/data.py
+++ b/src/pharmpy/modeling/data.py
@@ -885,15 +885,21 @@ def get_admid(model: Model):
     adm.name = "ADMID"
     
     # Replace all observations with the previous admid type
-    current = None
-    for i, data in enumerate(zip(get_evid(model), adm)):
+    # FIXME : Replace with the last dose instead for all observations?
+    current_admin = adm[0]
+    current_subject = model.dataset["ID"][0]
+    for i, data in enumerate(zip(get_evid(model), adm, model.dataset["ID"])):
         event = data[0]
         admin = data[1]
-        if event == 1:
-            current = admin
-        if event != 1:
-            if current is not None:
-                adm[i] = current
+        subject = data[2]
+        if current_subject == subject:
+            if event == 1:
+                current_admin = admin
+            if event != 1:
+                if current_admin is not None:
+                    adm[i] = current_admin
+        else:
+            current_subject = subject
     return adm
 
 

--- a/src/pharmpy/modeling/data.py
+++ b/src/pharmpy/modeling/data.py
@@ -978,7 +978,7 @@ def get_cmt(model: Model):
         # No admid found --> Assume dose/non-dose
         odes = model.statements.ode_system
         if isinstance(odes, CompartmentalSystem):
-            dosing = odes.first_dosing_compartment
+            dosing = odes.dosing_compartments[0]
             names = odes.compartment_names
             dose_cmt = names.index(dosing.name) + 1
         else:

--- a/src/pharmpy/modeling/data.py
+++ b/src/pharmpy/modeling/data.py
@@ -988,6 +988,7 @@ def get_cmt(model: Model):
         cmt.name = "CMT"
         return cmt
     else:
+        admidcols = model.dataset[admidcols[0].name]
         # Admid found -> convert to CMT based on doses
         odes = model.statements.ode_system
         names = odes.compartment_names
@@ -996,9 +997,11 @@ def get_cmt(model: Model):
             for dosing in odes.dosing_compartments:
                 if dosing == odes.central_compartment:
                     remap[2] = names.index(dosing.name) + 1
+                    central_number = names.index(dosing.name) + 1
                 else:
                     remap[1] = names.index(dosing.name) + 1
         admidcols = admidcols.replace(remap)
+        admidcols.loc[get_evid(model) == 0] = central_number
         admidcols.name = "ADMID"
         return admidcols
 

--- a/src/pharmpy/modeling/data.py
+++ b/src/pharmpy/modeling/data.py
@@ -944,6 +944,14 @@ def get_cmt(model: Model):
         pass
     else:
         return model.dataset[cmtcols[0].name]
+
+    try:
+        cmtcols = model.dataset["CMT"]
+    except KeyError:
+        pass
+    else:
+        return cmtcols
+
     odes = model.statements.ode_system
     if isinstance(odes, CompartmentalSystem):
         dosing = odes.first_dosing_compartment

--- a/src/pharmpy/modeling/expressions.py
+++ b/src/pharmpy/modeling/expressions.py
@@ -211,7 +211,7 @@ def create_symbol(model: Model, stem: str, force_numbering: bool = False):
         First part of the new variable name
     force_numbering : bool
         Forces addition of number to name even if variable does not exist, e.g.
-        COVEFF --> COVEFF1
+        COVEFF → COVEFF1
 
     Returns
     -------
@@ -537,7 +537,7 @@ def cleanup_model(model: Model):
              ETA₂
     V = TVV⋅ℯ
     S₁ = V
-    Bolus(AMT, admid=2) --> CENTRAL
+    Bolus(AMT, admid=1) → CENTRAL
     ┌───────┐
     │CENTRAL│──CL/V→
     └───────┘
@@ -565,7 +565,7 @@ def cleanup_model(model: Model):
     CL = TVCL⋅ℯ
              ETA₂
     V = TVV⋅ℯ
-    Bolus(AMT, admid=2) --> CENTRAL
+    Bolus(AMT, admid=1) → CENTRAL
     ┌───────┐
     │CENTRAL│──CL/V→
     └───────┘
@@ -627,7 +627,7 @@ def greekify_model(model: Model, named_subscripts: bool = False):
              ETA₂
     V = TVV⋅ℯ
     S₁ = V
-    Bolus(AMT, admid=2) --> CENTRAL
+    Bolus(AMT, admid=1) → CENTRAL
     ┌───────┐
     │CENTRAL│──CL/V→
     └───────┘
@@ -656,7 +656,7 @@ def greekify_model(model: Model, named_subscripts: bool = False):
     CL = TVCL⋅ℯ
              η₂
     V = TVV⋅ℯ
-    Bolus(AMT, admid=2) --> CENTRAL
+    Bolus(AMT, admid=1) → CENTRAL
     ┌───────┐
     │CENTRAL│──CL/V→
     └───────┘

--- a/src/pharmpy/modeling/expressions.py
+++ b/src/pharmpy/modeling/expressions.py
@@ -1261,8 +1261,8 @@ def _pk_free_symbols(cs: CompartmentalSystem, kind: str) -> Iterable[sympy.Symbo
     if kind == 'absorption':
         return (
             []
-            if cs.first_dosing_compartment == cs.central_compartment
-            else _pk_free_symbols_from_compartment(cs, cs.first_dosing_compartment)
+            if cs.dosing_compartments[0] == cs.central_compartment
+            else _pk_free_symbols_from_compartment(cs, cs.dosing_compartments[0])
         )
 
     if kind == 'distribution':

--- a/src/pharmpy/modeling/expressions.py
+++ b/src/pharmpy/modeling/expressions.py
@@ -1261,8 +1261,8 @@ def _pk_free_symbols(cs: CompartmentalSystem, kind: str) -> Iterable[sympy.Symbo
     if kind == 'absorption':
         return (
             []
-            if cs.dosing_compartment[0] == cs.central_compartment
-            else _pk_free_symbols_from_compartment(cs, cs.dosing_compartment[0])
+            if cs.first_dosing_compartment == cs.central_compartment
+            else _pk_free_symbols_from_compartment(cs, cs.first_dosing_compartment)
         )
 
     if kind == 'distribution':

--- a/src/pharmpy/modeling/expressions.py
+++ b/src/pharmpy/modeling/expressions.py
@@ -537,7 +537,7 @@ def cleanup_model(model: Model):
              ETA₂
     V = TVV⋅ℯ
     S₁ = V
-    Bolus(AMT, admid=1)
+    Bolus(AMT, admid=2) --> CENTRAL
     ┌───────┐
     │CENTRAL│──CL/V→
     └───────┘
@@ -565,7 +565,7 @@ def cleanup_model(model: Model):
     CL = TVCL⋅ℯ
              ETA₂
     V = TVV⋅ℯ
-    Bolus(AMT, admid=1)
+    Bolus(AMT, admid=2) --> CENTRAL
     ┌───────┐
     │CENTRAL│──CL/V→
     └───────┘
@@ -627,7 +627,7 @@ def greekify_model(model: Model, named_subscripts: bool = False):
              ETA₂
     V = TVV⋅ℯ
     S₁ = V
-    Bolus(AMT, admid=1)
+    Bolus(AMT, admid=2) --> CENTRAL
     ┌───────┐
     │CENTRAL│──CL/V→
     └───────┘
@@ -656,7 +656,7 @@ def greekify_model(model: Model, named_subscripts: bool = False):
     CL = TVCL⋅ℯ
              η₂
     V = TVV⋅ℯ
-    Bolus(AMT, admid=1)
+    Bolus(AMT, admid=2) --> CENTRAL
     ┌───────┐
     │CENTRAL│──CL/V→
     └───────┘

--- a/src/pharmpy/modeling/odes.py
+++ b/src/pharmpy/modeling/odes.py
@@ -1212,7 +1212,7 @@ def set_first_order_absorption(model: Model):
         dose_comp = cb.set_lag_time(dose_comp, sympy.Integer(0))
     if not depot:
         # TODO : Add another way of removing dependencies
-        if dose_comp.number_of_doses == 1:
+        if len(dose_comp.dose) == 1:
             dose_comp = cb.set_dose(dose_comp, Bolus(amount))
             remove_dose = True
         else:
@@ -1351,7 +1351,7 @@ def set_seq_zo_fo_absorption(model: Model):
     if depot and not have_ZO:
         model = _add_zero_order_absorption(model, dose_comp.dose[0], depot, 'MDT')
     elif not depot and have_ZO:
-        if dose_comp.number_of_doses == 1:
+        if len(dose_comp.dose) == 1:
             fo_dose = dose_comp.dose[0]
             remove_dose = True
         else:

--- a/src/pharmpy/modeling/odes.py
+++ b/src/pharmpy/modeling/odes.py
@@ -1343,6 +1343,7 @@ def set_seq_zo_fo_absorption(model: Model):
         model = _add_zero_order_absorption(model, dose_comp.first_dose, depot, 'MDT')
     elif not depot and have_ZO:
         if dose_comp.number_of_doses == 1:
+            fo_dose = dose_comp.first_dose
             remove_dose = True
         else:
             fo_dose = dose_comp.first_dose

--- a/src/pharmpy/modeling/odes.py
+++ b/src/pharmpy/modeling/odes.py
@@ -1201,7 +1201,9 @@ def set_first_order_absorption(model: Model):
     bio = dose_comp.bioavailability
     cb = CompartmentalSystemBuilder(cs)
     if depot and depot == dose_comp:
-        dose_comp = cb.replace_dose(dose_comp, dose_comp.first_dose, Bolus(dose_comp.first_dose.amount))
+        dose_comp = cb.replace_dose(
+            dose_comp, dose_comp.first_dose, Bolus(dose_comp.first_dose.amount)
+        )
         dose_comp = cb.set_lag_time(dose_comp, sympy.Integer(0))
     if not depot:
         # TODO : Add another way of removing dependencies
@@ -1223,7 +1225,9 @@ def set_first_order_absorption(model: Model):
     model = remove_unused_parameters_and_rvs(model)
     if not depot:
         # The new dose is created here
-        model, _ = _add_first_order_absorption(model, Bolus(amount), dose_comp, lag_time, bio, remove_dose=remove_dose)
+        model, _ = _add_first_order_absorption(
+            model, Bolus(amount), dose_comp, lag_time, bio, remove_dose=remove_dose
+        )
         model = model.update_source()
     return model
 
@@ -1452,7 +1456,9 @@ def _add_zero_order_absorption(model, old_dose, to_comp, parameter_name, lag_tim
     return model
 
 
-def _add_first_order_absorption(model, dose, to_comp, lag_time=None, bioavailability=None, remove_dose=True):
+def _add_first_order_absorption(
+    model, dose, to_comp, lag_time=None, bioavailability=None, remove_dose=True
+):
     """Add first order absorption
     Disregards what is currently in the model.
     """

--- a/src/pharmpy/modeling/odes.py
+++ b/src/pharmpy/modeling/odes.py
@@ -209,7 +209,7 @@ def set_first_order_elimination(model: Model):
 
 
 def add_bioavailability(
-    model: Model, add_parameter: bool = True, init: float = 0.5, lower: float = 0, upper: float = 1
+    model: Model, add_parameter: bool = True, lower: float = 0, upper: float = 1
 ):
     """Add bioavailability statement for the first dose compartment of the model.
     Can be added as a new parameter or otherwise it will be set to 1.
@@ -220,8 +220,6 @@ def add_bioavailability(
         Pharmpy model
     add_parameter : bool
         Add new parameter representing bioavailability or not
-    init: float
-
 
     Return
     ------
@@ -250,7 +248,7 @@ def add_bioavailability(
         # Bio not defined
         if add_parameter:
             model, bio_symb = _add_parameter(
-                model, 'BIO', init=float(init), lower=float(lower), upper=float(upper)
+                model, 'BIO', init=float(bio), lower=float(lower), upper=float(upper)
             )
             f_ass = Assignment.create(sympy.Symbol('F_BIO'), bio_symb)
 

--- a/src/pharmpy/modeling/odes.py
+++ b/src/pharmpy/modeling/odes.py
@@ -1190,8 +1190,9 @@ def set_first_order_absorption(model: Model):
     if depot and depot == dose_comp:
         dose_comp = cb.set_dose(dose_comp, Bolus(dose_comp.first_dose.amount))
         dose_comp = cb.set_lag_time(dose_comp, sympy.Integer(0))
-    if not depot:
-        dose_comp = cb.set_dose(dose_comp, Bolus(amount))
+    # FIXME : What is the purpose of this?
+    #if not depot:
+    #   dose_comp = cb.set_dose(dose_comp, Bolus(amount))
     statements = statements.before_odes + CompartmentalSystem(cb) + statements.after_odes
 
     new_statements = statements.remove_symbol_definitions(symbols, statements.ode_system)
@@ -1429,7 +1430,7 @@ def _add_first_order_absorption(model, dose, to_comp, lag_time=None, bioavailabi
         bioavailability=sympy.Integer(1) if bioavailability is None else bioavailability,
     )
     cb.add_compartment(depot)
-    to_comp = cb.set_dose(to_comp, None)
+    to_comp = cb.set_dose(to_comp, to_comp.iv_dose)
     to_comp = cb.set_lag_time(to_comp, sympy.Integer(0))
     to_comp = cb.set_bioavailability(to_comp, sympy.Integer(1))
 

--- a/src/pharmpy/modeling/odes.py
+++ b/src/pharmpy/modeling/odes.py
@@ -1423,7 +1423,7 @@ def _add_zero_order_absorption(model, old_dose, to_comp, parameter_name, lag_tim
             model, parameter_name, init=_get_absorption_init(model, parameter_name)
         )
     if to_comp == model.statements.ode_system.central_compartment:
-        new_dose = Infusion(old_dose.amount, admid=2, duration=mat_symb * 2)
+        new_dose = Infusion(old_dose.amount, duration=mat_symb * 2)
     else:
         new_dose = Infusion(old_dose.amount, duration=mat_symb * 2)
     cb = CompartmentalSystemBuilder(model.statements.ode_system)

--- a/src/pharmpy/modeling/odes.py
+++ b/src/pharmpy/modeling/odes.py
@@ -873,7 +873,7 @@ def set_transit_compartments(model: Model, n: int, keep_depot: bool = True):
             comp = new_comp
         comp = cb.set_bioavailability(comp, dosing_comp.bioavailability)
         dosing_comp = cb.set_bioavailability(dosing_comp, sympy.Integer(1))
-        cb.move_dose(dosing_comp, comp)
+        cb.move_oral_dose(dosing_comp, comp)
         statements = (
             model.statements.before_odes + CompartmentalSystem(cb) + model.statements.after_odes
         )

--- a/src/pharmpy/modeling/results.py
+++ b/src/pharmpy/modeling/results.py
@@ -463,7 +463,7 @@ def calculate_pk_parameters_statistics(
         d = sympy.diff(expr, odes.t)
         tmax_closed_form = sympy.solve(d, odes.t)[0]
         expressions.append(sympy.Eq(sympy.Symbol('t_max'), tmax_closed_form))
-        e2 = sympy.simplify(expr / depot.dose[0].amount / sympy.denom(elimination_rate))
+        e2 = sympy.simplify(expr / depot.doses[0].amount / sympy.denom(elimination_rate))
         cmax_dose_closed_form = sympy.simplify(
             subs(e2, {odes.t: tmax_closed_form}, simultaneous=True)
         )
@@ -498,8 +498,8 @@ def calculate_pk_parameters_statistics(
 
         beta = m[beta] / odes.t
         alpha = m[alpha] / odes.t
-        A = m[A] / central.dose[0].amount
-        B = m[B] / central.dose[0].amount
+        A = m[A] / central.doses[0].amount
+        B = m[B] / central.doses[0].amount
 
         if (beta - alpha).extract_multiplicatively(-1) is not None:
             # alpha > beta  (sympy couldn't simplify this directly)

--- a/src/pharmpy/modeling/results.py
+++ b/src/pharmpy/modeling/results.py
@@ -463,7 +463,7 @@ def calculate_pk_parameters_statistics(
         d = sympy.diff(expr, odes.t)
         tmax_closed_form = sympy.solve(d, odes.t)[0]
         expressions.append(sympy.Eq(sympy.Symbol('t_max'), tmax_closed_form))
-        e2 = sympy.simplify(expr / depot.first_dose.amount / sympy.denom(elimination_rate))
+        e2 = sympy.simplify(expr / depot.dose[0].amount / sympy.denom(elimination_rate))
         cmax_dose_closed_form = sympy.simplify(
             subs(e2, {odes.t: tmax_closed_form}, simultaneous=True)
         )
@@ -498,8 +498,8 @@ def calculate_pk_parameters_statistics(
 
         beta = m[beta] / odes.t
         alpha = m[alpha] / odes.t
-        A = m[A] / central.first_dose.amount
-        B = m[B] / central.first_dose.amount
+        A = m[A] / central.dose[0].amount
+        B = m[B] / central.dose[0].amount
 
         if (beta - alpha).extract_multiplicatively(-1) is not None:
             # alpha > beta  (sympy couldn't simplify this directly)

--- a/src/pharmpy/modeling/results.py
+++ b/src/pharmpy/modeling/results.py
@@ -463,7 +463,7 @@ def calculate_pk_parameters_statistics(
         d = sympy.diff(expr, odes.t)
         tmax_closed_form = sympy.solve(d, odes.t)[0]
         expressions.append(sympy.Eq(sympy.Symbol('t_max'), tmax_closed_form))
-        e2 = sympy.simplify(expr / depot.dose.amount / sympy.denom(elimination_rate))
+        e2 = sympy.simplify(expr / depot.first_dose.amount / sympy.denom(elimination_rate))
         cmax_dose_closed_form = sympy.simplify(
             subs(e2, {odes.t: tmax_closed_form}, simultaneous=True)
         )
@@ -498,8 +498,8 @@ def calculate_pk_parameters_statistics(
 
         beta = m[beta] / odes.t
         alpha = m[alpha] / odes.t
-        A = m[A] / central.dose.amount
-        B = m[B] / central.dose.amount
+        A = m[A] / central.first_dose.amount
+        B = m[B] / central.first_dose.amount
 
         if (beta - alpha).extract_multiplicatively(-1) is not None:
             # alpha > beta  (sympy couldn't simplify this directly)

--- a/src/pharmpy/tools/amd/funcs.py
+++ b/src/pharmpy/tools/amd/funcs.py
@@ -24,6 +24,8 @@ from pharmpy.model import (
 # FIXME: This shouldn't be used here
 from pharmpy.model.external.nonmem.advan import dosing, find_dose
 from pharmpy.modeling import (
+    add_admid,
+    add_bioavailability,
     add_iiv,
     create_joint_distribution,
     set_first_order_absorption,

--- a/src/pharmpy/tools/amd/funcs.py
+++ b/src/pharmpy/tools/amd/funcs.py
@@ -24,8 +24,6 @@ from pharmpy.model import (
 # FIXME: This shouldn't be used here
 from pharmpy.model.external.nonmem.advan import dosing, find_dose
 from pharmpy.modeling import (
-    add_admid,
-    add_bioavailability,
     add_iiv,
     create_joint_distribution,
     set_first_order_absorption,

--- a/src/pharmpy/tools/amd/funcs.py
+++ b/src/pharmpy/tools/amd/funcs.py
@@ -58,7 +58,7 @@ def create_start_model(dataset_path, modeltype='pk_oral', cl_init=0.01, vc_init=
 
     cb = CompartmentalSystemBuilder()
     doses = dosing(di, df, 1)
-    central = Compartment.create('CENTRAL', dose=find_dose(doses, 1))
+    central = Compartment.create('CENTRAL', doses=find_dose(doses, 1))
     cb.add_compartment(central)
     cb.add_flow(central, output, CL / VC)
 

--- a/tests/model/test_statements.py
+++ b/tests/model/test_statements.py
@@ -293,7 +293,7 @@ def test_find_compartment(load_model_for_test, testdata):
 
 def test_dosing_compartment(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    assert model.statements.ode_system.first_dosing_compartment.name == 'CENTRAL'
+    assert model.statements.ode_system.dosing_compartments[0].name == 'CENTRAL'
 
 
 def test_central_compartment(load_model_for_test, testdata):
@@ -432,12 +432,12 @@ def test_builder():
     cb.add_compartment(depot)
     cb.add_flow(depot, central, S('KA'))
     cm = CompartmentalSystem(cb)
-    assert cm.find_compartment('DEPOT').first_dose is None
-    assert cm.central_compartment.first_dose == dose
+    assert not cm.find_compartment('DEPOT').dose
+    assert cm.central_compartment.dose[0] == dose
     cb.move_dose(central, depot)
     cm2 = CompartmentalSystem(cb)
-    assert cm2.find_compartment('DEPOT').first_dose == dose
-    assert cm2.central_compartment.dose is None
+    assert cm2.find_compartment('DEPOT').dose[0] == dose
+    assert not cm2.central_compartment.dose
     assert hash(cm) != hash(cm2)
 
 
@@ -488,4 +488,4 @@ def test_multi_dose_comp_order(load_model_for_test, testdata):
     cb = CompartmentalSystemBuilder(ode)
     cb.set_dose(cb.find_compartment("CENTRAL"), cb.find_compartment("DEPOT").dose)
     ode = CompartmentalSystem(cb)
-    assert ode.first_dosing_compartment.name == "DEPOT"
+    assert ode.dosing_compartments[0].name == "DEPOT"

--- a/tests/model/test_statements.py
+++ b/tests/model/test_statements.py
@@ -293,7 +293,7 @@ def test_find_compartment(load_model_for_test, testdata):
 
 def test_dosing_compartment(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    assert model.statements.ode_system.dosing_compartment[0].name == 'CENTRAL'
+    assert model.statements.ode_system.first_dosing_compartment.name == 'CENTRAL'
 
 
 def test_central_compartment(load_model_for_test, testdata):
@@ -488,4 +488,4 @@ def test_multi_dose_comp_order(load_model_for_test, testdata):
     cb = CompartmentalSystemBuilder(ode)
     cb.set_dose(cb.find_compartment("CENTRAL"), cb.find_compartment("DEPOT").dose)
     ode = CompartmentalSystem(cb)
-    assert ode.dosing_compartment[0].name == "DEPOT"
+    assert ode.first_dosing_compartment.name == "DEPOT"

--- a/tests/model/test_statements.py
+++ b/tests/model/test_statements.py
@@ -186,7 +186,7 @@ def test_dict(load_model_for_test, testdata):
                 'class': 'Compartment',
                 'name': 'CENTRAL',
                 'amount': "Symbol('A_CENTRAL')",
-                'dose': ({'class': 'Bolus', 'amount': "Symbol('AMT')", 'admid': 1},),
+                'dose': ({'class': 'Bolus', 'amount': "Symbol('AMT')", 'admid': 2},),
                 'input': 'Integer(0)',
                 'lag_time': 'Integer(0)',
                 'bioavailability': 'Integer(1)',

--- a/tests/model/test_statements.py
+++ b/tests/model/test_statements.py
@@ -156,13 +156,13 @@ def test_dict(load_model_for_test, testdata):
     inf2 = Infusion.from_dict(d)
     assert inf1 == inf2
 
-    central = Compartment.create('CENTRAL', dose=dose1)
+    central = Compartment.create('CENTRAL', doses=(dose1,))
     d = central.to_dict()
     assert d == {
         'class': 'Compartment',
         'name': 'CENTRAL',
         'amount': "Symbol('A_CENTRAL')",
-        'dose': ({'class': 'Bolus', 'amount': "Symbol('AMT')", 'admid': 1},),
+        'doses': ({'class': 'Bolus', 'amount': "Symbol('AMT')", 'admid': 1},),
         'input': 'Integer(0)',
         'lag_time': 'Integer(0)',
         'bioavailability': 'Integer(1)',
@@ -186,7 +186,7 @@ def test_dict(load_model_for_test, testdata):
                 'class': 'Compartment',
                 'name': 'CENTRAL',
                 'amount': "Symbol('A_CENTRAL')",
-                'dose': ({'class': 'Bolus', 'amount': "Symbol('AMT')", 'admid': 2},),
+                'doses': ({'class': 'Bolus', 'amount': "Symbol('AMT')", 'admid': 1},),
                 'input': 'Integer(0)',
                 'lag_time': 'Integer(0)',
                 'bioavailability': 'Integer(1)',
@@ -371,7 +371,7 @@ def test_repr_html():
 
     cb = CompartmentalSystemBuilder()
     dose = Bolus.create('AMT')
-    central = Compartment.create('CENTRAL', dose=dose)
+    central = Compartment.create('CENTRAL', doses=(dose,))
     cb.add_compartment(central)
     cb.add_compartment(output)
     cb.add_flow(central, output, S('K'))
@@ -425,19 +425,19 @@ def test_dependencies(load_model_for_test, pheno_path):
 def test_builder():
     cb = CompartmentalSystemBuilder()
     dose = Bolus('AMT')
-    central = Compartment.create('CENTRAL', dose=dose)
+    central = Compartment.create('CENTRAL', doses=(dose,))
     cb.add_compartment(central)
     cb.add_flow(central, output, S('K'))
     depot = Compartment.create('DEPOT')
     cb.add_compartment(depot)
     cb.add_flow(depot, central, S('KA'))
     cm = CompartmentalSystem(cb)
-    assert not cm.find_compartment('DEPOT').dose
-    assert cm.central_compartment.dose[0] == dose
+    assert not cm.find_compartment('DEPOT').doses
+    assert cm.central_compartment.doses[0] == dose
     cb.move_dose(central, depot)
     cm2 = CompartmentalSystem(cb)
-    assert cm2.find_compartment('DEPOT').dose[0] == dose
-    assert not cm2.central_compartment.dose
+    assert cm2.find_compartment('DEPOT').doses[0] == dose
+    assert not cm2.central_compartment.doses
     assert hash(cm) != hash(cm2)
 
 
@@ -486,6 +486,6 @@ def test_multi_dose_comp_order(load_model_for_test, testdata):
 
     ode = model.statements.ode_system
     cb = CompartmentalSystemBuilder(ode)
-    cb.set_dose(cb.find_compartment("CENTRAL"), cb.find_compartment("DEPOT").dose)
+    cb.set_dose(cb.find_compartment("CENTRAL"), cb.find_compartment("DEPOT").doses)
     ode = CompartmentalSystem(cb)
     assert ode.dosing_compartments[0].name == "DEPOT"

--- a/tests/model/test_statements.py
+++ b/tests/model/test_statements.py
@@ -162,7 +162,7 @@ def test_dict(load_model_for_test, testdata):
         'class': 'Compartment',
         'name': 'CENTRAL',
         'amount': "Symbol('A_CENTRAL')",
-        'dose': {'class': 'Bolus', 'amount': "Symbol('AMT')", 'admid': 1},
+        'dose': ({'class': 'Bolus', 'amount': "Symbol('AMT')", 'admid': 1},),
         'input': 'Integer(0)',
         'lag_time': 'Integer(0)',
         'bioavailability': 'Integer(1)',
@@ -186,7 +186,7 @@ def test_dict(load_model_for_test, testdata):
                 'class': 'Compartment',
                 'name': 'CENTRAL',
                 'amount': "Symbol('A_CENTRAL')",
-                'dose': {'class': 'Bolus', 'amount': "Symbol('AMT')", 'admid': 1},
+                'dose': ({'class': 'Bolus', 'amount': "Symbol('AMT')", 'admid': 1},),
                 'input': 'Integer(0)',
                 'lag_time': 'Integer(0)',
                 'bioavailability': 'Integer(1)',
@@ -432,11 +432,11 @@ def test_builder():
     cb.add_compartment(depot)
     cb.add_flow(depot, central, S('KA'))
     cm = CompartmentalSystem(cb)
-    assert cm.find_compartment('DEPOT').dose is None
-    assert cm.central_compartment.dose == dose
+    assert cm.find_compartment('DEPOT').first_dose is None
+    assert cm.central_compartment.first_dose == dose
     cb.move_dose(central, depot)
     cm2 = CompartmentalSystem(cb)
-    assert cm2.find_compartment('DEPOT').dose == dose
+    assert cm2.find_compartment('DEPOT').first_dose == dose
     assert cm2.central_compartment.dose is None
     assert hash(cm) != hash(cm2)
 

--- a/tests/modeling/test_odes.py
+++ b/tests/modeling/test_odes.py
@@ -2650,5 +2650,5 @@ def test_multi_dose_change_absorption(load_model_for_test, testdata):
     model = set_zero_order_absorption(model)
     central = model.statements.ode_system.find_compartment("CENTRAL")
 
-    assert central.number_of_doses == 2
+    assert len(central.dose) == 2
     assert central.dose[0] == Infusion(sympy.Symbol('AMT'), admid=1, duration=sympy.Symbol("D1"))

--- a/tests/modeling/test_odes.py
+++ b/tests/modeling/test_odes.py
@@ -2655,4 +2655,4 @@ def test_multi_dose_change_absorption(load_model_for_test, testdata):
     central = model.statements.ode_system.find_compartment("CENTRAL")
 
     assert central.number_of_doses == 2
-    assert central.first_dose == Infusion(sympy.Symbol('AMT'), admid=1, duration=sympy.Symbol("D1"))
+    assert central.first_dose == Infusion(sympy.Symbol('AMT'), admid=2, duration=sympy.Symbol("D1"))

--- a/tests/modeling/test_odes.py
+++ b/tests/modeling/test_odes.py
@@ -1695,7 +1695,7 @@ def test_move_bioavailability(load_model_for_test, testdata):
     model = set_first_order_absorption(model)
     assert model.statements.ode_system.dosing_compartments[0].name == "DEPOT"
     assert model.statements.ode_system.dosing_compartments[0].bioavailability == sympy.Symbol("F1")
-    assert not model.statements.ode_system.find_compartment("CENTRAL").dose
+    assert not model.statements.ode_system.find_compartment("CENTRAL").doses
 
 
 def test_lag_time(load_model_for_test, testdata):
@@ -2644,11 +2644,11 @@ def test_multi_dose_change_absorption(load_model_for_test, testdata):
     depot = model.statements.ode_system.find_compartment("DEPOT")
     central = model.statements.ode_system.find_compartment("CENTRAL")
 
-    assert depot.dose[0] == Bolus(sympy.Symbol('AMT'), admid=1)
-    assert central.dose[0] == Bolus(sympy.Symbol('AMT'), admid=2)
+    assert depot.doses[0] == Bolus(sympy.Symbol('AMT'), admid=1)
+    assert central.doses[0] == Bolus(sympy.Symbol('AMT'), admid=1)
 
     model = set_zero_order_absorption(model)
     central = model.statements.ode_system.find_compartment("CENTRAL")
 
-    assert len(central.dose) == 2
-    assert central.dose[0] == Infusion(sympy.Symbol('AMT'), admid=1, duration=sympy.Symbol("D1"))
+    assert len(central.doses) == 2
+    assert central.doses[0] == Infusion(sympy.Symbol('AMT'), admid=1, duration=sympy.Symbol("D1"))

--- a/tests/modeling/test_odes.py
+++ b/tests/modeling/test_odes.py
@@ -41,6 +41,13 @@ from pharmpy.modeling import (
     set_zero_order_input,
 )
 
+from pharmpy.modeling.odes import (
+    CompartmentalSystem,
+    CompartmentalSystemBuilder,
+    )
+
+from pharmpy.model import Bolus
+
 
 def test_advan1(create_model_for_test):
     code = """$PROBLEM PHENOBARB SIMPLE MODEL
@@ -2629,3 +2636,20 @@ def test_find_clearance_and_volume_parameters_tmdd(load_example_model_for_test):
     model = set_tmdd(model, 'qss')
     assert find_clearance_parameters(model) == _symbols(['CL', 'LAFREE'])
     assert find_volume_parameters(model) == _symbols(['V'])
+
+def test_multi_dose_fo_absorption(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
+    ode = model.statements.ode_system
+    cb = CompartmentalSystemBuilder(ode)
+    cb.add_dose(cb.find_compartment("CENTRAL"), Bolus(sympy.Symbol('AMT'), admid=1))
+    ode = CompartmentalSystem(cb)
+    model = model.replace(statements = model.statements.before_odes + ode + model.statements.after_odes)
+    
+    model = set_first_order_absorption(model)
+    assert len(model.statements.ode_system.dosing_compartments) == 2
+    
+    depot = model.statements.ode_system.find_compartment("DEPOT")
+    central = model.statements.ode_system.find_compartment("CENTRAL")
+    
+    assert depot.first_dose == Bolus(sympy.Symbol('AMT'), admid=1)
+    assert central.first_dose == Bolus(sympy.Symbol('AMT'), admid=2)

--- a/tests/modeling/test_odes.py
+++ b/tests/modeling/test_odes.py
@@ -1689,11 +1689,11 @@ def test_bioavailability(load_model_for_test, testdata):
 def test_move_bioavailability(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     model = add_bioavailability(model)
-    assert model.statements.ode_system.dosing_compartment[0].bioavailability == sympy.Symbol("F1")
+    assert model.statements.ode_system.first_dosing_compartment.bioavailability == sympy.Symbol("F1")
 
     model = set_first_order_absorption(model)
-    assert model.statements.ode_system.dosing_compartment[0].name == "DEPOT"
-    assert model.statements.ode_system.dosing_compartment[0].bioavailability == sympy.Symbol("F1")
+    assert model.statements.ode_system.first_dosing_compartment.name == "DEPOT"
+    assert model.statements.ode_system.first_dosing_compartment.bioavailability == sympy.Symbol("F1")
     assert model.statements.ode_system.find_compartment("CENTRAL").dose is None
 
 

--- a/tests/modeling/test_odes.py
+++ b/tests/modeling/test_odes.py
@@ -1689,11 +1689,15 @@ def test_bioavailability(load_model_for_test, testdata):
 def test_move_bioavailability(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     model = add_bioavailability(model)
-    assert model.statements.ode_system.first_dosing_compartment.bioavailability == sympy.Symbol("F1")
+    assert model.statements.ode_system.first_dosing_compartment.bioavailability == sympy.Symbol(
+        "F1"
+    )
 
     model = set_first_order_absorption(model)
     assert model.statements.ode_system.first_dosing_compartment.name == "DEPOT"
-    assert model.statements.ode_system.first_dosing_compartment.bioavailability == sympy.Symbol("F1")
+    assert model.statements.ode_system.first_dosing_compartment.bioavailability == sympy.Symbol(
+        "F1"
+    )
     assert model.statements.ode_system.find_compartment("CENTRAL").dose is None
 
 

--- a/tests/modeling/test_odes.py
+++ b/tests/modeling/test_odes.py
@@ -46,7 +46,7 @@ from pharmpy.modeling.odes import (
     CompartmentalSystemBuilder,
     )
 
-from pharmpy.model import Bolus
+from pharmpy.model import Bolus, Infusion
 
 
 def test_advan1(create_model_for_test):
@@ -2637,7 +2637,7 @@ def test_find_clearance_and_volume_parameters_tmdd(load_example_model_for_test):
     assert find_clearance_parameters(model) == _symbols(['CL', 'LAFREE'])
     assert find_volume_parameters(model) == _symbols(['V'])
 
-def test_multi_dose_fo_absorption(load_model_for_test, testdata):
+def test_multi_dose_change_absorption(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     ode = model.statements.ode_system
     cb = CompartmentalSystemBuilder(ode)
@@ -2653,3 +2653,9 @@ def test_multi_dose_fo_absorption(load_model_for_test, testdata):
     
     assert depot.first_dose == Bolus(sympy.Symbol('AMT'), admid=1)
     assert central.first_dose == Bolus(sympy.Symbol('AMT'), admid=2)
+    
+    model = set_zero_order_absorption(model)
+    central = model.statements.ode_system.find_compartment("CENTRAL")
+    
+    assert central.number_of_doses == 2
+    assert central.first_dose == Infusion(sympy.Symbol('AMT'), admid=1, duration=sympy.Symbol("D1"))

--- a/tests/nonmem/test_advan.py
+++ b/tests/nonmem/test_advan.py
@@ -280,4 +280,4 @@ def test_multiple_dv_CMT_parsing(tmp_path, testdata, load_model_for_test, create
         dataset.to_csv(tmp_path / "data_iv_oral.csv", index=False)
         model = create_model_for_test(code)
         odes = model.statements.ode_system
-        assert len(odes.dosing_compartment) == 2
+        assert len(odes.dosing_compartments) == 2

--- a/tests/tools/test_start_model.py
+++ b/tests/tools/test_start_model.py
@@ -11,7 +11,7 @@ def test_create_start_model(testdata):
     assert len(model.parameters) == 6
     assert 'POP_CL' in model.parameters
     assert 'POP_MAT' not in model.parameters
-    assert model.statements.ode_system.dosing_compartments[0].dose[0] == Bolus.create("AMT")
+    assert model.statements.ode_system.dosing_compartments[0].doses[0] == Bolus.create("AMT")
     model = create_start_model(path, modeltype='pk_oral')
     assert 'IIV_MAT' in model.parameters
     assert 'POP_CL' in model.parameters
@@ -19,6 +19,6 @@ def test_create_start_model(testdata):
 
     path_2 = testdata / 'nonmem' / 'modeling' / 'pheno_zero_order.csv'
     model = create_start_model(path_2, modeltype='pk_iv')
-    assert model.statements.ode_system.dosing_compartments[0].dose[0] == Infusion.create(
+    assert model.statements.ode_system.dosing_compartments[0].doses[0] == Infusion.create(
         "AMT", duration="D1"
     )

--- a/tests/tools/test_start_model.py
+++ b/tests/tools/test_start_model.py
@@ -11,7 +11,7 @@ def test_create_start_model(testdata):
     assert len(model.parameters) == 6
     assert 'POP_CL' in model.parameters
     assert 'POP_MAT' not in model.parameters
-    assert model.statements.ode_system.dosing_compartment[0].dose == Bolus.create("AMT")
+    assert model.statements.ode_system.dosing_compartment[0].first_dose == Bolus.create("AMT")
     model = create_start_model(path, modeltype='pk_oral')
     assert 'IIV_MAT' in model.parameters
     assert 'POP_CL' in model.parameters
@@ -19,6 +19,6 @@ def test_create_start_model(testdata):
 
     path_2 = testdata / 'nonmem' / 'modeling' / 'pheno_zero_order.csv'
     model = create_start_model(path_2, modeltype='pk_iv')
-    assert model.statements.ode_system.dosing_compartment[0].dose == Infusion.create(
+    assert model.statements.ode_system.dosing_compartment[0].first_dose == Infusion.create(
         "AMT", duration="D1"
     )

--- a/tests/tools/test_start_model.py
+++ b/tests/tools/test_start_model.py
@@ -11,7 +11,7 @@ def test_create_start_model(testdata):
     assert len(model.parameters) == 6
     assert 'POP_CL' in model.parameters
     assert 'POP_MAT' not in model.parameters
-    assert model.statements.ode_system.dosing_compartment[0].first_dose == Bolus.create("AMT")
+    assert model.statements.ode_system.first_dosing_compartment.first_dose == Bolus.create("AMT")
     model = create_start_model(path, modeltype='pk_oral')
     assert 'IIV_MAT' in model.parameters
     assert 'POP_CL' in model.parameters
@@ -19,6 +19,6 @@ def test_create_start_model(testdata):
 
     path_2 = testdata / 'nonmem' / 'modeling' / 'pheno_zero_order.csv'
     model = create_start_model(path_2, modeltype='pk_iv')
-    assert model.statements.ode_system.dosing_compartment[0].first_dose == Infusion.create(
+    assert model.statements.ode_system.first_dosing_compartment.first_dose == Infusion.create(
         "AMT", duration="D1"
     )

--- a/tests/tools/test_start_model.py
+++ b/tests/tools/test_start_model.py
@@ -11,7 +11,7 @@ def test_create_start_model(testdata):
     assert len(model.parameters) == 6
     assert 'POP_CL' in model.parameters
     assert 'POP_MAT' not in model.parameters
-    assert model.statements.ode_system.first_dosing_compartment.first_dose == Bolus.create("AMT")
+    assert model.statements.ode_system.dosing_compartments[0].dose[0] == Bolus.create("AMT")
     model = create_start_model(path, modeltype='pk_oral')
     assert 'IIV_MAT' in model.parameters
     assert 'POP_CL' in model.parameters
@@ -19,6 +19,6 @@ def test_create_start_model(testdata):
 
     path_2 = testdata / 'nonmem' / 'modeling' / 'pheno_zero_order.csv'
     model = create_start_model(path_2, modeltype='pk_iv')
-    assert model.statements.ode_system.first_dosing_compartment.first_dose == Infusion.create(
+    assert model.statements.ode_system.dosing_compartments[0].dose[0] == Infusion.create(
         "AMT", duration="D1"
     )


### PR DESCRIPTION
Added update to both support multiple doses per compartment as  well as the parsing ability of these models. Models with multiple doses require either a CMT column or an admid column in order to work correctly. Changes some naming convention to be more streamline with the number of doses. For instance
ode_system.dosing_compartment -> dosing_compartments
Compartment.dose -> Compartment.first_dose (if only interested in dose, as .dose will return a tuple)

Let me know if there are any comments