### PR TITLE
Add rescale logit to add_iiv

### DIFF
--- a/src/pharmpy/modeling/expressions.py
+++ b/src/pharmpy/modeling/expressions.py
@@ -331,17 +331,21 @@ def mu_reference_model(model: Model):
         old_def = assignment.expression
         dep = old_def.as_independent(eta)[1]
         mu = sympy.Symbol(f'mu_{index[eta]}')
-        new_def = subs(dep, {eta: mu + eta})
-        mu_expr = sympy.solve(old_def - new_def, mu)[0]
-        insertion_ind = offset + old_ind
-        statements = (
-            statements[0:insertion_ind]
-            + Assignment(mu, mu_expr)
-            + Assignment(assignment.symbol, new_def)
-            + statements[insertion_ind + 1 :]
-        )
-        offset += 1  # NOTE We need this offset because we replace one
-        # statement by two statements
+        if mu in old_def.free_symbols:
+            # If mu reference is already used, ignore
+            pass
+        else:
+            new_def = subs(dep, {eta: mu + eta})
+            mu_expr = sympy.solve(old_def - new_def, mu)[0]        
+            insertion_ind = offset + old_ind
+            statements = (
+                statements[0:insertion_ind]
+                + Assignment(mu, mu_expr)
+                + Assignment(assignment.symbol, new_def)
+                + statements[insertion_ind + 1 :]
+            )
+            offset += 1  # NOTE We need this offset because we replace one
+            # statement by two statements
     model = model.replace(statements=statements).update_source()
     return model
 

--- a/src/pharmpy/modeling/expressions.py
+++ b/src/pharmpy/modeling/expressions.py
@@ -336,7 +336,7 @@ def mu_reference_model(model: Model):
             pass
         else:
             new_def = subs(dep, {eta: mu + eta})
-            mu_expr = sympy.solve(old_def - new_def, mu)[0]        
+            mu_expr = sympy.solve(old_def - new_def, mu)[0]
             insertion_ind = offset + old_ind
             statements = (
                 statements[0:insertion_ind]

--- a/src/pharmpy/modeling/parameter_variability.py
+++ b/src/pharmpy/modeling/parameter_variability.py
@@ -131,7 +131,7 @@ def add_iiv(
 
         if expression[i] == "re_log":
             # Need to add phi as well
-            phi = sympy.Symbol(f'phi_{eta_name}')
+            phi = sympy.Symbol(f'phi_{statement.expression}')
             eta_addition.apply(phi, eta.names[0])
             sset = (
                 sset[0:index]

--- a/src/pharmpy/modeling/parameter_variability.py
+++ b/src/pharmpy/modeling/parameter_variability.py
@@ -131,7 +131,7 @@ def add_iiv(
 
         if expression[i] == "re_log":
             # Need to add phi as well
-            phi = sympy.Symbol("phi")
+            phi = sympy.Symbol(f'phi_{eta_name}')
             eta_addition.apply(phi, eta.names[0])
             sset = (
                 sset[0:index]

--- a/tests/modeling/test_parameter_variability.py
+++ b/tests/modeling/test_parameter_variability.py
@@ -51,8 +51,8 @@ from pharmpy.tools import read_modelfit_results
             're_log',
             '+',
             None,
-            'V=TVV*EXP(ETA(2))\nPHI_ETA_S1 = LOG(V/(1 - V))'
-            '\nS1 = EXP(ETA_S1*PHI_ETA_S1)/(EXP(ETA_S1*PHI_ETA_S1) + 1)',
+            'V=TVV*EXP(ETA(2))\nPHI_V = LOG(V/(1 - V))'
+            '\nS1 = EXP(ETA_S1*PHI_V)/(EXP(ETA_S1*PHI_V) + 1)',
             2,
         ),
         (

--- a/tests/modeling/test_parameter_variability.py
+++ b/tests/modeling/test_parameter_variability.py
@@ -47,6 +47,15 @@ from pharmpy.tools import read_modelfit_results
         ('S1', 'eta_new**2', '+', None, 'V=TVV*EXP(ETA(2))\nS1 = V + ETA_S1**2', 2),
         ('S1', 'exp', '+', 'ETA(3)', 'V=TVV*EXP(ETA(2))\nS1 = V + EXP(ETA(3))', 2),
         (
+            'S1',
+            're_log',
+            '+',
+            None,
+            'V=TVV*EXP(ETA(2))\nPHI_ETA_S1 = LOG(V/(1 - V))'
+            '\nS1 = EXP(ETA_S1*PHI_ETA_S1)/(EXP(ETA_S1*PHI_ETA_S1) + 1)',
+            2,
+        ),
+        (
             ['V', 'S1'],
             'exp',
             '+',


### PR DESCRIPTION
Feature requested in issue #1708. There where some uncertainties regarding the issue description where "mu" was believed to be an ETA. An example of the implemented IIV addition, named "re_logit" in the add_iiv function, can be seen below.

S₁ = V
Is transformed to
phi_V = log( V / (1 - V))
S₁ = exp(ETA_S₁ + phi_V) / (1 + exp(ETA_S₁ + phi_V)

If there are any comments on the naming or implementation, please let me know!