### PR TITLE
Fix bug in get_pk_parameters

### DIFF
--- a/src/pharmpy/modeling/expressions.py
+++ b/src/pharmpy/modeling/expressions.py
@@ -1180,9 +1180,13 @@ def get_pk_parameters(model: Model, kind: str = 'all') -> List[str]:
     dependency_graph = _dependency_graph(natural_assignments)
 
     pk_symbols = _filter_symbols(dependency_graph, free_symbols)
+
     if model.statements.ode_system.find_compartment("EFFECT") is not None:
-        pd_symbols = model.statements.ode_system.find_compartment("EFFECT").input.free_symbols
-        pk_symbols = pk_symbols.difference(pd_symbols)
+        pd_outflow = model.statements.ode_system.get_flow(
+            model.statements.ode_system.find_compartment("EFFECT"), output
+        )
+        pk_symbols.remove(pd_outflow)
+
     return sorted(map(str, pk_symbols))
 
 

--- a/tests/modeling/test_expressions.py
+++ b/tests/modeling/test_expressions.py
@@ -360,6 +360,8 @@ def test_get_pd_parameters(load_model_for_test, testdata, model_path, kind, expe
     model = load_model_for_test(testdata / model_path)
     assert set(get_pd_parameters(set_direct_effect(model, kind))) == set(expected)
     assert set(get_pd_parameters(add_effect_compartment(model, kind))) == set(expected + ["KE0"])
+    assert get_pk_parameters(add_effect_compartment(model, kind)) == ['CL', 'V']
+    assert get_pk_parameters(set_direct_effect(model, kind)) == ['CL', 'V']
     assert not set(
         set(get_pd_parameters(set_direct_effect(model, kind))).intersection(
             get_pk_parameters(set_direct_effect(model, kind))


### PR DESCRIPTION
Fix bug in `get_pk_parameters` for models with an effect compartment.
Previously the input to the effect compartment has been changed and now the volume `V` is included into the input into the effect compartment. This resulted in the volume being removed from the pk parameters. Now only `KE0` is removed from the pk parameters.