### PR TITLE
Exclude PK start model from Structsearch results

### DIFF
--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -26,6 +26,7 @@ def create_baseline_pd_model(model: Model, ests: pd.Series):
     """
     baseline_model = set_direct_effect(model, expr='baseline')
     baseline_model = set_name(baseline_model, "baseline_pd_model")
+    baseline_model = baseline_model.replace(parent_model='baseline_model')
     baseline_model = baseline_model.replace(description="direct_effect_baseline")
     baseline_model = fix_parameters_to(baseline_model, ests)
     baseline_model = add_iiv(baseline_model, ["E0"], "exp")
@@ -79,6 +80,7 @@ def create_pkpd_models(
                     pkpd_model = add_iiv(pkpd_model, [parameter], "exp")
                 except ValueError:
                     pass
+            pkpd_model = pkpd_model.replace(parent_model='baseline_model')
             models.append(pkpd_model)
     return models
 

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -133,8 +133,8 @@ def run_pkpd(context, model, emax_init, ec50_init):
     return create_results(
         StructSearchResults,
         model,
-        model,
-        list(pd_baseline_fit + pkpd_models_fit),
+        pd_baseline_fit[0],
+        list(pkpd_models_fit),
         rank_type='bic',
         cutoff=None,
         summary_models=pd.concat([summary_input, summary_candidates], keys=[0, 1], names=["step"]),


### PR DESCRIPTION
Remove PK start model from the ranking from the Structsearch results for pkpd models.
The PD baseline model is set as the reference model instead and all pkpd models have the baseline model as the parent model.