### PR TITLE
Adapt iivsearch fullblock for pd models

### DIFF
--- a/src/pharmpy/modeling/__init__.py
+++ b/src/pharmpy/modeling/__init__.py
@@ -167,6 +167,7 @@ from .parameter_sampling import (
 from .parameter_variability import (
     add_iiv,
     add_iov,
+    add_pd_iiv,
     add_pk_iiv,
     create_joint_distribution,
     remove_iiv,
@@ -230,6 +231,7 @@ __all__ = [
     'add_metabolite',
     'add_peripheral_compartment',
     'add_pk_iiv',
+    'add_pd_iiv',
     'add_population_parameter',
     'add_time_after_dose',
     'append_estimation_step_options',

--- a/src/pharmpy/modeling/expressions.py
+++ b/src/pharmpy/modeling/expressions.py
@@ -1265,7 +1265,7 @@ def get_pd_parameters(model: Model) -> List[str]:
 
     """
     # FIXME: this function needs to be updated. Currently uses fixed parameter names.
-    pd_symbols = ['B', 'SLOPE', 'E_MAX', 'EC_50', 'N', 'sigma', 'K_OUT', 'K_IN', 'KE0']
+    pd_symbols = ['B', 'SLOPE', 'E_MAX', 'EC_50', 'N', 'K_OUT', 'KE0']
     return sorted(
         [param for param in pd_symbols if sympy.Symbol(param) in model.statements.free_symbols]
     )

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -39,10 +39,10 @@ def run_amd(
     cl_init: float = 0.01,
     vc_init: float = 1.0,
     mat_init: float = 0.1,
-    b_init: Optional[float] = None,
-    emax_init: Optional[float] = None,
-    ec50_init: Optional[float] = None,
-    met_init: Optional[float] = None,
+    b_init: Optional[Union[int, float]] = None,
+    emax_init: Optional[Union[int, float]] = None,
+    ec50_init: Optional[Union[int, float]] = None,
+    met_init: Optional[Union[int, float]] = None,
     search_space: Optional[str] = None,
     lloq_method: Optional[str] = None,
     lloq_limit: Optional[str] = None,
@@ -125,8 +125,10 @@ def run_amd(
 
     if modeltype == 'pkpd':
         dv = 2
+        iiv_strategy = 'pd_fullblock'
     else:
         dv = None
+        iiv_strategy = 'fullblock'
 
     if type(input) is str:
         from pharmpy.modeling import create_basic_pk_model
@@ -230,7 +232,7 @@ def run_amd(
                 func = _subfunc_modelsearch(search_space=modelsearch_features, path=db.path)
                 run_subfuncs['modelsearch'] = func
         elif section == 'iivsearch':
-            func = _subfunc_iiv(path=db.path)
+            func = _subfunc_iiv(iiv_strategy=iiv_strategy, path=db.path)
             run_subfuncs['iivsearch'] = func
         elif section == 'iovsearch':
             func = _subfunc_iov(amd_start_model=model, occasion=occasion, path=db.path)
@@ -392,12 +394,12 @@ def _subfunc_structsearch(
     return _run_structsearch
 
 
-def _subfunc_iiv(path) -> SubFunc:
+def _subfunc_iiv(iiv_strategy, path) -> SubFunc:
     def _run_iiv(model):
         res = run_tool(
             'iivsearch',
             'brute_force',
-            iiv_strategy='fullblock',
+            iiv_strategy=iiv_strategy,
             model=model,
             path=path / 'iivsearch',
         )

--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -45,11 +45,11 @@ def create_baseline_pd_model(model: Model, ests: pd.Series, b_init: Optional[flo
 
 def create_pkpd_models(
     model: Model,
-    b_init: Optional[float] = None,
+    b_init: Optional[Union[int, float]] = None,
     ests: pd.Series = None,
-    emax_init: Optional[float] = None,
-    ec50_init: Optional[float] = None,
-    mat_init: Optional[float] = None,
+    emax_init: Optional[Union[int, float]] = None,
+    ec50_init: Optional[Union[int, float]] = None,
+    mat_init: Optional[Union[int, float]] = None,
     response_type: Union[str, List] = 'all',
 ):
     """Create pkpd models
@@ -76,7 +76,6 @@ def create_pkpd_models(
     List of pharmpy models
     """
 
-    print(response_type)
     if response_type == 'all':
         models_list = ['direct', 'effect_compartment', 'indirect']
     elif isinstance(response_type, str):

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Union
 
 from pharmpy.deps import numpy as np
 from pharmpy.deps import pandas as pd
@@ -24,10 +24,10 @@ TYPES = frozenset(('tmdd', 'pkpd'))
 def create_workflow(
     route: str,
     type: str,
-    b_init: Optional[float] = None,
-    emax_init: Optional[float] = None,
-    ec50_init: Optional[float] = None,
-    met_init: Optional[float] = None,
+    b_init: Optional[Union[int, float]] = None,
+    emax_init: Optional[Union[int, float]] = None,
+    ec50_init: Optional[Union[int, float]] = None,
+    met_init: Optional[Union[int, float]] = None,
     results: Optional[ModelfitResults] = None,
     model: Optional[Model] = None,
 ):

--- a/tests/modeling/test_expressions.py
+++ b/tests/modeling/test_expressions.py
@@ -379,12 +379,12 @@ def test_get_pd_parameters(load_model_for_test, testdata, model_path, kind, expe
 @pytest.mark.parametrize(
     ('model_path', 'kind', 'prod', 'expected'),
     (
-        ('nonmem/pheno.mod', 'linear', True, ['B', 'SLOPE', 'K_IN', 'K_OUT']),
-        ('nonmem/pheno.mod', 'linear', False, ['B', 'SLOPE', 'K_IN', 'K_OUT']),
-        ('nonmem/pheno.mod', 'Emax', True, ['B', 'E_MAX', 'EC_50', 'K_IN', 'K_OUT']),
-        ('nonmem/pheno.mod', 'Emax', False, ['B', 'E_MAX', 'EC_50', 'K_IN', 'K_OUT']),
-        ('nonmem/pheno.mod', 'sigmoid', True, ['B', 'EC_50', 'E_MAX', 'N', 'K_IN', 'K_OUT']),
-        ('nonmem/pheno.mod', 'sigmoid', False, ['B', 'EC_50', 'E_MAX', 'N', 'K_IN', 'K_OUT']),
+        ('nonmem/pheno.mod', 'linear', True, ['B', 'SLOPE', 'K_OUT']),
+        ('nonmem/pheno.mod', 'linear', False, ['B', 'SLOPE', 'K_OUT']),
+        ('nonmem/pheno.mod', 'Emax', True, ['B', 'E_MAX', 'EC_50', 'K_OUT']),
+        ('nonmem/pheno.mod', 'Emax', False, ['B', 'E_MAX', 'EC_50', 'K_OUT']),
+        ('nonmem/pheno.mod', 'sigmoid', True, ['B', 'EC_50', 'E_MAX', 'N', 'K_OUT']),
+        ('nonmem/pheno.mod', 'sigmoid', False, ['B', 'EC_50', 'E_MAX', 'N', 'K_OUT']),
     ),
     ids=repr,
 )


### PR DESCRIPTION
Changes made in this PR:

- iivsearch: 
  - add iiv_strategies `pd_add_diagonal` and `pd_fullblock`. They perform the same operations as `add_diagonal` and `fullblock` but only add iivs to pd parameters
  - Add function `add_pd_iiv` to parameter_variability.py. This functions adds iiv to all pd parameters that do not already have iiv

- amd tool
  - iivstrategy is `pd_fullblock` if `modeltype == pkpd`

- simplified `get_pd_parameters` because the function could not handle more complex functions such as indirect effect models. Now the parameters are hard coded. This needs to be updated later.

- Allow integer initial estimates for pkpd models. Previously they had to be floats.