### PR TITLE
Update help_functions.py

### DIFF
--- a/src/pharmpy/modeling/help_functions.py
+++ b/src/pharmpy/modeling/help_functions.py
@@ -53,7 +53,7 @@ def _get_eta_symbs(eta_str, rvs, sset):
         exp_symbs = sset.find_assignment(eta_str).expression.free_symbols
     except AttributeError:
         raise KeyError(f'Symbol "{eta_str}" does not exist')
-    return [str(e) for e in exp_symbs.intersection(rvs.free_symbols)]
+    return [str(e) for e in exp_symbs.intersection(rvs.etas.free_symbols)]
 
 
 def _has_fixed_params(model, rv):


### PR DESCRIPTION
Changed `_get_eta_symbs` to prevent a bug accidentally returning EPS. Changing `rvs.free_symbols` to `rvs.etas.free_symbols` in row 56 fixes the bug. 