### PR TITLE
Add iiv proportional

### DIFF
--- a/src/pharmpy/modeling/parameter_variability.py
+++ b/src/pharmpy/modeling/parameter_variability.py
@@ -40,18 +40,31 @@ def add_iiv(
     initial_estimate: float = 0.09,
     eta_names: Optional[List[str]] = None,
 ):
-    """Adds IIVs to :class:`pharmpy.model`.
+    r"""Adds IIVs to :class:`pharmpy.model`.
 
     Effects that currently have templates are:
 
     - Additive (*add*)
     - Proportional (*prop*)
+    - Proportional Additive (*prop_add*)
     - Exponential (*exp*)
     - Logit (*log*)
     - Rescaled logit (*re_log*)
 
     For all except exponential the operation input is not needed. Otherwise user specified
     input is supported. Initial estimates for new etas are 0.09.
+
+
+
+    Assuming a statement :math:`CL = \Theta`, IIVs are added in the following ways:
+
+    - Additive: :math:`CL = \Theta + \eta`
+    - Proportional: :math:`CL = \Theta \cdot \eta`
+    - Proportional Additive: :math:`CL = \cdot (1 + \eta)`
+    - Exponential: :math:`CL = \Theta +/\cdot e^{\eta}`
+    - Logit: :math:`CL = \Theta \cdot e^{\eta}/ (e^{\eta} + 1)`
+    - Rescaled logit: :math:`CL = e^{\Phi \cdot \eta}/(1+e^{\Phi \cdot \eta})`
+      with :math:`\Phi = log(\Theta/(1-\Theta))`
 
     Parameters
     ----------
@@ -517,6 +530,8 @@ def _create_template(expression, operation):
         return EtaAddition.logit()
     elif expression == 're_log':
         return EtaAddition.re_logit()
+    elif expression == 'prop_add':
+        return EtaAddition.prop_add()
     else:
         expression = parse_expr(f'original {operation} {expression}')
         return EtaAddition(expression)
@@ -583,6 +598,12 @@ class EtaAddition:
     @classmethod
     def proportional(cls):
         template = sympy.Symbol('original') * sympy.Symbol('eta_new')
+
+        return cls(template)
+
+    @classmethod
+    def prop_add(cls):
+        template = sympy.Symbol('original') * (1 + sympy.Symbol('eta_new'))
 
         return cls(template)
 

--- a/src/pharmpy/modeling/parameter_variability.py
+++ b/src/pharmpy/modeling/parameter_variability.py
@@ -60,7 +60,7 @@ def add_iiv(
 
     - Additive: :math:`CL = \Theta + \eta`
     - Proportional: :math:`CL = \Theta \cdot \eta`
-    - Proportional Additive: :math:`CL = \cdot (1 + \eta)`
+    - Proportional Additive: :math:`CL = \Theta \cdot (1 + \eta)`
     - Exponential: :math:`CL = \Theta +/\cdot e^{\eta}`
     - Logit: :math:`CL = \Theta \cdot e^{\eta}/ (e^{\eta} + 1)`
     - Rescaled logit: :math:`CL = e^{\Phi \cdot \eta}/(1+e^{\Phi \cdot \eta})`

--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -125,13 +125,13 @@ def create_pkpd_models(
             pkpd_model = set_lower_bounds(pkpd_model, {'POP_E_MAX': -1})
 
             # set iiv
-            for parameter in ["B", "SLOPE"]:
+            for parameter in ["E_MAX", "SLOPE"]:
                 try:
-                    pkpd_model = add_iiv(pkpd_model, [parameter], "exp")
+                    pkpd_model = add_iiv(pkpd_model, [parameter], "prop_add")
                 except ValueError:
                     pass
             try:
-                pkpd_model = add_iiv(pkpd_model, ['E_MAX'], "prop")
+                pkpd_model = add_iiv(pkpd_model, 'B', "exp")
             except ValueError:
                 pass
 

--- a/tests/modeling/test_parameter_variability.py
+++ b/tests/modeling/test_parameter_variability.py
@@ -792,43 +792,30 @@ def test_remove_iiv(load_model_for_test, testdata, etas, pk_ref, omega_ref):
     assert rec_omega == omega_ref
 
 
-def test_remove_iiv2(load_model_for_test, testdata):
+@pytest.mark.parametrize(
+    'iiv_type, operation',
+    [
+        ('add', '*'),
+        ('prop', '*'),
+        ('log', '*'),
+        ('exp', '*'),
+        ('exp', '+'),
+        ('prop_add', '*'),
+    ],
+)
+def test_remove_iiv2(load_model_for_test, testdata, iiv_type, operation):
     model = load_model_for_test(testdata / 'nonmem/pheno_real.mod')
-    model = add_individual_parameter(model, 'A')
-    model = add_iiv(model, 'A', 'add')
-    model = add_individual_parameter(model, 'B')
-    model = add_iiv(model, 'B', 'prop')
-    model = add_individual_parameter(model, 'C')
-    model = add_iiv(model, 'C', 'log')
-    model = add_individual_parameter(model, 'D')
-    model = add_iiv(model, 'D', 'exp')
-    model = add_individual_parameter(model, 'E')
-    model = add_iiv(model, 'E', 'exp', '+')
-    model = add_iiv(model, "TVCL", "add")
 
+    model = add_individual_parameter(model, 'A')
+    without_iiv = model.statements.find_assignment('A')
+    model = add_iiv(model, 'A', iiv_type, operation)
     model = remove_iiv(model, 'A')
-    assert model.statements.find_assignment('A') == Assignment(
-        sympy.Symbol('A'), sympy.Symbol('POP_A')
-    )
-    model = remove_iiv(model, 'B')
-    assert model.statements.find_assignment('B') == Assignment(
-        sympy.Symbol('B'), sympy.Symbol('POP_B')
-    )
-    model = remove_iiv(model, 'C')
-    assert model.statements.find_assignment('C') == Assignment(
-        sympy.Symbol('C'), sympy.Symbol('POP_C')
-    )
+    assert model.statements.find_assignment('A') == without_iiv
+
+    model = add_iiv(model, "TVCL", "add")
     model = remove_iiv(model, 'TVCL')
     assert model.statements.find_assignment('TVCL') == Assignment(
         sympy.Symbol('TVCL'), sympy.Symbol('PTVCL') * sympy.Symbol('WGT')
-    )
-    model = remove_iiv(model, 'D')
-    assert model.statements.find_assignment('D') == Assignment(
-        sympy.Symbol('D'), sympy.Symbol('POP_D')
-    )
-    model = remove_iiv(model, 'E')
-    assert model.statements.find_assignment('E') == Assignment(
-        sympy.Symbol('E'), sympy.Symbol('POP_E')
     )
 
     # Test with two different ETAs


### PR DESCRIPTION
- A new iiv type was added to `add_iiv`, called `prop_add`.
- Documentation for `add_iiv` was updated with mathematical equations showing how IIVs are added.
- In pkpd models the parameters E_MAX and SLOPE have now iiv type `prop_add`