### PR TITLE
Handle multiple DVs in nonmem models

### DIFF
--- a/src/pharmpy/model/external/nonmem/model.py
+++ b/src/pharmpy/model/external/nonmem/model.py
@@ -11,6 +11,7 @@ from typing import Dict, Optional, Tuple
 from pharmpy.deps import pandas as pd
 from pharmpy.deps import sympy
 from pharmpy.internals.fs.path import path_absolute, path_relative_to
+from pharmpy.internals.immutable import frozenmapping
 from pharmpy.model import Assignment, DataInfo, EstimationSteps
 from pharmpy.model import Model as BaseModel
 from pharmpy.model import NormalDistribution, Parameter, Parameters, RandomVariables, Statements
@@ -92,14 +93,13 @@ def convert_model(model):
     nm_model._dataset = model.dataset
     nm_model._estimation_steps = model.estimation_steps
     nm_model._initial_individual_estimates = model.initial_individual_estimates
-    # FIXME: This is handled equivalently to dependent variables, should handle multiple DVs
-    new_obs_trans = {sympy.Symbol('Y'): sympy.Symbol('Y')}
+    new_obs_trans = frozenmapping({dv: dv for dv in model.dependent_variables.keys()})
     internals = nm_model.internals.replace(old_parameters=Parameters())
     nm_model = nm_model.replace(
         name=model.name,
         value_type=model.value_type,
         observation_transformation=new_obs_trans,
-        dependent_variables={sympy.Symbol('Y'): 1},
+        dependent_variables=model.dependent_variables,
         random_variables=model.random_variables,
         statements=model.statements,
         description=model.description,
@@ -377,6 +377,7 @@ def parse_model(
         dataset=dataset,
         datainfo=di,
         dependent_variables=dependent_variables,
+        observation_transformation=obs_trans,
         estimation_steps=estimation_steps,
         parent_model=None,
         initial_individual_estimates=init_etas,

--- a/src/pharmpy/model/external/nonmem/parsing.py
+++ b/src/pharmpy/model/external/nonmem/parsing.py
@@ -291,7 +291,7 @@ def convert_dvs(statements, control_stream):
                 kept.append(ass1)
                 kept.append(ass2)
                 dvs = frozenmapping({sympy.Symbol('Y_1'): 1, sympy.Symbol('Y_2'): 2})
-                obs_trans = {sympy.Symbol('Y_1'): sympy.Symbol('Y_1')}
+                obs_trans = frozenmapping({dv: dv for dv in dvs.keys()})
                 change = True
                 continue
         kept.append(s)

--- a/tests/nonmem/test_nonmem_model.py
+++ b/tests/nonmem/test_nonmem_model.py
@@ -24,8 +24,11 @@ from pharmpy.model.external.nonmem.records.factory import create_record
 from pharmpy.modeling import (
     add_iiv,
     add_population_parameter,
+    create_basic_pk_model,
     create_joint_distribution,
+    read_model,
     remove_iiv,
+    set_direct_effect,
     set_estimation_step,
     set_initial_condition,
     set_initial_estimates,
@@ -49,6 +52,24 @@ def S(x):
 
 def test_source(pheno):
     assert pheno.model_code.startswith('$PROBLEM PHENOBARB')
+
+
+def test_convert_nonmem_model(testdata):
+    model = create_basic_pk_model('iv', testdata / 'nonmem/pheno_pd.csv')
+    model = set_direct_effect(model, 'linear')
+    model = convert_model(model)
+    assert model.dependent_variables == {S('Y'): 1, S('Y_2'): 2}
+    assert model.observation_transformation == {S('Y'): S('Y'), S('Y_2'): S('Y_2')}
+
+
+def test_parse_nonmem_model(testdata):
+    model = read_model(testdata / 'nonmem/pheno_pd.mod')
+    assert model.dependent_variables == {S('Y'): 1}
+    assert model.observation_transformation == {S('Y'): S('Y')}
+
+    model = read_model(testdata / 'nonmem/models/pheno_dvid.mod')
+    assert model.dependent_variables == {S('Y_1'): 1, S('Y_2'): 2}
+    assert model.observation_transformation == {S('Y_1'): S('Y_1'), S('Y_2'): S('Y_2')}
 
 
 def test_update_inits(load_model_for_test, pheno_path):


### PR DESCRIPTION
Handle multiple DVs in nonmem models. 
`convert_model` and `parse_model` should handle multiple DVs correctly now.