### PR TITLE
Refactor naming in EstimationStep class

### DIFF
--- a/docs/estmethod.rst
+++ b/docs/estmethod.rst
@@ -24,17 +24,17 @@ To initiate Estmethod in Python/R:
     res = run_estmethod(algorithm='exhaustive',
                         model=start_model,
                         results=start_model_results,
-                        methods='all',
+                        est_methods='all',
                         solvers=['LSODA', 'LSODI'])
 
 This will take an input model ``start_model``. The tool will use the 'exhaustive' ``algorithm`` and try all combinations
-between all available ``methods`` and ``solvers`` LSODA and LSODI.
+between all available ``est_methods`` and ``solvers`` LSODA and LSODI.
 
 To run Estmethod from the command line, the example code is redefined accordingly:
 
 .. code::
 
-    pharmpy run estmethod path/to/model 'exhaustive' --methods 'all' --solvers 'LSODA LSODI'
+    pharmpy run estmethod path/to/model 'exhaustive' --est_methods 'all' --solvers 'LSODA LSODI'
 
 Arguments
 ~~~~~~~~~
@@ -113,7 +113,7 @@ Settings for evaluation step is the same as for estimation step, with the follow
 +---------------------------+----------------------------------------------------------------------------------------+
 | Setting                   | Value                                                                                  |
 +===========================+========================================================================================+
-| ``method``                | ``IMP``                                                                                |
+| ``est_method``                | ``IMP``                                                                                |
 +---------------------------+----------------------------------------------------------------------------------------+
 | ``isample``               | ``100000``                                                                             |
 +---------------------------+----------------------------------------------------------------------------------------+
@@ -168,10 +168,10 @@ Settings are the same as for ``exhaustive`` evaluation step, where the method is
 .. _methods_estmethod:
 
 ~~~~~~~
-Methods
+Estimation methods
 ~~~~~~~
 
-For a list of supported methods, see :py:func:`pharmpy.model.EstimationStep.supported_methods` (to test ``FOCE`` with
+For a list of supported estimation methods, see :py:func:`pharmpy.model.EstimationStep.supported_est_methods` (to test ``FOCE`` with
 ``LAPLACE``, simply specify ``LAPLACE`` as input argument in the tool).
 
 .. _solvers_estmethod:
@@ -196,7 +196,7 @@ Consider a Estmethod run with the ``exhaustive`` algorithm and testing ``FO`` an
     res = run_estmethod(algorithm='exhaustive',
                         model=start_model,
                         results=start_model_results,
-                        methods=['FO', 'IMP'])
+                        est_methods=['FO', 'IMP'])
 
 The ``summary_tool`` table contains information such as which feature each model candidate has, the OFV, estimation
 runtime, and parent model:

--- a/docs/estmethod.rst
+++ b/docs/estmethod.rst
@@ -45,7 +45,7 @@ For a more detailed description of each argument, see their respective chapter o
 +=================================================+==================================================================+
 | :ref:`algorithm<algorithms_estmethod>`          | Algorithm to use (e.g. ``'reduced'``                             |
 +-------------------------------------------------+------------------------------------------------------------------+
-| :ref:`methods<methods_estmethod>`               | Which methods to test (e.g. ``['IMP']``)                         |
+| :ref:`methods<est_methods_estmethod>`           | Which estimation methods to test (e.g. ``['IMP']``)              |
 +-------------------------------------------------+------------------------------------------------------------------+
 | :ref:`solvers<solvers_estmethod>`               | Which solvers to test (e.g. ``['LSODA']``)                       |
 +-------------------------------------------------+------------------------------------------------------------------+
@@ -113,7 +113,7 @@ Settings for evaluation step is the same as for estimation step, with the follow
 +---------------------------+----------------------------------------------------------------------------------------+
 | Setting                   | Value                                                                                  |
 +===========================+========================================================================================+
-| ``est_method``                | ``IMP``                                                                                |
+| ``est_method``            | ``IMP``                                                                                |
 +---------------------------+----------------------------------------------------------------------------------------+
 | ``isample``               | ``100000``                                                                             |
 +---------------------------+----------------------------------------------------------------------------------------+
@@ -165,11 +165,11 @@ candidate models it only evaluates.
 
 Settings are the same as for ``exhaustive`` evaluation step, where the method is the method being examined.
 
-.. _methods_estmethod:
+.. _est_methods_estmethod:
 
-~~~~~~~
+~~~~~~~~~~~~~~~~~~
 Estimation methods
-~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 For a list of supported estimation methods, see :py:func:`pharmpy.model.EstimationStep.supported_est_methods` (to test ``FOCE`` with
 ``LAPLACE``, simply specify ``LAPLACE`` as input argument in the tool).

--- a/docs/modeling.rst
+++ b/docs/modeling.rst
@@ -425,7 +425,7 @@ how many iterations to output (the ``PRINT`` option in NONMEM) using the :py:fun
 function:
 
 .. pharmpy-execute::
-    run1 = set_estimation_step(model_start, method='imp', keep_every_nth_iter=10)
+    run1 = set_estimation_step(model_start, est_method='imp', keep_every_nth_iter=10)
     run1.estimation_steps
 
 If we then examine the model code:

--- a/src/pharmpy/cli.py
+++ b/src/pharmpy/cli.py
@@ -222,9 +222,9 @@ def run_estmethod(args):
     from pharmpy.tools import run_tool
 
     try:
-        methods = args.methods.split(" ")
+        est_methods = args.est_methods.split(" ")
     except AttributeError:
-        methods = args.methods
+        est_methods = args.est_methods
     try:
         solvers = args.solvers.split(" ")
     except AttributeError:
@@ -233,7 +233,7 @@ def run_estmethod(args):
     run_tool(
         'estmethod',
         args.algorithm,
-        methods=methods,
+        est_methods=est_methods,
         solvers=solvers,
         model=args.model,
         path=args.path,
@@ -1281,10 +1281,10 @@ parser_definition = [
                                 'help': 'Algorithm to use',
                             },
                             {
-                                'name': '--methods',
+                                'name': '--est_methods',
                                 'type': str,
                                 'default': None,
-                                'help': 'List of methods to try, mark group of methods in single '
+                                'help': 'List of estimation methods to try, mark group of estimation methods in single '
                                 'quote separated by spaces. Supported are: FOCE, FO, IMP, '
                                 'IMPMAP, ITS, SAEM, LAPLACE, BAYES, or \'all\'. Default is None.',
                             },
@@ -1292,7 +1292,7 @@ parser_definition = [
                                 'name': '--solvers',
                                 'type': str,
                                 'default': None,
-                                'help': 'List of solvers to try, mark group of methods in single '
+                                'help': 'List of solvers to try, mark group of solvers in single '
                                 'quote separated by spaces. Supported are: CVODES '
                                 '(ADVAN14), DGEAR (ADVAN8), DVERK (ADVAN6), IDA '
                                 '(ADVAN15), LSODA (ADVAN13) and LSODI (ADVAN9), or \'all\'. '

--- a/src/pharmpy/model/external/nlmixr/ini.py
+++ b/src/pharmpy/model/external/nlmixr/ini.py
@@ -19,7 +19,7 @@ def add_theta(model: pharmpy.model.Model, cg: CodeGenerator) -> None:
     cg.add("# --- THETAS ---")
     thetas = [p for p in model.parameters if p.symbol not in model.random_variables.free_symbols]
     for theta in thetas:
-        if model.estimation_steps[0].method not in ["SAEM", "NLME"]:
+        if model.estimation_steps[0].est_method not in ["SAEM", "NLME"]:
             add_ini_parameter(cg, theta, boundary=True)
         else:
             add_ini_parameter(cg, theta)
@@ -84,12 +84,12 @@ def add_sigma(model: pharmpy.model.Model, cg: CodeGenerator) -> None:
         if len(dist.names) == 1:
             sigma_param = model.parameters[sigma]
             if sigma_param.init != 1:
-                if model.estimation_steps[0].method not in ["SAEM", "NLME"]:
+                if model.estimation_steps[0].est_method not in ["SAEM", "NLME"]:
                     add_ini_parameter(cg, sigma_param, boundary=True)
                 else:
                     add_ini_parameter(cg, sigma_param)
             elif not sigma_param.fix:
-                if model.estimation_steps[0].method not in ["SAEM", "NLME"]:
+                if model.estimation_steps[0].est_method not in ["SAEM", "NLME"]:
                     add_ini_parameter(cg, sigma_param, boundary=True)
                 else:
                     add_ini_parameter(cg, sigma_param)
@@ -97,12 +97,12 @@ def add_sigma(model: pharmpy.model.Model, cg: CodeGenerator) -> None:
             for row, col in zip(range(sigma.rows), range(sigma.rows + 1)):
                 sigma_param = model.parameters[sigma[row, col]]
                 if sigma_param.init != 1:
-                    if model.estimation_steps[0].method not in ["SAEM", "NLME"]:
+                    if model.estimation_steps[0].est_method not in ["SAEM", "NLME"]:
                         add_ini_parameter(cg, sigma_param, boundary=True)
                     else:
                         add_ini_parameter(cg, sigma_param)
                 elif not sigma_param.fix:
-                    if model.estimation_steps[0].method not in ["SAEM", "NLME"]:
+                    if model.estimation_steps[0].est_method not in ["SAEM", "NLME"]:
                         add_ini_parameter(cg, sigma_param, boundary=True)
                     else:
                         add_ini_parameter(cg, sigma_param)

--- a/src/pharmpy/model/external/nlmixr/model.py
+++ b/src/pharmpy/model/external/nlmixr/model.py
@@ -211,7 +211,7 @@ def create_fit(cg: CodeGenerator, model: pharmpy.model.Model) -> None:
         A pharmpy.model.Model object.
 
     """
-    # FIXME : rasie error if the method does not match when evaluating
+    # FIXME : raise error if the method does not match when evaluating
     estimation_steps = model.estimation_steps[0]
     if "fix_eta" in estimation_steps.tool_options:
         fix_eta = True
@@ -223,32 +223,32 @@ def create_fit(cg: CodeGenerator, model: pharmpy.model.Model) -> None:
     else:
         max_eval = estimation_steps.maximum_evaluations
 
-    method = estimation_steps.method
+    est_method = estimation_steps.est_method
     interaction = estimation_steps.interaction
 
-    nonmem_method_to_nlmixr = {"FOCE": "foce", "FO": "fo", "SAEM": "saem"}
+    nonmem_est_method_to_nlmixr = {"FOCE": "foce", "FO": "fo", "SAEM": "saem"}
 
-    if method not in nonmem_method_to_nlmixr.keys():
-        nlmixr_method = "focei"
+    if est_method not in nonmem_est_method_to_nlmixr.keys():
+        nlmixr_est_method = "focei"
     else:
-        nlmixr_method = nonmem_method_to_nlmixr[method]
+        nlmixr_est_method = nonmem_est_method_to_nlmixr[est_method]
 
-    if interaction and nlmixr_method != "saem":
-        nlmixr_method += "i"
+    if interaction and nlmixr_est_method != "saem":
+        nlmixr_est_method += "i"
 
     if max_eval is not None:
-        if max_eval == 0 and nlmixr_method not in ["fo", "foi", "foce", "focei"]:
-            nlmixr_method = "posthoc"
-            cg.add(f'fit <- nlmixr2({model.name}, dataset, est = "{nlmixr_method}"')
+        if max_eval == 0 and nlmixr_est_method not in ["fo", "foi", "foce", "focei"]:
+            nlmixr_est_method = "posthoc"
+            cg.add(f'fit <- nlmixr2({model.name}, dataset, est = "{nlmixr_est_method}"')
         else:
-            f = f'fit <- nlmixr2({model.name}, dataset, est = "{nlmixr_method}", '
+            f = f'fit <- nlmixr2({model.name}, dataset, est = "{nlmixr_est_method}", '
             if fix_eta:
                 f += f'control=foceiControl(maxOuterIterations={max_eval}, maxInnerIterations=0, etaMat = etas))'
             else:
                 f += f'control=foceiControl(maxOuterIterations={max_eval}))'
             cg.add(f)
     else:
-        cg.add(f'fit <- nlmixr2({model.name}, dataset, est = "{nlmixr_method}")')
+        cg.add(f'fit <- nlmixr2({model.name}, dataset, est = "{nlmixr_est_method}")')
 
 
 def add_evid(model: pharmpy.model.Model) -> pharmpy.model.Model:

--- a/src/pharmpy/model/external/nlmixr/sanity_checks.py
+++ b/src/pharmpy/model/external/nlmixr/sanity_checks.py
@@ -19,7 +19,7 @@ def check_model(
     model: pharmpy.model.Model, skip_error_model_check: bool = False
 ) -> pharmpy.model.Model:
     """
-    Perform all neccessary checks to see if there are any issues with the input
+    Perform all necessary checks to see if there are any issues with the input
     model. Such as if the error model is unknown, or if there are other limitations
     in the handling of the model.
     Skipping checking the error model has no effect on the translation.
@@ -69,11 +69,11 @@ def check_model(
         print_warning("Omega with value same not supported. Parameters are updated")
         model = change_rvs_same(model, omega=True)
 
-    # Checks regarding esimation method
-    method = model.estimation_steps[0].method
-    if not known_estimation_method(method):
+    # Checks regarding est_method
+    est_method = model.estimation_steps[0].est_method
+    if not known_est_method(est_method):
         print_warning(
-            f"Estimation method {method} unknown to nlmixr2. Using 'FOCEI' as placeholder"
+            f"Estimation method {est_method} unknown to nlmixr2. Using 'FOCEI' as placeholder"
         )
 
     return model
@@ -86,9 +86,9 @@ def add_time(model):
     return model
 
 
-def known_estimation_method(method):
-    nonmem_method_to_nlmixr = {"FOCE": "foce", "FO": "fo", "SAEM": "saem"}
-    if method in nonmem_method_to_nlmixr.keys():
+def known_est_method(est_method):
+    nonmem_est_method_to_nlmixr = {"FOCE": "foce", "FO": "fo", "SAEM": "saem"}
+    if est_method in nonmem_est_method_to_nlmixr.keys():
         return True
     else:
         return False
@@ -243,8 +243,8 @@ def rvs_same(model: pharmpy.model.Model, sigma: bool = False, omega: bool = Fals
     Returns
     -------
     bool
-        True if there are random variables referenceing the same distribution
-        value. Otherwise False.
+        True if there are random variables referencing the same distribution
+        value. Otherwise, False.
 
     """
     if sigma:
@@ -266,7 +266,7 @@ def change_rvs_same(
     model: pharmpy.model.Model, sigma: bool = False, omega: bool = False
 ) -> pharmpy.model.Model:
     """
-    Add more distribution parameters if mutiple random variables are referencing
+    Add more distribution parameters if multiple random variables are referencing
     the same distribution. Done for sigma and omega values.
     Prints conversion to console.
 

--- a/src/pharmpy/model/external/nonmem/parsing.py
+++ b/src/pharmpy/model/external/nonmem/parsing.py
@@ -385,7 +385,7 @@ def parse_estimation_steps(control_stream, random_variables) -> EstimationSteps:
         interaction = False
         evaluation = False
         maximum_evaluations = None
-        cov = None
+        uncert_method = None
         laplace = False
         isample = None
         niter = None
@@ -404,7 +404,7 @@ def parse_estimation_steps(control_stream, random_variables) -> EstimationSteps:
         if eval_opt is not None and int(eval_opt) == 1:
             evaluation = True
         if covrec:
-            cov = 'SANDWICH'
+            uncert_method = 'SANDWICH'
         if record.has_option('LAPLACIAN') or record.has_option('LAPLACE'):
             laplace = True
         if record.has_option('ISAMPLE'):
@@ -449,7 +449,7 @@ def parse_estimation_steps(control_stream, random_variables) -> EstimationSteps:
             meth = EstimationStep.create(
                 name,
                 interaction=interaction,
-                cov=cov,
+                uncert_method=uncert_method,
                 evaluation=evaluation,
                 maximum_evaluations=maximum_evaluations,
                 laplace=laplace,

--- a/src/pharmpy/model/external/nonmem/table.py
+++ b/src/pharmpy/model/external/nonmem/table.py
@@ -87,7 +87,7 @@ class NONMEMTableFile:
                 table_line,
             )
             if m:
-                table.method = m.group(1)
+                table.est_method = m.group(1)
                 table.goal_function = m.group(2)
                 table.problem = int(m.group(3))
                 table.subproblem = int(m.group(4))
@@ -139,7 +139,7 @@ class NONMEMTable:
 
     number: Optional[int] = None
     is_evaluation: Optional[bool] = None
-    method: Optional[str] = None
+    est_method: Optional[str] = None
     goal_function: Optional[str] = None
     problem: Optional[int] = None
     subproblem: Optional[int] = None

--- a/src/pharmpy/model/external/nonmem/update.py
+++ b/src/pharmpy/model/external/nonmem/update.py
@@ -1546,29 +1546,29 @@ def update_estimation(control_stream, model):
             newrec = create_record(str(rec))
             control_stream = control_stream.insert_record(newrec)
 
-    # Initiate old_cov
-    old_cov = None
+    # Initiate old_uncert_method
+    old_uncert_method = None
     for est in old:
-        old_cov = est.cov
+        old_uncert_method = est.uncert_method
 
-    # Initiate new_cov
-    new_cov = None
+    # Initiate new_uncert_method
+    new_uncert_method = None
     for est in new:
-        new_cov = est.cov
+        new_uncert_method = est.uncert_method
 
-    if old_cov is None and new_cov is not None:
+    if old_uncert_method is None and new_uncert_method is not None:
         # Add $COV
         last_est_rec = control_stream.get_records('ESTIMATION')[-1]
         idx_cov = control_stream.records.index(last_est_rec)
-        if new_cov == 'SANDWICH':
+        if new_uncert_method == 'SANDWICH':
             covrec_ = '$COVARIANCE'
-        elif new_cov == 'CPG':
+        elif new_uncert_method == 'CPG':
             covrec_ = '$COVARIANCE MATRIX=S'
-        elif new_cov == 'OFIM':
+        elif new_uncert_method == 'OFIM':
             covrec_ = '$COVARIANCE MATRIX=R'
         covrec = create_record(f'{covrec_}\n')
         control_stream = control_stream.insert_record(covrec, at_index=idx_cov + 1)
-    elif old_cov is not None and new_cov is None:
+    elif old_uncert_method is not None and new_uncert_method is None:
         # Remove $COV
         covrecs = control_stream.get_records('COVARIANCE')
         control_stream = control_stream.remove_records(covrecs)

--- a/src/pharmpy/model/external/nonmem/update.py
+++ b/src/pharmpy/model/external/nonmem/update.py
@@ -1471,13 +1471,13 @@ def update_estimation(control_stream, model):
         if op == 1:
             est_code = '$ESTIMATION'
             protected_attributes = []
-            if est.method == 'FO':
-                method = 'ZERO'
-            elif est.method == 'FOCE':
-                method = 'COND'
+            if est.est_method == 'FO':
+                est_method = 'ZERO'
+            elif est.est_method == 'FOCE':
+                est_method = 'COND'
             else:
-                method = est.method
-            est_code += f' METHOD={method}'
+                est_method = est.est_method
+            est_code += f' METHOD={est_method}'
             if est.laplace:
                 est_code += ' LAPLACE'
                 protected_attributes += ['LAPLACE']
@@ -1485,7 +1485,7 @@ def update_estimation(control_stream, model):
                 est_code += ' INTER'
                 protected_attributes += ['INTERACTION', 'INTER']
             if est.evaluation:
-                if est.method == 'FO' or est.method == 'FOCE':
+                if est.est_method == 'FO' or est.est_method == 'FOCE':
                     est_code += ' MAXEVAL=0'
                     protected_attributes += ['MAXEVALS', 'MAXEVAL']
                 else:
@@ -1494,7 +1494,7 @@ def update_estimation(control_stream, model):
             if est.maximum_evaluations is not None:
                 op_prev, est_prev = prev
                 if not (
-                    est.method.startswith('FO')
+                    est.est_method.startswith('FO')
                     and op_prev == -1
                     and est.evaluation
                     and est_prev is not None

--- a/src/pharmpy/modeling/estimation_steps.py
+++ b/src/pharmpy/modeling/estimation_steps.py
@@ -33,7 +33,7 @@ def set_estimation_step(model: Model, est_method: str, idx: int = 0, **kwargs):
     >>> opts = {'NITER': 1000, 'ISAMPLE': 100}
     >>> model = set_estimation_step(model, 'IMP', evaluation=True, tool_options=opts)
     >>> model.estimation_steps[0]   # doctest: +ELLIPSIS
-    EstimationStep('IMP', interaction=True, cov='SANDWICH', evaluation=True, ..., tool_options=...
+    EstimationStep('IMP', interaction=True, uncert_method='SANDWICH', evaluation=True, ..., tool_options=...
 
     See also
     --------
@@ -91,7 +91,7 @@ def add_estimation_step(model: Model, est_method: str, idx: Optional[int] = None
     >>> len(ests)
     2
     >>> ests[1]   # doctest: +ELLIPSIS
-    EstimationStep('IMP', interaction=False, cov=None, ..., tool_options={'NITER': 1000,...
+    EstimationStep('IMP', interaction=False, uncert_method=None, ..., tool_options={'NITER': 1000,...
 
     See also
     --------
@@ -217,16 +217,15 @@ def append_estimation_step_options(model: Model, tool_options: Dict[str, Any], i
     return model.update_source()
 
 
-def add_covariance_step(model: Model, cov: str):
+def add_covariance_step(model: Model, uncert_method: str):
     """Adds covariance step to the final estimation step
 
     Parameters
     ----------
     model : Model
         Pharmpy model
-    cov : str
-        covariance method to use
-        covariance est_method to use
+    uncert_method : str
+        parameter uncertainty method to use
 
     Returns
     -------
@@ -237,11 +236,11 @@ def add_covariance_step(model: Model, cov: str):
     --------
     >>> from pharmpy.modeling import *
     >>> model = load_example_model("pheno")
-    >>> model = set_estimation_step(model, 'FOCE', cov=None)
+    >>> model = set_estimation_step(model, 'FOCE', uncert_method=None)
     >>> model = add_covariance_step(model, 'SANDWICH')
     >>> ests = model.estimation_steps
     >>> ests[0]   # doctest: +ELLIPSIS
-    EstimationStep('FOCE', interaction=True, cov='SANDWICH', ...)
+    EstimationStep('FOCE', interaction=True, uncert_method='SANDWICH', ...)
 
     See also
     --------
@@ -254,7 +253,7 @@ def add_covariance_step(model: Model, cov: str):
 
     """
     steps = model.estimation_steps
-    newstep = steps[-1].replace(cov=f'{cov}')
+    newstep = steps[-1].replace(uncert_method=f'{uncert_method}')
     newsteps = steps[0:-1] + newstep
     model = model.replace(estimation_steps=newsteps)
     return model.update_source()
@@ -280,7 +279,7 @@ def remove_covariance_step(model: Model):
     >>> model = remove_covariance_step(model)
     >>> ests = model.estimation_steps
     >>> ests[0]   # doctest: +ELLIPSIS
-    EstimationStep('FOCE', interaction=True, cov=None, ...)
+    EstimationStep('FOCE', interaction=True, uncert_method=None, ...)
 
     See also
     --------
@@ -293,7 +292,7 @@ def remove_covariance_step(model: Model):
 
     """
     steps = model.estimation_steps
-    newstep = steps[-1].replace(cov=None)
+    newstep = steps[-1].replace(uncert_method=None)
     newsteps = steps[:-1] + newstep
     model = model.replace(estimation_steps=newsteps)
     return model.update_source()
@@ -323,7 +322,7 @@ def set_evaluation_step(model: Model, idx: int = -1):
     >>> model = load_example_model("pheno")
     >>> model = set_evaluation_step(model)
     >>> model.estimation_steps[0]   # doctest: +ELLIPSIS
-    EstimationStep('FOCE', interaction=True, cov='SANDWICH', evaluation=True, ...
+    EstimationStep('FOCE', interaction=True, uncert_method='SANDWICH', evaluation=True, ...
 
     See also
     --------

--- a/src/pharmpy/modeling/estimation_steps.py
+++ b/src/pharmpy/modeling/estimation_steps.py
@@ -4,7 +4,7 @@ from pharmpy.model import EstimationStep, Model
 from pharmpy.modeling.help_functions import _as_integer
 
 
-def set_estimation_step(model: Model, method: str, idx: int = 0, **kwargs):
+def set_estimation_step(model: Model, est_method: str, idx: int = 0, **kwargs):
     """Set estimation step
 
     Sets estimation step for a model. Methods currently supported are:
@@ -14,8 +14,8 @@ def set_estimation_step(model: Model, method: str, idx: int = 0, **kwargs):
     ----------
     model : Model
         Pharmpy model
-    method : str
-        estimation method to change to
+    est_method : str
+        Estimation method to change to
     idx : int
         index of estimation step, default is 0 (first estimation step)
     kwargs
@@ -51,7 +51,7 @@ def set_estimation_step(model: Model, method: str, idx: int = 0, **kwargs):
         raise TypeError(f'Index must be integer: {idx}')
 
     d = kwargs
-    d['method'] = method
+    d['est_method'] = est_method
     steps = model.estimation_steps
     newstep = steps[idx].replace(**d)
     newsteps = steps[0:idx] + newstep + steps[idx + 1 :]
@@ -59,7 +59,7 @@ def set_estimation_step(model: Model, method: str, idx: int = 0, **kwargs):
     return model.update_source()
 
 
-def add_estimation_step(model: Model, method: str, idx: Optional[int] = None, **kwargs):
+def add_estimation_step(model: Model, est_method: str, idx: Optional[int] = None, **kwargs):
     """Add estimation step
 
     Adds estimation step for a model in a given index. Methods currently supported are:
@@ -69,8 +69,8 @@ def add_estimation_step(model: Model, method: str, idx: Optional[int] = None, **
     ----------
     model : Model
         Pharmpy model
-    method : str
-        estimation method to change to
+    est_method : str
+        Estimation method to change to
     idx : int
         index of estimation step (starting from 0), default is None (adds step at the end)
     kwargs
@@ -103,7 +103,7 @@ def add_estimation_step(model: Model, method: str, idx: Optional[int] = None, **
     set_evaluation_step
 
     """
-    meth = EstimationStep.create(method, **kwargs)
+    meth = EstimationStep.create(est_method, **kwargs)
 
     if idx is not None:
         try:
@@ -226,6 +226,7 @@ def add_covariance_step(model: Model, cov: str):
         Pharmpy model
     cov : str
         covariance method to use
+        covariance est_method to use
 
     Returns
     -------
@@ -301,7 +302,7 @@ def remove_covariance_step(model: Model):
 def set_evaluation_step(model: Model, idx: int = -1):
     """Set estimation step
 
-    Sets estimation step for a model. Methods currently supported are:
+    Sets estimation step for a model. Estimation methods currently supported are:
         FO, FOCE, ITS, LAPLACE, IMPMAP, IMP, SAEM, BAYES
 
     Parameters
@@ -309,7 +310,7 @@ def set_evaluation_step(model: Model, idx: int = -1):
     model : Model
         Pharmpy model
     idx : int
-        index of estimation step, default is -1 (last estimation step)
+        Index of estimation step, default is -1 (last estimation step)
 
     Returns
     -------

--- a/src/pharmpy/modeling/parameter_variability.py
+++ b/src/pharmpy/modeling/parameter_variability.py
@@ -1077,7 +1077,7 @@ def _choose_cov_param_init(model, individual_estimates, rvs, parent1, parent2):
     init_default = round(0.1 * sd[0] * sd[1], 7)
 
     last_estimation_step = [est for est in model.estimation_steps if not est.evaluation][-1]
-    if last_estimation_step.method == 'FO':
+    if last_estimation_step.est_method == 'FO':
         return init_default
     elif individual_estimates is not None:
         try:

--- a/src/pharmpy/tools/estmethod/tool.py
+++ b/src/pharmpy/tools/estmethod/tool.py
@@ -24,7 +24,7 @@ ALGORITHMS = frozenset(['exhaustive', 'exhaustive_with_update', 'exhaustive_only
 
 def create_workflow(
     algorithm: str,
-    methods: Optional[Union[List[str], str]] = None,
+    est_methods: Optional[Union[List[str], str]] = None,
     solvers: Optional[Union[List[str], str]] = None,
     covs: Optional[Union[List[str], str]] = None,
     results: Optional[ModelfitResults] = None,
@@ -32,40 +32,40 @@ def create_workflow(
 ):
     """Run estmethod tool.
 
-    Parameters
-    ----------
-    algorithm : str
-        The algorithm to use (can be 'exhaustive', 'exhaustive_with_update' or 'exhaustive_only_eval')
-    methods : list or None
-        List of estimation methods to test. Can be specified as 'all', a list of methods, or
-        None (to not test any estimation method)
-    solvers : list, str or None
-        List of solver to test. Can be specified as 'all', a list of solvers, or None (to
-        not test any solver)
-    covs : list, str or None
-        List of covariance to test. Can be specified as 'all', a list of covs, or None (to
-        not evaluate any covariance)
-    results : ModelfitResults
-        Results for model
-    model : Model
-        Pharmpy model
+     Parameters
+     ----------
+     algorithm : str
+         The algorithm to use (can be 'exhaustive', 'exhaustive_with_update' or 'exhaustive_only_eval')
+    est_ methods : list or None
+         List of estimation methods to test. Can be specified as 'all', a list of estimation methods, or
+         None (to not test any estimation method)
+     solvers : list, str or None
+         List of solver to test. Can be specified as 'all', a list of solvers, or None (to
+         not test any solver)
+     covs : list, str or None
+         List of covariance to test. Can be specified as 'all', a list of covs, or None (to
+         not evaluate any covariance)
+     results : ModelfitResults
+         Results for model
+     model : Model
+         Pharmpy model
 
-    Returns
-    -------
-    EstMethodResults
-        Estmethod tool result object
+     Returns
+     -------
+     EstMethodResults
+         Estmethod tool result object
 
-    Examples
-    --------
-    >>> from pharmpy.modeling import *
-    >>> from pharmpy.tools import run_estmethod, load_example_modelfit_results
-    >>> model = load_example_model("pheno")
-    >>> results = load_example_modelfit_results("pheno")
-    >>> methods = ['imp', 'saem']
-    >>> covs = None
-    >>> run_estmethod( # doctest: +SKIP
-    >>>     'reduced', methods=methods, solvers='all', covs=covs, results=results, model=model # doctest: +SKIP
-    >>> ) # doctest: +SKIP
+     Examples
+     --------
+     >>> from pharmpy.modeling import *
+     >>> from pharmpy.tools import run_estmethod, load_example_modelfit_results
+     >>> model = load_example_model("pheno")
+     >>> results = load_example_modelfit_results("pheno")
+     >>> est_methods = ['imp', 'saem']
+     >>> covs = None
+     >>> run_estmethod( # doctest: +SKIP
+     >>>     'reduced', est_methods=est_methods, solvers='all', covs=covs, results=results, model=model # doctest: +SKIP
+     >>> ) # doctest: +SKIP
 
     """
     wb = WorkflowBuilder(name="estmethod")
@@ -79,11 +79,11 @@ def create_workflow(
 
     wb.add_task(start_task)
 
-    if methods is None:
-        methods = [model.estimation_steps[-1].method]
+    if est_methods is None:
+        est_methods = [model.estimation_steps[-1].est_method]
 
     wf_algorithm, task_base_model_fit = algorithm_func(
-        _format_input(methods, EST_METHODS),
+        _format_input(est_methods, EST_METHODS),
         _format_input(solvers, SOLVERS),
         _format_input(covs, COVS),
     )
@@ -186,7 +186,7 @@ def summarize_estimation_steps(models):
 
 @with_runtime_arguments_type_check
 @with_same_arguments_as(create_workflow)
-def validate_input(algorithm, methods, solvers, covs, model):
+def validate_input(algorithm, est_methods, solvers, covs, model):
     if solvers is not None and has_linear_odes(model):
         raise ValueError(
             'Invalid input `model`: testing non-linear solvers on linear system is not supported'
@@ -197,13 +197,13 @@ def validate_input(algorithm, methods, solvers, covs, model):
             f'Invalid `algorithm`: got `{algorithm}`, must be one of {sorted(ALGORITHMS)}.'
         )
 
-    if methods is None and solvers is None and covs is None:
+    if est_methods is None and solvers is None and covs is None:
         raise ValueError(
-            'Invalid search space options: please specify at least one of `methods`, `solvers`, or `covs`'
+            'Invalid search space options: please specify at least one of `est_methods`, `solvers`, or `covs`'
         )
 
-    if methods is not None:
-        _validate_search_space(methods, EST_METHODS, 'methods')
+    if est_methods is not None:
+        _validate_search_space(est_methods, EST_METHODS, 'est_methods')
 
     if solvers is not None:
         _validate_search_space(solvers, SOLVERS, 'solvers')

--- a/tests/integration/test_estmethod.py
+++ b/tests/integration/test_estmethod.py
@@ -5,7 +5,7 @@ from pharmpy.tools import run_estmethod
 
 
 @pytest.mark.parametrize(
-    'algorithm, methods, covs, no_of_candidates, advan_ref',
+    'algorithm, est_methods, covs, no_of_candidates, advan_ref',
     [
         ('exhaustive', ['foce', 'imp'], None, 2, 'ADVAN2'),
         ('exhaustive_only_eval', ['foce', 'imp'], None, 2, 'ADVAN2'),
@@ -19,13 +19,13 @@ def test_estmethod(
     model_count,
     testdata,
     algorithm,
-    methods,
+    est_methods,
     covs,
     no_of_candidates,
     advan_ref,
 ):
     with chdir(tmp_path):
-        res = run_estmethod(algorithm, methods=methods, covs=covs, model=start_model)
+        res = run_estmethod(algorithm, est_methods=est_methods, covs=covs, model=start_model)
 
         assert len(res.summary_tool) == no_of_candidates
         assert len(res.models) == no_of_candidates

--- a/tests/integration/test_estmethod.py
+++ b/tests/integration/test_estmethod.py
@@ -5,7 +5,7 @@ from pharmpy.tools import run_estmethod
 
 
 @pytest.mark.parametrize(
-    'algorithm, est_methods, covs, no_of_candidates, advan_ref',
+    'algorithm, est_methods, uncert_methods, no_of_candidates, advan_ref',
     [
         ('exhaustive', ['foce', 'imp'], None, 2, 'ADVAN2'),
         ('exhaustive_only_eval', ['foce', 'imp'], None, 2, 'ADVAN2'),
@@ -20,12 +20,14 @@ def test_estmethod(
     testdata,
     algorithm,
     est_methods,
-    covs,
+    uncert_methods,
     no_of_candidates,
     advan_ref,
 ):
     with chdir(tmp_path):
-        res = run_estmethod(algorithm, est_methods=est_methods, covs=covs, model=start_model)
+        res = run_estmethod(
+            algorithm, est_methods=est_methods, uncert_methods=uncert_methods, model=start_model
+        )
 
         assert len(res.summary_tool) == no_of_candidates
         assert len(res.models) == no_of_candidates

--- a/tests/model/test_estimation.py
+++ b/tests/model/test_estimation.py
@@ -16,14 +16,14 @@ def test_init():
 
 def test_estimation_method():
     a = EstimationStep.create('foce', cov='sandwich')
-    assert a.method == 'FOCE'
+    assert a.est_method == 'FOCE'
     assert a.cov == 'SANDWICH'
 
     with pytest.raises(ValueError):
         EstimationStep.create('sklarfs')
 
-    a = a.replace(method='fo')
-    assert a.method == 'FO'
+    a = a.replace(est_method='fo')
+    assert a.est_method == 'FO'
     assert a.cov == 'SANDWICH'
 
     assert a == EstimationStep.create('fo', interaction=False, cov='sandwich')
@@ -105,7 +105,7 @@ def test_dict():
     a = EstimationStep.create('foce')
     d = a.to_dict()
     assert d == {
-        'method': 'FOCE',
+        'est_method': 'FOCE',
         'interaction': False,
         'cov': None,
         'evaluation': False,
@@ -129,7 +129,7 @@ def test_dict():
     assert d == {
         'steps': (
             {
-                'method': 'FOCE',
+                'est_method': 'FOCE',
                 'interaction': False,
                 'cov': None,
                 'evaluation': False,
@@ -145,7 +145,7 @@ def test_dict():
                 'tool_options': {},
             },
             {
-                'method': 'FO',
+                'est_method': 'FO',
                 'interaction': False,
                 'cov': None,
                 'evaluation': False,
@@ -170,8 +170,8 @@ def test_getitem():
     a = EstimationStep.create('foce')
     b = EstimationStep.create('fo')
     s = EstimationSteps.create([a, b])
-    assert s[0].method == 'FOCE'
-    assert s[1].method == 'FO'
+    assert s[0].est_method == 'FOCE'
+    assert s[1].est_method == 'FO'
 
     assert len(s[1:]) == 1
 
@@ -189,8 +189,8 @@ def test_properties():
 
 def test_replace():
     a = EstimationStep.create('foce')
-    b = a.replace(method='fo')
-    assert b.method == 'FO'
+    b = a.replace(est_method='fo')
+    assert b.est_method == 'FO'
     c = a.replace(solver_atol=0.01)
     assert c.solver_atol == 0.01
 

--- a/tests/model/test_estimation.py
+++ b/tests/model/test_estimation.py
@@ -15,20 +15,21 @@ def test_init():
 
 
 def test_estimation_method():
-    a = EstimationStep.create('foce', cov='sandwich')
+    a = EstimationStep.create('foce', uncert_method='sandwich')
     assert a.est_method == 'FOCE'
-    assert a.cov == 'SANDWICH'
+    assert a.uncert_method == 'SANDWICH'
 
     with pytest.raises(ValueError):
         EstimationStep.create('sklarfs')
 
     a = a.replace(est_method='fo')
     assert a.est_method == 'FO'
-    assert a.cov == 'SANDWICH'
+    assert a.uncert_method == 'SANDWICH'
 
-    assert a == EstimationStep.create('fo', interaction=False, cov='sandwich')
+    assert a == EstimationStep.create('fo', interaction=False, uncert_method='sandwich')
     assert (
-        repr(a) == "EstimationStep('FO', interaction=False, cov='SANDWICH', evaluation=False, "
+        repr(a)
+        == "EstimationStep('FO', interaction=False, uncert_method='SANDWICH', evaluation=False, "
         "maximum_evaluations=None, laplace=False, isample=None, niter=None, auto=None, "
         "keep_every_nth_iter=None, solver=None, solver_rtol=None, solver_atol=None, "
         "tool_options={})"
@@ -107,7 +108,7 @@ def test_dict():
     assert d == {
         'est_method': 'FOCE',
         'interaction': False,
-        'cov': None,
+        'uncert_method': None,
         'evaluation': False,
         'maximum_evaluations': None,
         'laplace': False,
@@ -131,7 +132,7 @@ def test_dict():
             {
                 'est_method': 'FOCE',
                 'interaction': False,
-                'cov': None,
+                'uncert_method': None,
                 'evaluation': False,
                 'maximum_evaluations': None,
                 'laplace': False,
@@ -147,7 +148,7 @@ def test_dict():
             {
                 'est_method': 'FO',
                 'interaction': False,
-                'cov': None,
+                'uncert_method': None,
                 'evaluation': False,
                 'maximum_evaluations': None,
                 'laplace': False,

--- a/tests/modeling/test_estimation_steps.py
+++ b/tests/modeling/test_estimation_steps.py
@@ -49,7 +49,7 @@ def test_set_estimation_step(testdata, load_model_for_test, est_method, kwargs, 
 
 def test_set_estimation_step_est_middle(testdata, load_model_for_test):
     model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
-    model = set_estimation_step(model, 'FOCE', interaction=True, cov='SANDWICH', idx=0)
+    model = set_estimation_step(model, 'FOCE', interaction=True, uncert_method='SANDWICH', idx=0)
     assert (
         '$ESTIMATION METHOD=COND INTER MAXEVAL=9990 PRINT=2 POSTHOC\n$COVARIANCE'
         in model.model_code

--- a/tests/modeling/test_estimation_steps.py
+++ b/tests/modeling/test_estimation_steps.py
@@ -12,7 +12,7 @@ from pharmpy.modeling import (
 
 
 @pytest.mark.parametrize(
-    'method,kwargs,code_ref',
+    'est_method,kwargs,code_ref',
     [
         (
             'fo',
@@ -41,9 +41,9 @@ from pharmpy.modeling import (
         ),
     ],
 )
-def test_set_estimation_step(testdata, load_model_for_test, method, kwargs, code_ref):
+def test_set_estimation_step(testdata, load_model_for_test, est_method, kwargs, code_ref):
     model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
-    model = set_estimation_step(model, method, **kwargs)
+    model = set_estimation_step(model, est_method, **kwargs)
     assert model.model_code.split('\n')[-2] == code_ref
 
 

--- a/tests/nonmem/test_nonmem_model.py
+++ b/tests/nonmem/test_nonmem_model.py
@@ -625,7 +625,10 @@ def test_zero_order_cmt(load_model_for_test, testdata):
         ('$ESTIMA METH=0', [EstimationStep.create('fo')]),
         ('$ESTIMA METH=ZERO', [EstimationStep.create('fo')]),
         ('$ESTIMA INTER', [EstimationStep.create('fo', interaction=True)]),
-        ('$ESTIMA INTER\n$COV', [EstimationStep.create('fo', interaction=True, cov='sandwich')]),
+        (
+            '$ESTIMA INTER\n$COV',
+            [EstimationStep.create('fo', interaction=True, uncert_method='sandwich')],
+        ),
         (
             '$ESTIMA METH=COND INTER\n$EST METH=COND',
             [
@@ -690,9 +693,9 @@ $ESTIMATION METHOD=1 SADDLE_RESET=1
     [
         ('$EST METH=COND INTER', {'est_method': 'fo'}, '$ESTIMATION METHOD=ZERO INTER'),
         ('$EST METH=COND INTER', {'interaction': False}, '$ESTIMATION METHOD=COND'),
-        ('$EST METH=COND INTER', {'cov': 'sandwich'}, '$COVARIANCE'),
-        ('$EST METH=COND INTER', {'cov': 'cpg'}, '$COVARIANCE MATRIX=S'),
-        ('$EST METH=COND INTER', {'cov': 'ofim'}, '$COVARIANCE MATRIX=R'),
+        ('$EST METH=COND INTER', {'uncert_method': 'sandwich'}, '$COVARIANCE'),
+        ('$EST METH=COND INTER', {'uncert_method': 'cpg'}, '$COVARIANCE MATRIX=S'),
+        ('$EST METH=COND INTER', {'uncert_method': 'ofim'}, '$COVARIANCE MATRIX=R'),
         (
             '$EST METH=COND INTER MAXEVAL=99999',
             {'est_method': 'fo'},

--- a/tests/nonmem/test_nonmem_model.py
+++ b/tests/nonmem/test_nonmem_model.py
@@ -681,26 +681,26 @@ $SIGMA 1
 $ESTIMATION METHOD=1 SADDLE_RESET=1
 '''
     model = Model.parse_model_from_string(code)
-    assert model.estimation_steps[0].method == 'FOCE'
+    assert model.estimation_steps[0].est_method == 'FOCE'
     assert model.estimation_steps[0].tool_options['SADDLE_RESET'] == '1'
 
 
 @pytest.mark.parametrize(
     'estcode,kwargs,rec_ref',
     [
-        ('$EST METH=COND INTER', {'method': 'fo'}, '$ESTIMATION METHOD=ZERO INTER'),
+        ('$EST METH=COND INTER', {'est_method': 'fo'}, '$ESTIMATION METHOD=ZERO INTER'),
         ('$EST METH=COND INTER', {'interaction': False}, '$ESTIMATION METHOD=COND'),
         ('$EST METH=COND INTER', {'cov': 'sandwich'}, '$COVARIANCE'),
         ('$EST METH=COND INTER', {'cov': 'cpg'}, '$COVARIANCE MATRIX=S'),
         ('$EST METH=COND INTER', {'cov': 'ofim'}, '$COVARIANCE MATRIX=R'),
         (
             '$EST METH=COND INTER MAXEVAL=99999',
-            {'method': 'fo'},
+            {'est_method': 'fo'},
             '$ESTIMATION METHOD=ZERO INTER MAXEVAL=99999',
         ),
         (
             '$EST METH=COND INTER POSTHOC',
-            {'method': 'fo'},
+            {'est_method': 'fo'},
             '$ESTIMATION METHOD=ZERO INTER POSTHOC',
         ),
         ('$EST METH=COND INTER', {'laplace': True}, '$ESTIMATION METHOD=COND LAPLACE INTER'),

--- a/tests/nonmem/test_nonmem_table.py
+++ b/tests/nonmem/test_nonmem_table.py
@@ -31,7 +31,7 @@ def test_ext_table(pheno_ext):
     assert ext_table.problem == 1
     assert ext_table.subproblem == 0
     assert ext_table.iteration2 == 0
-    assert ext_table.method == "First Order Conditional Estimation with Interaction"
+    assert ext_table.est_method == "First Order Conditional Estimation with Interaction"
     assert ext_table.goal_function == "MINIMUM VALUE OF OBJECTIVE FUNCTION"
     assert ext_table.final_parameter_estimates['THETA(1)'] == 0.00469555
     assert list(ext_table.fixed) == [False, False, False, False, True, False, False]
@@ -46,7 +46,7 @@ def test_phi_table(pheno_phi):
     assert phi_table.problem == 1
     assert phi_table.subproblem == 0
     assert phi_table.iteration2 == 0
-    assert phi_table.method == "First Order Conditional Estimation with Interaction"
+    assert phi_table.est_method == "First Order Conditional Estimation with Interaction"
     assert phi_table.goal_function is None
 
 

--- a/tests/tools/test_estmethod.py
+++ b/tests/tools/test_estmethod.py
@@ -5,7 +5,7 @@ from pharmpy.tools.estmethod.tool import SOLVERS, create_workflow, validate_inpu
 
 
 @pytest.mark.parametrize(
-    'algorithm, est_methods, solvers, covs, no_of_models',
+    'algorithm, est_methods, solvers, uncert_methods, no_of_models',
     [
         ('exhaustive', ['foce'], None, None, 1),
         ('exhaustive', ['foce', 'laplace'], None, None, 2),
@@ -20,8 +20,10 @@ from pharmpy.tools.estmethod.tool import SOLVERS, create_workflow, validate_inpu
         ('exhaustive', ['foce', 'imp'], None, ['sandwich', 'cpg'], 4),
     ],
 )
-def test_algorithm(algorithm, est_methods, solvers, covs, no_of_models):
-    wf = create_workflow(algorithm, est_methods=est_methods, solvers=solvers, covs=covs)
+def test_algorithm(algorithm, est_methods, solvers, uncert_methods, no_of_models):
+    wf = create_workflow(
+        algorithm, est_methods=est_methods, solvers=solvers, uncert_methods=uncert_methods
+    )
     fit_tasks = [task.name for task in wf.tasks if task.name.startswith('run')]
 
     assert len(fit_tasks) == no_of_models

--- a/tests/tools/test_estmethod.py
+++ b/tests/tools/test_estmethod.py
@@ -5,7 +5,7 @@ from pharmpy.tools.estmethod.tool import SOLVERS, create_workflow, validate_inpu
 
 
 @pytest.mark.parametrize(
-    'algorithm, methods, solvers, covs, no_of_models',
+    'algorithm, est_methods, solvers, covs, no_of_models',
     [
         ('exhaustive', ['foce'], None, None, 1),
         ('exhaustive', ['foce', 'laplace'], None, None, 2),
@@ -20,15 +20,15 @@ from pharmpy.tools.estmethod.tool import SOLVERS, create_workflow, validate_inpu
         ('exhaustive', ['foce', 'imp'], None, ['sandwich', 'cpg'], 4),
     ],
 )
-def test_algorithm(algorithm, methods, solvers, covs, no_of_models):
-    wf = create_workflow(algorithm, methods=methods, solvers=solvers, covs=covs)
+def test_algorithm(algorithm, est_methods, solvers, covs, no_of_models):
+    wf = create_workflow(algorithm, est_methods=est_methods, solvers=solvers, covs=covs)
     fit_tasks = [task.name for task in wf.tasks if task.name.startswith('run')]
 
     assert len(fit_tasks) == no_of_models
 
 
 @pytest.mark.parametrize(
-    'method, est_rec, eval_rec',
+    'est_method, est_rec, eval_rec',
     [
         (
             'FO',
@@ -43,11 +43,11 @@ def test_algorithm(algorithm, methods, solvers, covs, no_of_models):
         ),
     ],
 )
-def test_create_est_model(load_model_for_test, pheno_path, method, est_rec, eval_rec):
+def test_create_est_model(load_model_for_test, pheno_path, est_method, est_rec, eval_rec):
     model = load_model_for_test(pheno_path)
     assert len(model.estimation_steps) == 1
     est_model = _create_candidate_model(
-        method, None, None, model=model, update=False, is_eval_candidate=False
+        est_method, None, None, model=model, update=False, is_eval_candidate=False
     )
     assert len(est_model.estimation_steps) == 2
     assert est_model.model_code.split('\n')[-5] == est_rec
@@ -67,7 +67,7 @@ def test_create_est_model(load_model_for_test, pheno_path, method, est_rec, eval
             'Invalid `algorithm`',
         ),
         (
-            dict(algorithm='exhaustive', methods=None, solvers=None),
+            dict(algorithm='exhaustive', est_methods=None, solvers=None),
             ValueError,
             'Invalid search space options',
         ),


### PR DESCRIPTION
This PR includes two major changes in the EstimationStep class and elsewhere:

Renaming `cov` to `uncert_method`.
Renaming `method` to `est_method`.

### Why These Changes Are Important:

- Clarity: Renaming `cov` to `uncert_method` distinguishes it from the term "covariate", and the term `est_method` specifies that it's the method for parameter estimation — limiting confusion.
- Consistency: These changes align well with each other, bringing a unified naming convention to the `EstimationStep` class.
- Searchability: The unique terms allows for more targeted code searches.

Please review these changes and let me know if you have any questions, comments, need further clarifications, or have feedback.