### PR TITLE
Modify AMD for PKPD models

### DIFF
--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -96,27 +96,6 @@ def run_amd(
     -------
     Model
         Reference to the same model object
-    search_space : str
-        MFL for search space for structural model
-    lloq_method : str
-        Method for how to remove LOQ data. See `transform_blq` for list of available methods
-    lloq_limit : float
-        Lower limit of quantification. If None LLOQ column from dataset will be used
-    order : list
-        Runorder of components
-    allometric_variable: str or Symbol
-        Variable to use for allometry
-    occasion : str
-        Name of occasion column
-    path : str or Path
-        Path to run AMD in
-    resume : bool
-        Whether to allow resuming previous run
-
-    Returns
-    -------
-    Model
-        Reference to the same model object
 
     Examples
     --------

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -49,7 +49,6 @@ def run_amd(
     occasion: Optional[str] = None,
     path: Optional[Union[str, Path]] = None,
     resume: Optional[bool] = False,
-    dv: Optional[bool] = None,
 ):
     """Run Automatic Model Development (AMD) tool
 
@@ -120,6 +119,8 @@ def run_amd(
 
     if modeltype == 'pkpd':
         dv = 2
+    else:
+        dv = None
 
     if type(input) is str:
         from pharmpy.modeling import create_basic_pk_model
@@ -384,7 +385,7 @@ def _subfunc_iiv(path) -> SubFunc:
         res = run_tool(
             'iivsearch',
             'brute_force',
-            iiv_strategy='no_add',
+            iiv_strategy='fullblock',
             model=model,
             path=path / 'iivsearch',
         )

--- a/src/pharmpy/tools/mfl/feature/covariate.py
+++ b/src/pharmpy/tools/mfl/feature/covariate.py
@@ -7,6 +7,7 @@ from pharmpy.modeling import get_bioavailability
 from pharmpy.modeling.covariate_effect import EffectType, OperationType, add_covariate_effect
 from pharmpy.modeling.expressions import (
     get_individual_parameters,
+    get_parameter_rv,
     get_pd_parameters,
     get_pk_parameters,
 )
@@ -143,10 +144,22 @@ def _interpret_symbol(model: Model, definition, symbol: Symbol) -> Tuple[str, ..
                 return tuple(get_individual_parameters(model, level='iiv'))
             elif symbol.name == 'PD':
                 return tuple(get_pd_parameters(model))
+            elif symbol.name == 'PD_IIV':
+                return [
+                    pd_param
+                    for pd_param in get_pd_parameters(model)
+                    if len(get_parameter_rv(model, pd_param)) > 0
+                ]
             elif symbol.name == 'PK':
                 return tuple(get_pk_parameters(model))
             elif symbol.name == 'BIOAVAIL':
                 return tuple(_get_bioaval_parameters(model))
+            elif symbol.name == 'PK_IIV':
+                return [
+                    pk_param
+                    for pk_param in get_pk_parameters(model)
+                    if len(get_parameter_rv(model, pk_param)) > 0
+                ]
             else:
                 return ()
 

--- a/src/pharmpy/tools/mfl/grammar.py
+++ b/src/pharmpy/tools/mfl/grammar.py
@@ -56,7 +56,7 @@ fp_wildcard: WILDCARD
 
 WILDCARD: "*"
 
-VARIABLE_NAME: /[a-zA-Z]+/
+VARIABLE_NAME: /[a-zA-Z_]+/
 
 values: value | _value_array
 _value_array: "[" [value ("," value)*] "]"

--- a/src/pharmpy/tools/ruvsearch/tool.py
+++ b/src/pharmpy/tools/ruvsearch/tool.py
@@ -347,9 +347,10 @@ def _create_combined_model(input_model, current_iteration):
 def _create_dataset(input_model, dv):
     # Non-observations have already been filtered
     residuals = input_model.modelfit_results.residuals
-    if dv:
+    if dv is not None:
         input_dataset = input_model.dataset
-        input_dataset = input_dataset[input_dataset['DV'] != 0].reset_index(
+        observation_label = input_model.datainfo.dv_column.name
+        input_dataset = input_dataset.query(f'{observation_label} != 0').reset_index(
             drop=True
         )  # filter non-observations
         indices = input_dataset.index[input_dataset['DVID'] == dv].tolist()

--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -25,7 +25,7 @@ def create_baseline_pd_model(model: Model, ests: pd.Series):
     Baseline PD model
     """
     baseline_model = set_direct_effect(model, expr='baseline')
-    baseline_model = set_name(baseline_model, "baseline_pd_model")
+    baseline_model = set_name(baseline_model, "baseline_model")
     baseline_model = baseline_model.replace(parent_model='baseline_model')
     baseline_model = baseline_model.replace(description="direct_effect_baseline")
     baseline_model = fix_parameters_to(baseline_model, ests)

--- a/tests/tools/test_mfl.py
+++ b/tests/tools/test_mfl.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 import pytest
 
-from pharmpy.modeling import create_basic_pk_model, set_direct_effect
+from pharmpy.modeling import add_iiv, create_basic_pk_model, set_direct_effect
 from pharmpy.tools.mfl.helpers import all_funcs
 from pharmpy.tools.mfl.parse import parse
 from pharmpy.tools.mfl.statement.feature.absorption import Absorption
@@ -365,6 +365,67 @@ def test_all_funcs(load_model_for_test, pheno_path, source, expected):
 def test_all_funcs_pd(load_model_for_test, pheno_path, source, expected):
     model = load_model_for_test(pheno_path)
     model = set_direct_effect(model, 'linear')
+    statements = parse(source)
+    funcs = all_funcs(model, statements)
+    keys = funcs.keys()
+    assert set(keys) == set(expected)
+
+
+@pytest.mark.parametrize(
+    ('source', 'expected'),
+    (
+        (
+            'COVARIATE(@PD_IIV, @CONTINUOUS, *);' 'COVARIATE(@PD_IIV, @CATEGORICAL, CAT, *)',
+            (
+                ('COVARIATE', 'SLOPE', 'APGR', 'cat', '*'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'pow', '*'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'piece_lin', '*'),
+            ),
+        ),
+        (
+            'COVARIATE(@PK_IIV, @CONTINUOUS, *);' 'COVARIATE(@PK_IIV, @CATEGORICAL, CAT, *)',
+            (
+                ('COVARIATE', 'CL', 'APGR', 'cat', '*'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*'),
+                ('COVARIATE', 'V', 'APGR', 'cat', '*'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*'),
+            ),
+        ),
+        (
+            'COVARIATE(@IIV, @CONTINUOUS, *);' 'COVARIATE(@IIV, @CATEGORICAL, CAT, *)',
+            (
+                ('COVARIATE', 'SLOPE', 'APGR', 'cat', '*'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'pow', '*'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'piece_lin', '*'),
+                ('COVARIATE', 'CL', 'APGR', 'cat', '*'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*'),
+                ('COVARIATE', 'V', 'APGR', 'cat', '*'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*'),
+            ),
+        ),
+    ),
+    ids=repr,
+)
+def test_all_funcs_pd_iiv(load_model_for_test, pheno_path, source, expected):
+    model = load_model_for_test(pheno_path)
+    model = set_direct_effect(model, 'linear')
+    model = add_iiv(model, 'SLOPE', 'exp')
     statements = parse(source)
     funcs = all_funcs(model, statements)
     keys = funcs.keys()


### PR DESCRIPTION
Modify AMD for PKPD models.
It is now possible to run the AMD tool for PKPD models (only the PD part).
- Added initial estimates for E_max and EC_50 as user input
- Added @PD, @PK, @PD_IIV and @PK_IIV to the covariates search space
 