### PR TITLE
Add indirect effect models

### DIFF
--- a/src/pharmpy/modeling/__init__.py
+++ b/src/pharmpy/modeling/__init__.py
@@ -193,7 +193,7 @@ from .parameters import (
     unfix_parameters_to,
     update_inits,
 )
-from .pd import add_effect_compartment, set_direct_effect
+from .pd import add_effect_compartment, add_indirect_effect, set_direct_effect
 from .plots import (
     plot_individual_predictions,
     plot_iofv_vs_iofv,
@@ -221,6 +221,7 @@ __all__ = [
     'add_covariate_effect',
     'add_estimation_step',
     'add_effect_compartment',
+    'add_indirect_effect',
     'add_iiv',
     'add_individual_parameter',
     'add_iov',

--- a/src/pharmpy/modeling/expressions.py
+++ b/src/pharmpy/modeling/expressions.py
@@ -1259,7 +1259,7 @@ def get_pd_parameters(model: Model) -> List[str]:
     >>> model = load_example_model("pheno")
     >>> model = set_direct_effect(model, "linear")
     >>> get_pd_parameters(model)
-    ['E0', 'SLOPE']
+    ['B', 'SLOPE']
 
     See also
     --------

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -39,8 +39,10 @@ def run_amd(
     cl_init: float = 0.01,
     vc_init: float = 1.0,
     mat_init: float = 0.1,
+    b_init: Optional[float] = None,
     emax_init: Optional[float] = None,
     ec50_init: Optional[float] = None,
+    met_init: Optional[float] = None,
     search_space: Optional[str] = None,
     lloq_method: Optional[str] = None,
     lloq_limit: Optional[str] = None,
@@ -70,10 +72,14 @@ def run_amd(
         Initial estimate for the central compartment population volume
     mat_init : float
         Initial estimate for the mean absorption time (not for iv models)
+    b_init : float
+        Initial estimate for the baseline (PKPD model)
     emax_init : float
         Initial estimate for E_max (PKPD model)
     ec50_init : float
         Initial estimate for EC_50 (PKPD model)
+    met_init : float
+        Initial estimate for mean equilibration time (PKPD model)
     search_space : str
         MFL for search space for structural model
     lloq_method : str
@@ -114,7 +120,7 @@ def run_amd(
 
     if administration not in ['iv', 'oral', 'ivoral']:
         raise ValueError(f'Invalid input: "{administration}" as administration is not supported')
-    if modeltype not in ['basic_pk']:
+    if modeltype not in ['basic_pk', 'pkpd']:
         raise ValueError(f'Invalid input: "{modeltype}" as modeltype is not supported')
 
     if modeltype == 'pkpd':
@@ -213,8 +219,10 @@ def run_amd(
                 func = _subfunc_structsearch(
                     route=administration,
                     modeltype=modeltype,
+                    b_init=b_init,
                     emax_init=emax_init,
                     ec50_init=ec50_init,
+                    met_init=met_init,
                     path=db.path,
                 )
                 run_subfuncs['structsearch'] = func
@@ -363,14 +371,18 @@ def _subfunc_modelsearch(search_space: Tuple[Statement, ...], path) -> SubFunc:
     return _run_modelsearch
 
 
-def _subfunc_structsearch(route, modeltype, emax_init, ec50_init, path) -> SubFunc:
+def _subfunc_structsearch(
+    route, modeltype, b_init, emax_init, ec50_init, met_init, path
+) -> SubFunc:
     def _run_structsearch(model):
         res = run_tool(
             'structsearch',
             route=route,
             type=modeltype,
+            b_init=b_init,
             emax_init=emax_init,
             ec50_init=ec50_init,
+            met_init=met_init,
             model=model,
             path=path / 'structsearch',
         )

--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -1,16 +1,22 @@
+from typing import List, Optional, Union
+
+from itertools import product
 from pharmpy.deps import pandas as pd
 from pharmpy.model import Model
 from pharmpy.modeling import (
     add_effect_compartment,
     add_iiv,
+    add_indirect_effect,
     fix_parameters_to,
     set_direct_effect,
     set_initial_estimates,
     set_name,
+    unconstrain_parameters,
+    set_lower_bounds,
 )
 
 
-def create_baseline_pd_model(model: Model, ests: pd.Series):
+def create_baseline_pd_model(model: Model, ests: pd.Series, b_init: Optional[float] = None):
     """Create baseline pkpd model
 
     Parameters
@@ -19,6 +25,8 @@ def create_baseline_pd_model(model: Model, ests: pd.Series):
         Pharmpy PK model
     ests : pd.Series
        List of estimated PK parameters
+    b_init : float
+        Initial estimate for baseline
 
     Returns
     -------
@@ -27,14 +35,22 @@ def create_baseline_pd_model(model: Model, ests: pd.Series):
     baseline_model = set_direct_effect(model, expr='baseline')
     baseline_model = set_name(baseline_model, "baseline_model")
     baseline_model = baseline_model.replace(parent_model='baseline_model')
-    baseline_model = baseline_model.replace(description="direct_effect_baseline")
+    baseline_model = baseline_model.replace(description="baseline_model")
     baseline_model = fix_parameters_to(baseline_model, ests)
-    baseline_model = add_iiv(baseline_model, ["E0"], "exp")
+    baseline_model = add_iiv(baseline_model, ["B"], "exp")
+    if b_init is not None:
+        baseline_model = set_initial_estimates(baseline_model, {'POP_B': b_init})
     return baseline_model
 
 
 def create_pkpd_models(
-    model: Model, e0_init: pd.Series, ests: pd.Series, emax_init=None, ec50_init=None
+    model: Model,
+    b_init: Optional[float] = None,
+    ests: pd.Series = None,
+    emax_init: Optional[float] = None,
+    ec50_init: Optional[float] = None,
+    mat_init: Optional[float] = None,
+    response_type: Union[str, List] = 'all',
 ):
     """Create pkpd models
 
@@ -42,47 +58,96 @@ def create_pkpd_models(
     ----------
     model : Model
         Pharmpy PK model
+    b_init : float
+       Initial estimate for baseline
     ests : pd.Series
        List of estimated PK parameters
     emax_init : float
         Initial estimate for E_max
     ec50_init : float
         Initial estimate for EC_50
+    mat_init : float
+        Initial estimate for MAT (mean equilibration time)
+    response_type : str
+        type of model (e.g. direct effect)
 
     Returns
     -------
     List of pharmpy models
     """
+
+    print(response_type)
+    if response_type == 'all':
+        models_list = ['direct', 'effect_compartment', 'indirect']
+    elif isinstance(response_type, str):
+        models_list = [response_type]
+    elif isinstance(response_type, list):
+        models_list = response_type
+
+    pd_types = ["linear", "Emax", "sigmoid"]
+
     models = []
-    index = 1
-    pd_types = ["linear", "Emax", "sigmoid", "step"]
-    for model_type in ["direct_effect", "effect_compartment"]:
-        for pd_type in pd_types:
-            if model_type == "direct_effect":
-                pkpd_model = set_direct_effect(model, expr=pd_type)
-            elif model_type == "effect_compartment":
-                pkpd_model = add_effect_compartment(model, expr=pd_type)
+    for modeltype in models_list:
+        if modeltype in ['direct', 'effect_compartment']:
+            for pd_type in pd_types:
+                pkpd_model = _create_model(model, modeltype, expr=pd_type)
+                pkpd_model = pkpd_model.replace(description=f"{modeltype}_{pd_type}")
+                models.append(pkpd_model)
+        elif modeltype == 'indirect':
+            for argument in list(product(pd_types, [True, False])):
+                pkpd_model = add_indirect_effect(model, *argument)
+                pkpd_model = pkpd_model.replace(
+                    description=f"{modeltype}_{argument[0]}_prod={argument[1]}"
+                )
+                models.append(pkpd_model)
 
+        final_models = []
+        index = 1
+        for pkpd_model in models:
             pkpd_model = set_name(pkpd_model, f"structsearch_run{index}")
-            pkpd_model = pkpd_model.replace(description=f"{model_type}_{pd_type}")
             index += 1
-            pkpd_model = add_iiv(pkpd_model, ["E0"], "exp")
-            pkpd_model = set_initial_estimates(pkpd_model, e0_init)
-            pkpd_model = fix_parameters_to(pkpd_model, ests)
 
-            if emax_init is not None:
+            # initial values
+            if b_init is not None:
+                pkpd_model = set_initial_estimates(pkpd_model, b_init)
+            if ests is not None:
+                pkpd_model = fix_parameters_to(pkpd_model, ests)
+
+            if emax_init is not None and ec50_init is not None:
                 pkpd_model = set_initial_estimates(pkpd_model, {'POP_E_MAX': emax_init})
-            if ec50_init is not None:
                 pkpd_model = set_initial_estimates(pkpd_model, {'POP_EC_50': ec50_init})
+                pkpd_model = set_initial_estimates(pkpd_model, {'POP_SLOPE': emax_init / ec50_init})
+            if mat_init is not None:
+                pkpd_model = set_initial_estimates(
+                    pkpd_model, {'POP_KE0': 1 / mat_init, 'POP_K_OUT': 1 / mat_init}
+                )
 
-            for parameter in ["SLOPE", "E_MAX"]:
+            pkpd_model = unconstrain_parameters(pkpd_model, ['SLOPE'])
+            pkpd_model = set_lower_bounds(pkpd_model, {'POP_E_MAX': -1})
+
+            # set iiv
+            for parameter in ["B", "SLOPE"]:
                 try:
                     pkpd_model = add_iiv(pkpd_model, [parameter], "exp")
                 except ValueError:
                     pass
+            try:
+                pkpd_model = add_iiv(pkpd_model, ['E_MAX'], "prop")
+            except ValueError:
+                pass
+
             pkpd_model = pkpd_model.replace(parent_model='baseline_model')
-            models.append(pkpd_model)
-    return models
+            final_models.append(pkpd_model)
+
+    return final_models
+
+
+def _create_model(model, modeltype, expr):
+    if modeltype == 'direct':
+        model = set_direct_effect(model, expr)
+    elif modeltype == 'effect_compartment':
+        model = add_effect_compartment(model, expr)
+    return model
 
 
 def create_pk_model(model: Model):

--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -1,6 +1,6 @@
+from itertools import product
 from typing import List, Optional, Union
 
-from itertools import product
 from pharmpy.deps import pandas as pd
 from pharmpy.model import Model
 from pharmpy.modeling import (
@@ -10,9 +10,9 @@ from pharmpy.modeling import (
     fix_parameters_to,
     set_direct_effect,
     set_initial_estimates,
+    set_lower_bounds,
     set_name,
     unconstrain_parameters,
-    set_lower_bounds,
 )
 
 

--- a/tests/modeling/test_expressions.py
+++ b/tests/modeling/test_expressions.py
@@ -349,11 +349,11 @@ def test_get_pk_parameters(load_model_for_test, testdata, model_path, kind, expe
 @pytest.mark.parametrize(
     ('model_path', 'kind', 'expected'),
     (
-        ('nonmem/pheno.mod', 'baseline', ['E0']),
-        ('nonmem/pheno.mod', 'linear', ['E0', 'SLOPE']),
-        ('nonmem/pheno.mod', 'Emax', ['E0', 'E_MAX', 'EC_50']),
-        ('nonmem/pheno.mod', 'step', ['E0', 'E_MAX']),
-        ('nonmem/pheno.mod', 'sigmoid', ['E0', 'EC_50', 'E_MAX', 'n']),
+        ('nonmem/pheno.mod', 'baseline', ['B']),
+        ('nonmem/pheno.mod', 'linear', ['B', 'SLOPE']),
+        ('nonmem/pheno.mod', 'Emax', ['B', 'E_MAX', 'EC_50']),
+        ('nonmem/pheno.mod', 'step', ['B', 'E_MAX']),
+        ('nonmem/pheno.mod', 'sigmoid', ['B', 'EC_50', 'E_MAX', 'N']),
     ),
     ids=repr,
 )

--- a/tests/modeling/test_pd.py
+++ b/tests/modeling/test_pd.py
@@ -8,7 +8,7 @@ from pharmpy.model import (
     CompartmentalSystemBuilder,
     output,
 )
-from pharmpy.modeling import add_effect_compartment, set_direct_effect
+from pharmpy.modeling import add_effect_compartment, add_indirect_effect, set_direct_effect
 
 
 def S(x):
@@ -51,50 +51,70 @@ def test_add_effect_compartment(load_model_for_test, pd_model, testdata):
 
 def _test_effect_models(model, expr, conc):
     e = S("E")
-    e0 = S("E0")
+    e0 = S("B")
     emax = S("E_MAX")
     ec50 = S("EC_50")
 
     if expr == 'baseline':
-        assert model.statements[0] == Assignment(e0, S("POP_E0"))
+        assert model.statements[0] == Assignment(e0, S("POP_B"))
         assert model.statements.after_odes[-2] == Assignment(e, e0)
         assert model.statements.after_odes[-1] == Assignment(S("Y_2"), e + e * S("epsilon_p"))
     elif expr == 'linear':
-        assert model.statements[1] == Assignment(e0, S("POP_E0"))
+        assert model.statements[1] == Assignment(e0, S("POP_B"))
         assert model.statements[0] == Assignment(S("SLOPE"), S("POP_SLOPE"))
         assert model.statements.after_odes[-2] == Assignment(e, e0 + S("SLOPE") * conc)
         assert model.statements.after_odes[-1] == Assignment(S("Y_2"), e + e * S("epsilon_p"))
     elif expr == "Emax":
         assert model.statements[0] == Assignment(ec50, S("POP_EC_50"))
-        assert model.statements[2] == Assignment(e0, S("POP_E0"))
+        assert model.statements[2] == Assignment(e0, S("POP_B"))
         assert model.statements[1] == Assignment(emax, S("POP_E_MAX"))
         assert model.statements.after_odes[-2] == Assignment(e, e0 + (emax * conc) / (ec50 + conc))
         assert model.statements.after_odes[-1] == Assignment(S("Y_2"), e + e * S("epsilon_p"))
     elif expr == "sigmoid":
-        assert model.statements[0] == Assignment(S("n"), S("POP_n"))
+        assert model.statements[0] == Assignment(S("N"), S("POP_N"))
         assert model.statements[1] == Assignment(ec50, S("POP_EC_50"))
-        assert model.statements[3] == Assignment(e0, S("POP_E0"))
+        assert model.statements[3] == Assignment(e0, S("POP_B"))
         assert model.statements[2] == Assignment(emax, S("POP_E_MAX"))
         assert model.statements.after_odes[-2] == Assignment(
             e,
             sympy.Piecewise(
-                (e0 + ((emax * conc ** S("n")) / (ec50 ** S("n") + conc ** S("n"))), conc > 0),
+                (e0 + ((emax * conc ** S("N")) / (ec50 ** S("N") + conc ** S("N"))), conc > 0),
                 (e0, True),
             ),
         )
         assert model.statements.after_odes[-1] == Assignment(S("Y_2"), e + e * S("epsilon_p"))
-        assert model.parameters["POP_n"].init == 1
+        assert model.parameters["POP_N"].init == 1
     elif expr == "step":
-        assert model.statements[1] == Assignment(e0, S("POP_E0"))
+        assert model.statements[1] == Assignment(e0, S("POP_B"))
         assert model.statements[0] == Assignment(emax, S("POP_E_MAX"))
         assert model.statements.after_odes[-2] == Assignment(
             e, sympy.Piecewise((e0, conc <= 0), (e0 + emax, True))
         )
         assert model.statements.after_odes[-1] == Assignment(S("Y_2"), e + e * S("epsilon_p"))
     elif expr == "loglin":
-        assert model.statements[1] == Assignment(e0, S("POP_E0"))
+        assert model.statements[1] == Assignment(e0, S("POP_B"))
         assert model.statements[0] == Assignment(S("SLOPE"), S("POP_SLOPE"))
         assert model.statements.after_odes[-2] == Assignment(
             e, S("SLOPE") * sympy.log(conc + sympy.exp(e0 / S("SLOPE")))
         )
         assert model.statements.after_odes[-1] == Assignment(S("Y_2"), e + e * S("epsilon_p"))
+
+
+@pytest.mark.parametrize(
+    'prod, expr',
+    [
+        (True, 'linear'),
+        (True, 'Emax'),
+        (True, 'sigmoid'),
+        (False, 'linear'),
+        (False, 'Emax'),
+        (False, 'sigmoid'),
+    ],
+)
+def test_indirect_effect(load_model_for_test, testdata, prod, expr):
+    model = load_model_for_test(testdata / "nonmem" / "pheno_pd.mod")
+    model = add_indirect_effect(
+        model,
+        prod=prod,
+        expr=expr,
+    )

--- a/tests/tools/test_mfl.py
+++ b/tests/tools/test_mfl.py
@@ -347,11 +347,11 @@ def test_all_funcs(load_model_for_test, pheno_path, source, expected):
         (
             'COVARIATE(@PD, @CONTINUOUS, *);' 'COVARIATE(@PD, @CATEGORICAL, CAT, *)',
             (
-                ('COVARIATE', 'E0', 'APGR', 'cat', '*'),
-                ('COVARIATE', 'E0', 'WGT', 'exp', '*'),
-                ('COVARIATE', 'E0', 'WGT', 'lin', '*'),
-                ('COVARIATE', 'E0', 'WGT', 'pow', '*'),
-                ('COVARIATE', 'E0', 'WGT', 'piece_lin', '*'),
+                ('COVARIATE', 'B', 'APGR', 'cat', '*'),
+                ('COVARIATE', 'B', 'WGT', 'exp', '*'),
+                ('COVARIATE', 'B', 'WGT', 'lin', '*'),
+                ('COVARIATE', 'B', 'WGT', 'pow', '*'),
+                ('COVARIATE', 'B', 'WGT', 'piece_lin', '*'),
                 ('COVARIATE', 'SLOPE', 'APGR', 'cat', '*'),
                 ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*'),
                 ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*'),

--- a/tests/tools/test_structsearch.py
+++ b/tests/tools/test_structsearch.py
@@ -71,35 +71,28 @@ def test_create_remaining_models(load_example_model_for_test):
 def test_pkpd(load_model_for_test, testdata):
     res = read_modelfit_results(testdata / "nonmem" / "pheno.mod")
     ests = res.parameter_estimates
-    e0_init = pd.Series({'POP_E0': 5.75, 'IIV_E0': 0.01, 'sigma': 0.33})
+    e0_init = pd.Series({'POP_B': 5.75, 'IIV_B': 0.01, 'sigma': 0.33})
     model = load_model_for_test(testdata / "nonmem" / "pheno_pd.mod")
-    pkpd_models = create_pkpd_models(model, e0_init, ests)
+    pkpd_models = create_pkpd_models(
+        model, e0_init, ests, emax_init=2.0, ec50_init=1.0, mat_init=0.5
+    )
 
-    assert len(pkpd_models) == 8
+    assert len(pkpd_models) == 12
     assert pkpd_models[0].name == "structsearch_run1"
     assert pkpd_models[1].name == "structsearch_run2"
-    assert pkpd_models[4].name == "structsearch_run5"
-    assert pkpd_models[5].name == "structsearch_run6"
-    assert pkpd_models[0].parameters[0].name == 'TVCL'
-    assert pkpd_models[5].parameters[0].name == 'TVCL'
-    assert pkpd_models[0].parameters[1].name == 'TVV'
-    assert pkpd_models[5].parameters[1].name == 'TVV'
+    assert pkpd_models[1].parameters['POP_B'].init == 5.75
+    assert pkpd_models[1].parameters['POP_E_MAX'].init == 2.0
+    assert pkpd_models[1].parameters['POP_E_MAX'].fix is False
+    assert pkpd_models[1].parameters['POP_EC_50'].init == 1.0
+    assert pkpd_models[1].parameters['POP_EC_50'].fix is False
+    assert pkpd_models[3].parameters['POP_KE0'].init == 1 / 0.5
+    assert pkpd_models[6].parameters['POP_K_OUT'].init == 1 / 0.5
 
-    models2 = create_pkpd_models(model, e0_init, ests, emax_init=2.0, ec50_init=1.0)
-    param_emax = models2[1].parameters['POP_E_MAX']
-    param_ec50 = models2[1].parameters['POP_EC_50']
-    assert param_emax.init == 2.0
-    assert param_emax.fix is False
-    assert param_ec50.init == 1.0
-    assert param_ec50.fix is False
-
-    models3 = create_pkpd_models(model, e0_init, ests)
-    param_emax = models3[1].parameters['POP_E_MAX']
-    param_ec50 = models3[1].parameters['POP_EC_50']
-    assert param_emax.init == 0.1
-    assert param_emax.fix is False
-    assert param_ec50.init == 0.1
-    assert param_ec50.fix is False
+    models3 = create_pkpd_models(model)
+    assert models3[1].parameters['POP_E_MAX'].init == 0.1
+    assert models3[1].parameters['POP_E_MAX'].fix is False
+    assert models3[1].parameters['POP_EC_50'].init == 0.1
+    assert models3[1].parameters['POP_EC_50'].fix is False
 
 
 def test_create_workflow():


### PR DESCRIPTION
Changes made in this PR:

- add indirect effect/turnover models
- Parameter name change: E_0 → B (baseline)
- Remove step effect from pkpd model scope
- lower bound for Emax = -1
- Emax = theta * eta (proportional iiv)
- Initial estimate for slope = Emax/EC50
- Emax, EC50, baseline and MET inits = user input