### PR TITLE
Unfix E_0 in structsearch

### DIFF
--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -5,6 +5,7 @@ from pharmpy.modeling import (
     add_iiv,
     fix_parameters_to,
     set_direct_effect,
+    set_initial_estimates,
     set_name,
 )
 
@@ -31,7 +32,7 @@ def create_baseline_pd_model(model: Model, ests: pd.Series):
     return baseline_model
 
 
-def create_pkpd_models(model: Model, ests: pd.Series):
+def create_pkpd_models(model: Model, e0_init: pd.Series, ests: pd.Series):
     """Create pkpd models
 
     Parameters
@@ -58,6 +59,7 @@ def create_pkpd_models(model: Model, ests: pd.Series):
             pkpd_model = pkpd_model.replace(description=f"{model_type}_{pd_type}")
             index += 1
             pkpd_model = add_iiv(pkpd_model, ["E0"], "exp")
+            pkpd_model = set_initial_estimates(pkpd_model, e0_init)
             pkpd_model = fix_parameters_to(pkpd_model, ests)
             for parameter in ["S", "E_max", "m"]:
                 try:

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -105,14 +105,11 @@ def run_pkpd(context, model):
     wb.add_task(task_results, predecessors=wf.output_tasks)
     pd_baseline_fit = call_workflow(Workflow(wb), 'results_remaining', context)
 
-    parameter_estimates = pd.concat(
-        [
-            model.modelfit_results.parameter_estimates,
-            pd_baseline_fit[0].modelfit_results.parameter_estimates,
-        ],
-        axis=0,
+    pkpd_models = create_pkpd_models(
+        model,
+        pd_baseline_fit[0].modelfit_results.parameter_estimates,
+        model.modelfit_results.parameter_estimates,
     )
-    pkpd_models = create_pkpd_models(model, parameter_estimates)
 
     wf2 = create_fit_workflow(pkpd_models)
     wb2 = WorkflowBuilder(wf2)

--- a/tests/integration/test_structsearch.py
+++ b/tests/integration/test_structsearch.py
@@ -1,11 +1,13 @@
 from pharmpy.internals.fs.cwd import chdir
+from pharmpy.modeling import convert_model, create_basic_pk_model
 from pharmpy.tools import fit, run_structsearch
 from pharmpy.tools.structsearch.pkpd import create_pk_model
 
 
 def test_pkpd(tmp_path, load_model_for_test, testdata):
     with chdir(tmp_path):
-        model = load_model_for_test(testdata / "nonmem" / "pheno_pd.mod")
+        model = create_basic_pk_model('iv', dataset_path=testdata / "nonmem" / "pheno_pd.csv")
+        model = convert_model(model, 'nonmem')
         pk_model = create_pk_model(model)  # NOTE: this step needs to be removed later
         pk_res = fit(pk_model)
         res = run_structsearch(type='pkpd', route='iv', results=pk_res, model=model)

--- a/tests/tools/test_structsearch.py
+++ b/tests/tools/test_structsearch.py
@@ -71,8 +71,10 @@ def test_create_remaining_models(load_example_model_for_test):
 def test_pkpd(load_model_for_test, testdata):
     res = read_modelfit_results(testdata / "nonmem" / "pheno.mod")
     ests = res.parameter_estimates
+    e0_init = pd.Series({'POP_E0': 5.75, 'IIV_E0': 0.01, 'sigma': 0.33})
     model = load_model_for_test(testdata / "nonmem" / "pheno_pd.mod")
-    pkpd_models = create_pkpd_models(model, ests)
+    pkpd_models = create_pkpd_models(model, e0_init, ests)
+
     assert len(pkpd_models) == 8
     assert pkpd_models[0].name == "structsearch_run1"
     assert pkpd_models[1].name == "structsearch_run2"


### PR DESCRIPTION
I erroneously fixed `E_0` in the structsearch tool in a previous PR. Instead the initial estimates for `E_0`should be set based on a fit to the baseline PD model.