### PR TITLE
Add initial ests for emax and ec50 as user input

### DIFF
--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -32,7 +32,9 @@ def create_baseline_pd_model(model: Model, ests: pd.Series):
     return baseline_model
 
 
-def create_pkpd_models(model: Model, e0_init: pd.Series, ests: pd.Series):
+def create_pkpd_models(
+    model: Model, e0_init: pd.Series, ests: pd.Series, emax_init=None, ec50_init=None
+):
     """Create pkpd models
 
     Parameters
@@ -55,12 +57,19 @@ def create_pkpd_models(model: Model, e0_init: pd.Series, ests: pd.Series):
                 pkpd_model = set_direct_effect(model, expr=pd_type)
             elif model_type == "effect_compartment":
                 pkpd_model = add_effect_compartment(model, expr=pd_type)
+
             pkpd_model = set_name(pkpd_model, f"structsearch_run{index}")
             pkpd_model = pkpd_model.replace(description=f"{model_type}_{pd_type}")
             index += 1
             pkpd_model = add_iiv(pkpd_model, ["E0"], "exp")
             pkpd_model = set_initial_estimates(pkpd_model, e0_init)
             pkpd_model = fix_parameters_to(pkpd_model, ests)
+
+            if emax_init:
+                pkpd_model = fix_parameters_to(pkpd_model, {'POP_E_MAX': emax_init})
+            if ec50_init:
+                pkpd_model = fix_parameters_to(pkpd_model, {'POP_EC_50': ec50_init})
+
             for parameter in ["SLOPE", "E_MAX"]:
                 try:
                     pkpd_model = add_iiv(pkpd_model, [parameter], "exp")

--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -66,9 +66,9 @@ def create_pkpd_models(
             pkpd_model = fix_parameters_to(pkpd_model, ests)
 
             if emax_init:
-                pkpd_model = fix_parameters_to(pkpd_model, {'POP_E_MAX': emax_init})
+                pkpd_model = set_initial_estimates(pkpd_model, {'POP_E_MAX': emax_init})
             if ec50_init:
-                pkpd_model = fix_parameters_to(pkpd_model, {'POP_EC_50': ec50_init})
+                pkpd_model = set_initial_estimates(pkpd_model, {'POP_EC_50': ec50_init})
 
             for parameter in ["SLOPE", "E_MAX"]:
                 try:

--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -65,9 +65,9 @@ def create_pkpd_models(
             pkpd_model = set_initial_estimates(pkpd_model, e0_init)
             pkpd_model = fix_parameters_to(pkpd_model, ests)
 
-            if emax_init:
+            if emax_init is not None:
                 pkpd_model = set_initial_estimates(pkpd_model, {'POP_E_MAX': emax_init})
-            if ec50_init:
+            if ec50_init is not None:
                 pkpd_model = set_initial_estimates(pkpd_model, {'POP_EC_50': ec50_init})
 
             for parameter in ["SLOPE", "E_MAX"]:

--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -43,6 +43,10 @@ def create_pkpd_models(
         Pharmpy PK model
     ests : pd.Series
        List of estimated PK parameters
+    emax_init : float
+        Initial estimate for E_max
+    ec50_init : float
+        Initial estimate for EC_50
 
     Returns
     -------

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -38,11 +38,9 @@ def create_workflow(
     type : str
         Type of model. Currently only 'tmdd' and 'pkpd'
     emax_init: float
-        Initial estimate for E_MAX. If None the initial estimate will be taken
-        from model.modelfit_results.parameter_estimates
+        Initial estimate for E_MAX. The default value is 0.1
     ec50_init: float
-        Initial estimate for EC_50. If None the initial estimate will be taken
-        from model.modelfit_results.parameter_estimates
+        Initial estimate for EC_50. The default value is 0.1
     results : ModelfitResults
         Results for the start model
     model : Model

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -24,6 +24,8 @@ TYPES = frozenset(('tmdd', 'pkpd'))
 def create_workflow(
     route: str,
     type: str,
+    emax_init: Optional[float] = None,
+    ec50_init: Optional[float] = None,
     results: Optional[ModelfitResults] = None,
     model: Optional[Model] = None,
 ):
@@ -35,6 +37,12 @@ def create_workflow(
         Route of administration. Either 'pk' or 'oral'
     type : str
         Type of model. Currently only 'tmdd' and 'pkpd'
+    emax_init: float
+        Initial estimate for E_MAX. If None the initial estimate will be taken
+        from model.modelfit_results.parameter_estimates
+    ec50_init: float
+        Initial estimate for EC_50. If None the initial estimate will be taken
+        from model.modelfit_results.parameter_estimates
     results : ModelfitResults
         Results for the start model
     model : Model
@@ -58,7 +66,7 @@ def create_workflow(
     if type == 'tmdd':
         start_task = Task('run_tmdd', run_tmdd, model)
     elif type == 'pkpd':
-        start_task = Task('run_pkpd', run_pkpd, model)
+        start_task = Task('run_pkpd', run_pkpd, model, emax_init, ec50_init)
     wb.add_task(start_task)
     return Workflow(wb)
 
@@ -97,7 +105,7 @@ def run_tmdd(context, model):
     )
 
 
-def run_pkpd(context, model):
+def run_pkpd(context, model, emax_init, ec50_init):
     baseline_pd_model = create_baseline_pd_model(model, model.modelfit_results.parameter_estimates)
     wf = create_fit_workflow(baseline_pd_model)
     wb = WorkflowBuilder(wf)
@@ -109,6 +117,8 @@ def run_pkpd(context, model):
         model,
         pd_baseline_fit[0].modelfit_results.parameter_estimates,
         model.modelfit_results.parameter_estimates,
+        emax_init,
+        ec50_init,
     )
 
     wf2 = create_fit_workflow(pkpd_models)

--- a/tests/tools/test_structsearch.py
+++ b/tests/tools/test_structsearch.py
@@ -89,9 +89,9 @@ def test_pkpd(load_model_for_test, testdata):
     param_emax = models2[1].parameters['POP_E_MAX']
     param_ec50 = models2[1].parameters['POP_EC_50']
     assert param_emax.init == 2.0
-    assert param_emax.fix is True
+    assert param_emax.fix is False
     assert param_ec50.init == 1.0
-    assert param_ec50.fix is True
+    assert param_ec50.fix is False
 
     models3 = create_pkpd_models(model, e0_init, ests)
     param_emax = models3[1].parameters['POP_E_MAX']

--- a/tests/tools/test_structsearch.py
+++ b/tests/tools/test_structsearch.py
@@ -85,6 +85,22 @@ def test_pkpd(load_model_for_test, testdata):
     assert pkpd_models[0].parameters[1].name == 'TVV'
     assert pkpd_models[5].parameters[1].name == 'TVV'
 
+    models2 = create_pkpd_models(model, e0_init, ests, emax_init=2.0, ec50_init=1.0)
+    param_emax = models2[1].parameters['POP_E_MAX']
+    param_ec50 = models2[1].parameters['POP_EC_50']
+    assert param_emax.init == 2.0
+    assert param_emax.fix is True
+    assert param_ec50.init == 1.0
+    assert param_ec50.fix is True
+
+    models3 = create_pkpd_models(model, e0_init, ests)
+    param_emax = models3[1].parameters['POP_E_MAX']
+    param_ec50 = models3[1].parameters['POP_EC_50']
+    assert param_emax.init == 0.1
+    assert param_emax.fix is False
+    assert param_ec50.init == 0.1
+    assert param_ec50.fix is False
+
 
 def test_create_workflow():
     assert isinstance(create_workflow('oral', 'pkpd'), Workflow)


### PR DESCRIPTION
Add initial estimates for emax and ec50 as user input in structsearch. 
If none are specified the initial estimates will be determined from model.modelfit_results.parameter_estimates.