### PR TITLE
ModelFeatures class and rework of modelsearch for rerunning

### DIFF
--- a/src/pharmpy/modeling/common.py
+++ b/src/pharmpy/modeling/common.py
@@ -649,3 +649,88 @@ def rename_symbols(
     )
     return model.update_source()
     # FIXME: Only handles parameters, statements and random_variables and no clashes and circular renaming
+
+
+def get_model_attributes(model: Model, supress_warnings=False) -> str:
+    # FIXME : Circular import. Do we want to have this function elsewhere?
+    from .odes import (
+        has_bolus_absorption,
+        has_first_order_absorption,
+        has_first_order_elimination,
+        has_lag_time,
+        has_michaelis_menten_elimination,
+        has_mixed_mm_fo_elimination,
+        has_seq_zo_fo_absorption,
+        has_zero_order_absorption,
+        has_zero_order_elimination,
+        number_of_peripheral_compartments,
+        number_of_transit_compartments,
+    )
+
+    # ABSORPTION
+    absorption = None
+    if has_seq_zo_fo_absorption(model):
+        absorption = "SEQ-ZO-FO"
+    elif has_zero_order_absorption(model):
+        absorption = "ZO"
+    elif has_first_order_absorption(model):
+        absorption = "FO"
+    elif has_bolus_absorption(model):
+        absorption = "INST"
+
+    if not supress_warnings:
+        if absorption is None:
+            warnings.warn("Could not determine absorption of model.")
+
+    # ElIMINATION
+    elimination = None
+    if has_mixed_mm_fo_elimination(model):
+        elimination = "MIX_FO_MM"
+    elif has_zero_order_elimination(model):
+        elimination = "ZO"
+    elif has_first_order_elimination(model):
+        elimination = "FO"
+    elif has_michaelis_menten_elimination(model):
+        elimination = "MM"
+
+    if not supress_warnings:
+        if elimination is None:
+            warnings.warn("Could not determine elimination of model.")
+
+    # ABSORPTION DELAY (TRANSIT AND LAGTIME)
+    # TRANSITS
+    transits = number_of_transit_compartments(model)
+
+    # TODO : DEPOT
+    if not model.statements.ode_system.find_depot(model.statements):
+        depot = "NODEPOT"
+    else:
+        depot = "DEPOT"
+
+    lagtime = has_lag_time(model)
+    if not lagtime:
+        lagtime = None
+
+    # DISTRIBUTION (PERIPHERALS)
+    peripherals = number_of_peripheral_compartments(model)
+
+    if absorption:
+        absorption = f'ABSORPTION({absorption})'
+    if elimination:
+        elimination = f'ELIMINATION({elimination})'
+    if lagtime:
+        lagtime = "LAGTIME()"
+    if transits != 0:
+        transits = f'TRANSITS({transits}{","+depot})'
+    if peripherals != 0:
+        peripherals = f'PERIPHERALS({peripherals})'
+
+    # TODO : Implement more features such as covariates and IIV
+
+    return ";".join(
+        [
+            e
+            for e in [absorption, elimination, lagtime, transits, peripherals]
+            if (e is not None and e != 0)
+        ]
+    )

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -178,7 +178,7 @@ def run_amd(
             modelsearch_features = (
                 Absorption((Name('ZO'), Name('SEQ-ZO-FO'))),
                 Elimination((Name('MM'), Name('MIX-FO-MM'))),
-                LagTime(),
+                LagTime((Name('ON'),)),
                 Transits((1, 3, 10), Wildcard()),
                 Peripherals((1,)),
             )
@@ -186,7 +186,7 @@ def run_amd(
             modelsearch_features = (
                 Absorption((Name('ZO'), Name('SEQ-ZO-FO'))),
                 Elimination((Name('MM'), Name('MIX-FO-MM'))),
-                LagTime(),
+                LagTime((Name('ON'),)),
                 Transits((1, 3, 10), Wildcard()),
                 Peripherals((1, 2)),
             )

--- a/src/pharmpy/tools/common.py
+++ b/src/pharmpy/tools/common.py
@@ -85,7 +85,11 @@ def create_results(
     if base_model.name != input_model.name:
         models = [base_model] + res_models
     else:
-        models = res_models
+        # Check if any resulting models exist
+        if res_models:
+            models = res_models
+        else:
+            models = None
 
     # FIXME: Remove best_model, input_model, models when there is function to read db
     res = res_class(

--- a/src/pharmpy/tools/mfl/feature/absorption.py
+++ b/src/pharmpy/tools/mfl/feature/absorption.py
@@ -2,6 +2,7 @@ from typing import Iterable
 
 from pharmpy.model import Model
 from pharmpy.modeling import (
+    set_bolus_absorption,
     set_first_order_absorption,
     set_seq_zo_fo_absorption,
     set_zero_order_absorption,
@@ -17,7 +18,7 @@ def features(model: Model, statements: Iterable[Statement]) -> Iterable[Feature]
     for statement in statements:
         if isinstance(statement, Absorption):
             modes = (
-                [Name('FO'), Name('ZO'), Name('SEQ-ZO-FO')]
+                [Name('FO'), Name('ZO'), Name('SEQ-ZO-FO'), Name('INST')]
                 if isinstance(statement.modes, Wildcard)
                 else statement.modes
             )
@@ -28,5 +29,7 @@ def features(model: Model, statements: Iterable[Statement]) -> Iterable[Feature]
                     yield ('ABSORPTION', mode.name), set_zero_order_absorption
                 elif mode.name == 'SEQ-ZO-FO':
                     yield ('ABSORPTION', mode.name), set_seq_zo_fo_absorption
+                elif mode.name == "INST":
+                    yield ('ABSORPTION', mode.name), set_bolus_absorption
                 else:
                     raise ValueError(f'Absorption {mode} not supported')

--- a/src/pharmpy/tools/mfl/feature/absorption.py
+++ b/src/pharmpy/tools/mfl/feature/absorption.py
@@ -9,7 +9,7 @@ from pharmpy.modeling import (
 )
 
 from ..statement.feature.absorption import Absorption
-from ..statement.feature.symbols import Name, Wildcard
+from ..statement.feature.symbols import Wildcard
 from ..statement.statement import Statement
 from .feature import Feature
 
@@ -18,9 +18,7 @@ def features(model: Model, statements: Iterable[Statement]) -> Iterable[Feature]
     for statement in statements:
         if isinstance(statement, Absorption):
             modes = (
-                [Name('FO'), Name('ZO'), Name('SEQ-ZO-FO'), Name('INST')]
-                if isinstance(statement.modes, Wildcard)
-                else statement.modes
+                statement._wildcard if isinstance(statement.modes, Wildcard) else statement.modes
             )
             for mode in modes:
                 if mode.name == 'FO':

--- a/src/pharmpy/tools/mfl/feature/elimination.py
+++ b/src/pharmpy/tools/mfl/feature/elimination.py
@@ -9,7 +9,7 @@ from pharmpy.modeling import (
 )
 
 from ..statement.feature.elimination import Elimination
-from ..statement.feature.symbols import Name, Wildcard
+from ..statement.feature.symbols import Wildcard
 from ..statement.statement import Statement
 from .feature import Feature
 
@@ -18,9 +18,7 @@ def features(model: Model, statements: Iterable[Statement]) -> Iterable[Feature]
     for statement in statements:
         if isinstance(statement, Elimination):
             modes = (
-                [Name('FO'), Name('ZO'), Name('MM'), Name('MIX-FO-MM')]
-                if isinstance(statement.modes, Wildcard)
-                else statement.modes
+                statement._wildcard if isinstance(statement.modes, Wildcard) else statement.modes
             )
             for mode in modes:
                 if mode.name == 'FO':

--- a/src/pharmpy/tools/mfl/feature/lagtime.py
+++ b/src/pharmpy/tools/mfl/feature/lagtime.py
@@ -4,7 +4,7 @@ from pharmpy.model import Model
 from pharmpy.modeling import add_lag_time, remove_lag_time
 
 from ..statement.feature.lagtime import LagTime
-from ..statement.feature.symbols import Name, Wildcard
+from ..statement.feature.symbols import Wildcard
 from ..statement.statement import Statement
 from .feature import Feature
 
@@ -13,9 +13,7 @@ def features(model: Model, statements: Iterable[Statement]) -> Iterable[Feature]
     for statement in statements:
         if isinstance(statement, LagTime):
             modes = (
-                [Name('ON'), Name('OFF')]
-                if isinstance(statement.modes, Wildcard)
-                else statement.modes
+                statement._wildcard if isinstance(statement.modes, Wildcard) else statement.modes
             )
             for mode in modes:
                 if mode.name == "ON":

--- a/src/pharmpy/tools/mfl/feature/lagtime.py
+++ b/src/pharmpy/tools/mfl/feature/lagtime.py
@@ -1,9 +1,10 @@
 from typing import Iterable
 
 from pharmpy.model import Model
-from pharmpy.modeling import add_lag_time
+from pharmpy.modeling import add_lag_time, remove_lag_time
 
 from ..statement.feature.lagtime import LagTime
+from ..statement.feature.symbols import Name, Wildcard
 from ..statement.statement import Statement
 from .feature import Feature
 
@@ -11,4 +12,15 @@ from .feature import Feature
 def features(model: Model, statements: Iterable[Statement]) -> Iterable[Feature]:
     for statement in statements:
         if isinstance(statement, LagTime):
-            yield ('LAGTIME',), add_lag_time
+            modes = (
+                [Name('ON'), Name('OFF')]
+                if isinstance(statement.modes, Wildcard)
+                else statement.modes
+            )
+            for mode in modes:
+                if mode.name == "ON":
+                    yield ('LAGTIME', mode.name), add_lag_time
+                elif mode.name == "OFF":
+                    yield ('LAGTIME', mode.name), remove_lag_time
+                else:
+                    raise ValueError(f'Lagtime {mode} not supported')

--- a/src/pharmpy/tools/mfl/feature/transits.py
+++ b/src/pharmpy/tools/mfl/feature/transits.py
@@ -5,7 +5,7 @@ from typing import Iterable
 from pharmpy.model import Model
 from pharmpy.modeling import set_transit_compartments
 
-from ..statement.feature.symbols import Name, Wildcard
+from ..statement.feature.symbols import Wildcard
 from ..statement.feature.transits import Transits
 from ..statement.statement import Statement
 from .feature import Feature
@@ -15,9 +15,7 @@ def features(model: Model, statements: Iterable[Statement]) -> Iterable[Feature]
     for statement in statements:
         if isinstance(statement, Transits):
             depots = (
-                [Name('DEPOT'), Name('NODEPOT')]
-                if isinstance(statement.depot, Wildcard)
-                else statement.depot
+                statement._wildcard if isinstance(statement.depot, Wildcard) else statement.depot
             )
             for count, depot in product(statement.counts, depots):
                 if depot.name == 'DEPOT':

--- a/src/pharmpy/tools/mfl/feature/transits.py
+++ b/src/pharmpy/tools/mfl/feature/transits.py
@@ -17,7 +17,7 @@ def features(model: Model, statements: Iterable[Statement]) -> Iterable[Feature]
             depots = (
                 [Name('DEPOT'), Name('NODEPOT')]
                 if isinstance(statement.depot, Wildcard)
-                else [statement.depot]
+                else statement.depot
             )
             for count, depot in product(statement.counts, depots):
                 if depot.name == 'DEPOT':

--- a/src/pharmpy/tools/mfl/grammar.py
+++ b/src/pharmpy/tools/mfl/grammar.py
@@ -37,7 +37,7 @@ covariate: "COVARIATE"i "(" parameter_option "," covariate_option "," fp_option 
 _absorption_option: absorption_modes | absorption_wildcard
 absorption_modes: ABSORPTION_MODE | "[" [ABSORPTION_MODE ("," ABSORPTION_MODE)*] "]"
 absorption_wildcard: WILDCARD
-ABSORPTION_MODE: "FO"i | "ZO"i | "SEQ-ZO-FO"i
+ABSORPTION_MODE: "FO"i | "ZO"i | "SEQ-ZO-FO"i | "INST"i
 _elimination_option: elimination_modes | elimination_wildcard
 elimination_modes: ELIMINATION_MODE | "[" [ELIMINATION_MODE ("," ELIMINATION_MODE)*] "]"
 elimination_wildcard: WILDCARD

--- a/src/pharmpy/tools/mfl/grammar.py
+++ b/src/pharmpy/tools/mfl/grammar.py
@@ -31,7 +31,7 @@ absorption: "ABSORPTION"i "(" (_absorption_option) ")"
 elimination: "ELIMINATION"i "(" (_elimination_option) ")"
 peripherals: "PERIPHERALS"i "(" (_counts) ")"
 transits: "TRANSITS"i "(" _counts ["," depot_option] ")"
-lagtime: "LAGTIME"i "(" ")"
+lagtime: "LAGTIME"i "(" (_lagtime_option) ")"
 covariate: "COVARIATE"i "(" parameter_option "," covariate_option "," fp_option ["," op_option] ")"
 
 _absorption_option: absorption_modes | absorption_wildcard
@@ -45,6 +45,10 @@ ELIMINATION_MODE: "FO"i | "ZO"i | "MM"i | "MIX-FO-MM"i
 depot_option: DEPOT | NODEPOT | WILDCARD
 DEPOT: "DEPOT"i
 NODEPOT: "NODEPOT"i
+_lagtime_option: lagtime_modes | lagtime_wildcard
+lagtime_modes: LAGTIME_MODE | "[" [LAGTIME_MODE ("," LAGTIME_MODE)*] "]"
+lagtime_wildcard: WILDCARD
+LAGTIME_MODE: "ON"i | "OFF"i
 parameter_option: values | ref | parameter_wildcard
 covariate_option: values | ref | covariate_wildcard
 fp_option: values | fp_wildcard

--- a/src/pharmpy/tools/mfl/grammar.py
+++ b/src/pharmpy/tools/mfl/grammar.py
@@ -30,7 +30,7 @@ _feature: absorption | elimination | peripherals | transits | lagtime | covariat
 absorption: "ABSORPTION"i "(" (_absorption_option) ")"
 elimination: "ELIMINATION"i "(" (_elimination_option) ")"
 peripherals: "PERIPHERALS"i "(" (_counts) ")"
-transits: "TRANSITS"i "(" _counts ["," depot_option] ")"
+transits: "TRANSITS"i "(" _counts ["," _depot_option] ")"
 lagtime: "LAGTIME"i "(" (_lagtime_option) ")"
 covariate: "COVARIATE"i "(" parameter_option "," covariate_option "," fp_option ["," op_option] ")"
 
@@ -42,9 +42,10 @@ _elimination_option: elimination_modes | elimination_wildcard
 elimination_modes: ELIMINATION_MODE | "[" [ELIMINATION_MODE ("," ELIMINATION_MODE)*] "]"
 elimination_wildcard: WILDCARD
 ELIMINATION_MODE: "FO"i | "ZO"i | "MM"i | "MIX-FO-MM"i
-depot_option: DEPOT | NODEPOT | WILDCARD
-DEPOT: "DEPOT"i
-NODEPOT: "NODEPOT"i
+_depot_option: depot_modes | depot_wildcard
+depot_modes: DEPOT_MODE | "[" [DEPOT_MODE ("," DEPOT_MODE)*] "]"
+DEPOT_MODE: "DEPOT"i |"NODEPOT"i
+depot_wildcard: WILDCARD
 _lagtime_option: lagtime_modes | lagtime_wildcard
 lagtime_modes: LAGTIME_MODE | "[" [LAGTIME_MODE ("," LAGTIME_MODE)*] "]"
 lagtime_wildcard: WILDCARD

--- a/src/pharmpy/tools/mfl/parse.py
+++ b/src/pharmpy/tools/mfl/parse.py
@@ -1,13 +1,24 @@
-from typing import List
+from typing import List, Optional
 
 from lark import Lark
 
+from pharmpy.model import Model
+from pharmpy.tools.mfl.statement.feature.absorption import Absorption
+from pharmpy.tools.mfl.statement.feature.covariate import Covariate
+from pharmpy.tools.mfl.statement.feature.elimination import Elimination
+from pharmpy.tools.mfl.statement.feature.lagtime import LagTime
+from pharmpy.tools.mfl.statement.feature.peripherals import Peripherals
+from pharmpy.tools.mfl.statement.feature.symbols import Name
+from pharmpy.tools.mfl.statement.feature.transits import Transits
+
 from .grammar import grammar
+from .helpers import funcs, modelsearch_features
 from .interpreter import MFLInterpreter
 from .statement.statement import Statement
+from .stringify import stringify as mfl_stringify
 
 
-def parse(code: str) -> List[Statement]:
+def parse(code: str, mfl_class=False) -> List[Statement]:
     parser = Lark(
         grammar,
         start='start',
@@ -22,4 +33,389 @@ def parse(code: str) -> List[Statement]:
 
     tree = parser.parse(code)
 
-    return MFLInterpreter().interpret(tree)
+    # TODO : only return class once it has been implemented everywhere
+    if mfl_class:
+        return ModelFeatures.create_from_mfl_statement_list(MFLInterpreter().interpret(tree))
+    else:
+        return MFLInterpreter().interpret(tree)
+
+
+class ModelFeatures:
+    def __init__(
+        self,
+        absorption=Absorption((Name('INST'),)),
+        elimination=Elimination((Name('FO'),)),
+        transits=(Transits((0,), (Name('DEPOT'),)),),  # NOTE : This is a tuple
+        peripherals=Peripherals((0,)),
+        lagtime=LagTime((Name('OFF'),)),
+        covariate=tuple(),  # TODO : Covariates (Should be represented by tuple similar to transits)
+    ):
+        self._absorption = absorption
+        self._elimination = elimination
+        self._transits = transits
+        self._peripherals = peripherals
+        self._lagtime = lagtime
+        self._covariate = covariate
+
+    @classmethod
+    def create(
+        cls,
+        absorption=Absorption((Name('INST'),)),
+        elimination=Elimination((Name('FO'),)),
+        transits=(Transits((0,), (Name('DEPOT'),)),),
+        peripherals=Peripherals((0,)),
+        lagtime=LagTime((Name('OFF'),)),
+        covariate=tuple(),  # TODO : Covariates
+    ):
+        # TODO : Check if allowed input value
+        if not isinstance(absorption, Absorption):
+            raise ValueError(f"Absorption : {absorption} is not suppoerted")
+
+        if not isinstance(elimination, Elimination):
+            raise ValueError(f"Elimination : {elimination} is not supported")
+
+        if not isinstance(transits, tuple):
+            raise ValueError("Transits need to be given within a tuple")
+            if not all(isinstance(t, Transits) for t in transits):
+                raise ValueError("All given elements of transits must be of type Transits")
+
+        if not isinstance(peripherals, Peripherals):
+            raise ValueError(f"Peripherals : {peripherals} is not supported")
+
+        if not isinstance(lagtime, LagTime):
+            raise ValueError(f"Lagtime : {lagtime} is not supported")
+
+        # TODO : Covariates
+
+        return cls(
+            absorption=absorption,
+            elimination=elimination,
+            transits=transits,
+            peripherals=peripherals,
+            lagtime=lagtime,
+            covariate=covariate,
+        )
+
+    @classmethod
+    def create_from_mfl_statement_list(cls, mfl_list):
+        m = ModelFeatures()
+        absorption = m._default_values()['absorption']
+        elimination = m._default_values()['elimination']
+        transits = m._default_values()['transits']
+        peripherals = m._default_values()['peripherals']
+        lagtime = m._default_values()['lagtime']
+        covariate = m._default_values()['covariate']
+        for statement in mfl_list:
+            if isinstance(statement, Absorption):
+                absorption = statement
+            elif isinstance(statement, Elimination):
+                elimination = statement
+            elif isinstance(statement, Transits):
+                transits = (statement,)
+            elif isinstance(statement, Peripherals):
+                peripherals = statement
+            elif isinstance(statement, LagTime):
+                lagtime = statement
+            elif isinstance(statement, Covariate):
+                covariate = statement
+            else:
+                raise ValueError(f'Unknown statement ({statement}) given.')
+        mfl = cls.create(
+            absorption=absorption,
+            elimination=elimination,
+            transits=transits,
+            peripherals=peripherals,
+            lagtime=lagtime,
+            covariate=covariate,
+        )
+        return mfl
+
+    @classmethod
+    def create_from_mfl_string(cls, mfl_string):
+        return parse(mfl_string, mfl_class=True)
+
+    def replace(self, **kwargs):
+        absorption = kwargs.get("absorption", self._absorption)
+        elimination = kwargs.get("elimination", self._elimination)
+        transits = kwargs.get("transits", self._transits)
+        peripherals = kwargs.get("peripherals", self._peripherals)
+        lagtime = kwargs.get("lagtime", self._lagtime)
+        covariate = kwargs.get("covariate", self._covariate)
+        return ModelFeatures.create(
+            absorption=absorption,
+            elimination=elimination,
+            transits=transits,
+            peripherals=peripherals,
+            lagtime=lagtime,
+            covariate=covariate,
+        )
+
+    def _default_values(self):
+        return {
+            'absorption': Absorption((Name('INST'),)),
+            'elimination': Elimination((Name('FO'),)),
+            'transits': (Transits((0,), (Name('DEPOT'),)),),
+            'peripherals': Peripherals((0,)),
+            'lagtime': LagTime((Name('OFF'),)),
+            'covariate': tuple(),
+        }
+
+    @property
+    def absorption(self):
+        return self._absorption
+
+    @property
+    def elimination(self):
+        return self._elimination
+
+    @property
+    def transits(self):
+        return self._transits
+
+    @property
+    def peripherals(self):
+        return self._peripherals
+
+    @property
+    def lagtime(self):
+        return self._lagtime
+
+    @property
+    def covariate(self):
+        return self._covariate
+
+    def mfl_statement_list(self, attribute_type: Optional[List[str]] = []):
+        """Add the repspective MFL attributes to a list"""
+
+        # NOTE : This function is needed to be able to convert the classes to functions
+
+        if not attribute_type:
+            attribute_type = [
+                "absorption",
+                "elimination",
+                "transits",
+                "peripherals",
+                "lagtime",
+                "covariate",
+            ]
+        mfl_list = []
+        if "absorption" in attribute_type:
+            mfl_list.append(self.absorption)
+        if "elimination" in attribute_type:
+            mfl_list.append(self.elimination)
+        if "transits" in attribute_type:
+            for t in self.transits:
+                mfl_list.append(t)
+        if "peripherals" in attribute_type:
+            mfl_list.append(self.peripherals)
+        if "lagtime" in attribute_type:
+            mfl_list.append(self.lagtime)
+        if "covariate" in attribute_type:
+            # TODO : COVARIATES
+            mfl_list.append(self.covariate)
+
+        return [m for m in mfl_list if m]
+
+    def convert_to_funcs(
+        self, attribute_type: Optional[List[str]] = None, model: Optional[Model] = None
+    ):
+        # The model argument is used for when extacting covariates.
+        if not model:
+            model = Model()
+        return funcs(model, self.mfl_statement_list(attribute_type), modelsearch_features)
+
+    def contain_subset(self, mfl):
+        transits = self._subset_transits(mfl)
+
+        if (
+            all([s in self.absorption.modes for s in mfl.absorption.eval.modes])
+            and all([s in self.elimination.modes for s in mfl.elimination.eval.modes])
+            and transits
+            and all([s in self.peripherals.counts for s in mfl.peripherals.counts])
+            and all([s in self.lagtime.modes for s in mfl.lagtime.eval.modes])
+            # TODO : COVARIATES --> Require model (optional argument?)
+        ):
+            return True
+        else:
+            return False
+
+    def _subset_transits(self, mfl):
+        lhs_counts = set([c for t in self.transits for c in t.counts])
+        lhs_depot = set([d for t in self.transits for d in t.eval.depot])
+
+        rhs_counts = set([c for t in mfl.transits for c in t.counts])
+        rhs_depot = set([d for t in mfl.transits for d in t.eval.depot])
+
+        return all([c in lhs_counts for c in rhs_counts]) and all(
+            [d in lhs_depot for d in rhs_depot]
+        )
+
+    def least_number_of_transformations(self, other):
+        """The smallest set of transformations to become part of other"""
+        lnt = {}
+        if not any(a in other.absorption.eval.modes for a in self.absorption.eval.modes):
+            name, func = list(other.convert_to_funcs(["absorption"]).items())[0]
+            lnt[name] = func
+
+        if not any(e in other.elimination.eval.modes for e in self.elimination.eval.modes):
+            name, func = list(other.convert_to_funcs(["elimination"]).items())[0]
+            lnt[name] = func
+
+        # FIXME : ! Currently not working
+        lnt = self._lnt_transits(other, lnt)
+
+        if not any(p in other.peripherals.counts for p in self.peripherals.counts):
+            name, func = list(other.convert_to_funcs(["peripherals"]).items())[0]
+            lnt[name] = func
+
+        if not any(lt in other.lagtime.eval.modes for lt in self.lagtime.eval.modes):
+            name, func = list(other.convert_to_funcs(["lagtime"]).items())[0]
+            lnt[name] = func
+
+        # TODO : Covariates
+
+        return lnt
+
+    def _lnt_transits(self, other, lnt):
+        lhs_depot = [d for t in self.transits for d in t.eval.depot]
+        rhs_depot = [d for t in other.transits for d in t.eval.depot]
+
+        if not any(td in rhs_depot for td in lhs_depot):
+            # DEPOT does not match -> Take first function regardless of counts
+            name, func = list(other.convert_to_funcs(["transits"]).items())[0]
+            lnt[name] = func
+        else:
+            # DEPOT does match -> Need to check counts for corresponding depot
+            # First check counts of all matching depots
+            for depot in lhs_depot:
+                if depot in rhs_depot:
+                    depot_counts = [
+                        c for t in self.transits for c in t.counts if depot in t.eval.depot
+                    ]
+                    rhs_depot_counts = [
+                        c for t in other.transits for c in t.counts if depot in t.eval.depot
+                    ]
+                    diff = [c for c in rhs_depot_counts if c not in depot_counts]
+                    match = [c for c in rhs_depot_counts if c in depot_counts]
+
+                    if len(match) != 0:
+                        return lnt
+                    # There is a difference in set of counts for the same depot argument
+                    if len(diff) != 0:
+                        func_dict = other.convert_to_funcs(["transits"])
+                        lnt[('TRANSITS', diff[0], depot.name)] = func_dict[
+                            ('TRANSITS', diff[0], depot.name)
+                        ]
+                        break
+
+            # else take first count value of non matching depot
+            depot = next(d for d in rhs_depot if d not in lhs_depot)
+            count = next(c for t in other.transits for c in t.counts if depot in t.eval.depot)
+            func_dict = other.convert_to_funcs(["transits"])
+            lnt[('TRANSITS', count, depot.name)] = func_dict[('TRANSITS', diff[0], depot.name)]
+
+        return lnt
+
+    def __repr__(self):
+        # TODO : Remove default values
+        return mfl_stringify(self.mfl_statement_list())
+
+    def __sub__(self, other):
+        transits = self._add_sub_transits(other, add=False)
+
+        return ModelFeatures.create(
+            absorption=self.absorption - other.absorption,
+            elimination=self.elimination - other.elimination,
+            transits=transits,
+            peripherals=self.peripherals - other.peripherals,
+            lagtime=self.lagtime - other.lagtime,
+            # TODO : Covariate
+        )
+
+    def __add__(self, other):
+        transits = self._add_sub_transits(other, add=True)
+
+        return ModelFeatures.create(
+            absorption=self.absorption + other.absorption,
+            elimination=self.elimination + other.elimination,
+            transits=transits,
+            peripherals=self.peripherals + other.peripherals,
+            lagtime=self.lagtime + other.lagtime,
+            covariate=self.covariate,  # TODO : Covariate
+        )
+
+    def _add_sub_transits(self, other, add=True):
+        """Apply logic for adding/subtracting mfl transits.
+        Use add = False for subtraction"""
+
+        # Need multiple Transit objects due to presence of both depot / nodepot
+        # and different sets of counts
+        lhs_counts_depot = [
+            c for t in self.transits if Name("DEPOT") in t.eval.depot for c in t.counts
+        ]
+        lhs_counts_nodepot = [
+            c for t in self.transits if Name("NODEPOT") in t.eval.depot for c in t.counts
+        ]
+        rhs_counts_depot = [
+            c for t in other.transits if Name("DEPOT") in t.eval.depot for c in t.counts
+        ]
+        rhs_counts_nodepot = [
+            c for t in other.transits if Name("NODEPOT") in t.eval.depot for c in t.counts
+        ]
+
+        if add:
+            depot_counts = list(set(lhs_counts_depot + rhs_counts_depot))
+            nodepot_counts = list(set(lhs_counts_nodepot + rhs_counts_nodepot))
+        else:
+            depot_counts = [c for c in lhs_counts_depot if c not in rhs_counts_depot]
+            nodepot_counts = [c for c in lhs_counts_nodepot if c not in rhs_counts_nodepot]
+
+        if len(depot_counts) == len(nodepot_counts) == 0:
+            transits = (
+                Transits(
+                    (0,),
+                    (Name("DEPOT"),),
+                ),
+            )
+        else:
+            both_depot = [d for d in depot_counts if d in nodepot_counts]
+            nodepot_diff = [d for d in nodepot_counts if d not in depot_counts]
+            depot_diff = [d for d in depot_counts if d not in nodepot_counts]
+
+            transits = []
+            if len(both_depot) != 0:
+                transits.append(Transits(tuple(both_depot), (Name("DEPOT"), Name("NODEPOT"))))
+            if len(depot_diff) != 0:
+                transits.append(Transits(tuple(depot_diff), (Name("DEPOT"),)))
+            if len(nodepot_diff) != 0:
+                transits.append(Transits(tuple(nodepot_diff), (Name("NODEPOT"),)))
+
+        return tuple(transits)
+
+    def __eq__(self, other):
+        transits = self._eq_transits(other)
+        return (
+            self.absorption == other.absorption
+            and self.elimination == other.elimination
+            and transits
+            and self.peripherals == other.peripherals
+            and self.lagtime == other.lagtime
+            and self.covariate == other.covariate
+        )
+
+    def _eq_transits(self, other):
+        lhs_counts_depot = [
+            c for t in self.transits if Name("DEPOT") in t.eval.depot for c in t.counts
+        ]
+        lhs_counts_nodepot = [
+            c for t in self.transits if Name("NODEPOT") in t.eval.depot for c in t.counts
+        ]
+        rhs_counts_depot = [
+            c for t in other.transits if Name("DEPOT") in t.eval.depot for c in t.counts
+        ]
+        rhs_counts_nodepot = [
+            c for t in other.transits if Name("NODEPOT") in t.eval.depot for c in t.counts
+        ]
+        return set(lhs_counts_depot) == set(rhs_counts_depot) and set(lhs_counts_nodepot) == set(
+            rhs_counts_nodepot
+        )

--- a/src/pharmpy/tools/mfl/statement/feature/absorption.py
+++ b/src/pharmpy/tools/mfl/statement/feature/absorption.py
@@ -9,7 +9,44 @@ from .symbols import Name, Wildcard
 
 @dataclass(frozen=True)
 class Absorption(ModelFeature):
-    modes: Union[Tuple[Name[Literal['FO', 'ZO', 'SEQ-FO-ZO', 'INST']], ...], Wildcard]
+    modes: Union[Tuple[Name[Literal['FO', 'ZO', 'SEQ-ZO-FO', 'INST']], ...], Wildcard]
+
+    def __add__(self, other):
+        if isinstance(self.modes, Wildcard) or isinstance(other.modes, Wildcard):
+            return Absorption(Wildcard())
+        else:
+            return Absorption(
+                tuple(set(self.modes + tuple([a for a in other.modes if a not in self.modes])))
+            )
+
+    def __sub__(self, other):
+        if isinstance(other.modes, Wildcard):
+            return Absorption((Name('INST')))
+        elif isinstance(self.modes, Wildcard):
+            default = self._wildcard
+            all_modes = tuple([a for a in default if a not in other.modes])
+        else:
+            # NOTE : WILDCARD should not be used here to future proof the method
+            all_modes = tuple(set([a for a in self.modes if a not in other.modes]))
+
+        if len(all_modes) == 0:
+            all_modes = (Name('INST'),)
+
+        return Absorption(all_modes)
+
+    def __eq__(self, other):
+        return set(self.modes) == set(other.modes)
+
+    @property
+    def eval(self):
+        if isinstance(self.modes, Wildcard):
+            return Absorption(self._wildcard)
+        else:
+            return self
+
+    @property
+    def _wildcard(self):
+        return tuple([Name(x) for x in ['FO', 'ZO', 'SEQ-ZO-FO', 'INST']])
 
 
 class AbsorptionInterpreter(Interpreter):

--- a/src/pharmpy/tools/mfl/statement/feature/absorption.py
+++ b/src/pharmpy/tools/mfl/statement/feature/absorption.py
@@ -9,7 +9,7 @@ from .symbols import Name, Wildcard
 
 @dataclass(frozen=True)
 class Absorption(ModelFeature):
-    modes: Union[Tuple[Name[Literal['FO', 'ZO', 'SEQ-FO-ZO']], ...], Wildcard]
+    modes: Union[Tuple[Name[Literal['FO', 'ZO', 'SEQ-FO-ZO', 'INST']], ...], Wildcard]
 
 
 class AbsorptionInterpreter(Interpreter):

--- a/src/pharmpy/tools/mfl/statement/feature/elimination.py
+++ b/src/pharmpy/tools/mfl/statement/feature/elimination.py
@@ -11,6 +11,41 @@ from .symbols import Name, Wildcard
 class Elimination(ModelFeature):
     modes: Union[Tuple[Name[Literal['FO', 'ZO', 'MM', 'MIX-FO-MM']], ...], Wildcard]
 
+    def __add__(self, other):
+        if isinstance(self.modes, Wildcard) or isinstance(other.modes, Wildcard):
+            return Elimination(Wildcard())
+        else:
+            return Elimination(self.modes + tuple([a for a in other.modes if a not in self.modes]))
+
+    def __sub__(self, other):
+        if isinstance(other.modes, Wildcard):
+            return Elimination((Name('INST')))
+        elif isinstance(self.modes, Wildcard):
+            default = self._wildcard
+            all_modes = tuple([a for a in default if a not in other.modes])
+        else:
+            # NOTE : WILDCARD should not be used here to future proof the method
+            all_modes = tuple([a for a in self.modes if a not in other.modes])
+
+        if len(all_modes) == 0:
+            all_modes = (Name('FO'),)
+
+        return Elimination(all_modes)
+
+    def __eq__(self, other):
+        return set(self.modes) == set(other.modes)
+
+    @property
+    def eval(self):
+        if isinstance(self.modes, Wildcard):
+            return Elimination(self._wildcard)
+        else:
+            return self
+
+    @property
+    def _wildcard(self):
+        return tuple([Name(x) for x in ['FO', 'ZO', 'MM', 'MIX-FO-MM']])
+
 
 class EliminationInterpreter(Interpreter):
     def interpret(self, tree):

--- a/src/pharmpy/tools/mfl/statement/feature/lagtime.py
+++ b/src/pharmpy/tools/mfl/statement/feature/lagtime.py
@@ -1,17 +1,27 @@
 from dataclasses import dataclass
+from typing import Literal, Tuple, Union
 
 from lark.visitors import Interpreter
 
-from .feature import ModelFeature
+from .feature import ModelFeature, feature
+from .symbols import Name, Wildcard
 
 
 @dataclass(frozen=True)
 class LagTime(ModelFeature):
+    modes: Union[Tuple[Name[Literal['ON', 'OFF']], ...], Wildcard]
     pass
 
 
 class LagTimeInterpreter(Interpreter):
     def interpret(self, tree):
         children = self.visit_children(tree)
-        assert not children
-        return LagTime()
+        assert len(children) == 1
+        return feature(LagTime, children)
+
+    def lagtime_modes(self, tree):
+        children = self.visit_children(tree)
+        return list(Name(child.value.upper()) for child in children)
+
+    def lagtime_wildcard(self, tree):
+        return Wildcard()

--- a/src/pharmpy/tools/mfl/statement/feature/lagtime.py
+++ b/src/pharmpy/tools/mfl/statement/feature/lagtime.py
@@ -10,7 +10,42 @@ from .symbols import Name, Wildcard
 @dataclass(frozen=True)
 class LagTime(ModelFeature):
     modes: Union[Tuple[Name[Literal['ON', 'OFF']], ...], Wildcard]
-    pass
+
+    def __add__(self, other):
+        if isinstance(self.modes, Wildcard) or isinstance(other.modes, Wildcard):
+            return LagTime(Wildcard())
+        else:
+            return LagTime(
+                tuple(set(self.modes + tuple([a for a in other.modes if a not in self.modes])))
+            )
+
+    def __sub__(self, other):
+        if isinstance(other.modes, Wildcard):
+            return LagTime((Name('OFF')))
+        elif isinstance(self.modes, Wildcard):
+            default = self._wildcard
+            all_modes = tuple([a for a in default if a not in other.modes])
+        else:
+            all_modes = tuple([a for a in self.modes if a not in other.modes])
+
+        if len(all_modes) == 0:
+            all_modes = (Name('OFF'),)
+
+        return LagTime(all_modes)
+
+    def __eq__(self, other):
+        return set(self.modes) == set(other.modes)
+
+    @property
+    def eval(self):
+        if isinstance(self.modes, Wildcard):
+            return LagTime(self._wildcard)
+        else:
+            return self
+
+    @property
+    def _wildcard(self):
+        return tuple([Name(x) for x in ['ON', 'OFF']])
 
 
 class LagTimeInterpreter(Interpreter):

--- a/src/pharmpy/tools/mfl/statement/feature/peripherals.py
+++ b/src/pharmpy/tools/mfl/statement/feature/peripherals.py
@@ -9,6 +9,22 @@ from .feature import ModelFeature, feature
 class Peripherals(ModelFeature):
     counts: Tuple[int, ...]
 
+    def __add__(self, other):
+        return Peripherals(
+            tuple(set(self.counts + tuple([a for a in other.counts if a not in self.counts])))
+        )
+
+    def __sub__(self, other):
+        all_counts = tuple([a for a in self.counts if a not in other.counts])
+
+        if len(all_counts) == 0:
+            all_counts = (0,)
+
+        return Peripherals(all_counts)
+
+    def __eq__(self, other):
+        return set(self.counts) == set(other.counts)
+
 
 class PeripheralsInterpreter(CountInterpreter):
     def interpret(self, tree):

--- a/src/pharmpy/tools/mfl/statement/feature/transits.py
+++ b/src/pharmpy/tools/mfl/statement/feature/transits.py
@@ -9,7 +9,7 @@ from .symbols import Name, Wildcard
 @dataclass(frozen=True)
 class Transits(ModelFeature):
     counts: Tuple[int, ...]
-    depot: Union[Name[Literal['DEPOT']], Name[Literal['NODEPOT']], Wildcard] = Name('DEPOT')
+    depot: Union[Tuple[Name[Literal['DEPOT', 'NODEPOT']], ...], Wildcard] = (Name('DEPOT'),)
 
 
 class TransitsInterpreter(CountInterpreter):
@@ -18,9 +18,9 @@ class TransitsInterpreter(CountInterpreter):
         assert 1 <= len(children) <= 2
         return feature(Transits, children)
 
-    def depot_option(self, tree):
+    def depot_modes(self, tree):
         children = self.visit_children(tree)
-        assert len(children) == 1
-        value = children[0].value.upper()
-        assert value in ['*', 'DEPOT', 'NODEPOT']
-        return Wildcard() if value == '*' else Name(value)
+        return list(Name(child.value.upper()) for child in children)
+
+    def depot_wildcard(self, tree):
+        return Wildcard()

--- a/src/pharmpy/tools/mfl/statement/feature/transits.py
+++ b/src/pharmpy/tools/mfl/statement/feature/transits.py
@@ -11,6 +11,61 @@ class Transits(ModelFeature):
     counts: Tuple[int, ...]
     depot: Union[Tuple[Name[Literal['DEPOT', 'NODEPOT']], ...], Wildcard] = (Name('DEPOT'),)
 
+    def __add__(self, other):
+        # NOTE : Use with caution as no addition logic is implemented here
+        if isinstance(self.depot, Wildcard) or isinstance(other.depot, Wildcard):
+            depot = Wildcard()
+        else:
+            depot = tuple(set(self.depot + tuple([a for a in other.depot if a not in self.depot])))
+
+        counts = tuple(set(self.counts + tuple([a for a in other.counts if a not in self.counts])))
+
+        return Transits(counts=counts, depot=depot)
+
+    def __sub__(self, other):
+        # NOTE : Use with caution as no subtraction logic is implemented here
+        if isinstance(other.depot, Wildcard):
+            all_depot = (Name('DEPOT'),)
+        elif isinstance(self.depot, Wildcard):
+            default = self._wildcard
+            all_depot = tuple([a for a in default if a not in other.depot])
+        else:
+            all_depot = tuple([a for a in self.depot if a not in other.depot])
+
+        if len(all_depot) == 0:
+            all_depot = (Name('DEPOT'),)
+
+        all_counts = tuple([a for a in self.counts if a not in other.counts])
+
+        if len(all_counts) == 0:
+            all_counts = (0,)
+
+        return Transits(counts=all_counts, depot=all_depot)
+
+    def __eq__(self, other):
+        if isinstance(self.depot, Wildcard):
+            lhs_depot = self.depot
+        else:
+            lhs_depot = set(self.depot)
+
+        if isinstance(other.depot, Wildcard):
+            rhs_depot = other.depot
+        else:
+            rhs_depot = set(other.depot)
+
+        return (set(self.counts) == set(other.counts), lhs_depot == rhs_depot)
+
+    @property
+    def eval(self):
+        if isinstance(self.depot, Wildcard):
+            return Transits(self.counts, self._wildcard)
+        else:
+            return self
+
+    @property
+    def _wildcard(self):
+        return tuple([Name(x) for x in ['DEPOT', 'NODEPOT']])
+
 
 class TransitsInterpreter(CountInterpreter):
     def interpret(self, tree):

--- a/src/pharmpy/tools/modelsearch/tool.py
+++ b/src/pharmpy/tools/modelsearch/tool.py
@@ -6,17 +6,20 @@ from pharmpy.deps import pandas as pd
 from pharmpy.internals.fn.signature import with_same_arguments_as
 from pharmpy.internals.fn.type import with_runtime_arguments_type_check
 from pharmpy.model import Model
+from pharmpy.modeling.common import get_model_attributes
 from pharmpy.results import ModelfitResults
 from pharmpy.tools import summarize_modelfit_results
 from pharmpy.tools.common import RANK_TYPES, ToolResults, create_results
-from pharmpy.workflows import Task, Workflow, WorkflowBuilder
+from pharmpy.tools.mfl.parse import ModelFeatures
+from pharmpy.tools.modelfit import create_fit_workflow
+from pharmpy.workflows import Task, Workflow, WorkflowBuilder, call_workflow
 
 from ..mfl.filter import modelsearch_statement_types
 from ..mfl.parse import parse as mfl_parse
 
 
 def create_workflow(
-    search_space: str,
+    search_space: Union[str, ModelFeatures],
     algorithm: str,
     iiv_strategy: str = 'absorption_delay',
     rank_type: str = 'bic',
@@ -28,8 +31,8 @@ def create_workflow(
 
     Parameters
     ----------
-    search_space : str
-        Search space to test
+    search_space : str, ModelFeatures
+        Search space to test. Either as a string or a ModelFeatures object.
     algorithm : str
         Algorithm to use (e.g. exhaustive)
     iiv_strategy : str
@@ -59,21 +62,60 @@ def create_workflow(
     >>> run_modelsearch('ABSORPTION(ZO);PERIPHERALS(1)', 'exhaustive', results=results, model=model) # doctest: +SKIP
 
     """
-
     wb = WorkflowBuilder(name='modelsearch')
+    start_task = Task(
+        'start_modelsearch',
+        start,
+        search_space,
+        algorithm,
+        iiv_strategy,
+        rank_type,
+        cutoff,
+        results,
+        model,
+    )
+    wb.add_task(start_task)
+    task_results = Task('results', _results)
+    wb.add_task(task_results, predecessors=[start_task])
+    return Workflow(wb)
 
-    if model:
-        start_task = Task('start_modelsearch', start, model)
-    else:
-        start_task = Task('start_modelsearch', start)
 
+def start(
+    context,
+    search_space,
+    algorithm,
+    iiv_strategy,
+    rank_type,
+    cutoff,
+    results,
+    model,
+):
+    wb = WorkflowBuilder()
+
+    start_task = Task('start_modelsearch', _start, model)
     wb.add_task(start_task)
 
     algorithm_func = getattr(algorithms, algorithm)
 
-    mfl_statements = mfl_parse(search_space)
-    wf_search, candidate_model_tasks = algorithm_func(mfl_statements, iiv_strategy)
-    wb.insert_workflow(wf_search, predecessors=wb.output_tasks)
+    if isinstance(search_space, str):
+        mfl_statements = mfl_parse(search_space, mfl_class=True)
+    else:
+        mfl_statements = search_space
+
+    # Add base model task
+    model_mfl = get_model_attributes(model, supress_warnings=True)
+    model_mfl = ModelFeatures.create_from_mfl_string(model_mfl)
+    if not mfl_statements.contain_subset(model_mfl):
+        base_task = Task("create_base_model", create_base_model, mfl_statements)
+        wb.add_task(base_task, predecessors=start_task)
+
+        base_fit = create_fit_workflow(n=1)
+        wb.insert_workflow(base_fit, predecessors=base_task)
+        base_fit = base_fit.output_tasks
+    else:
+        # Always create base, even if same as input for proper
+        # post-process behaviour.
+        base_fit = start_task
 
     task_result = Task(
         'results',
@@ -82,40 +124,161 @@ def create_workflow(
         cutoff,
     )
 
-    wb.add_task(task_result, predecessors=[start_task] + candidate_model_tasks)
+    # Filter the mfl_statements from base model attributes
+    mfl_funcs = filter_mfl_statements(mfl_statements, create_base_model(mfl_statements, model))
 
-    return Workflow(wb)
+    # TODO : Implement task for filtering the search space instead
+    wf_search, candidate_model_tasks = algorithm_func(mfl_funcs, iiv_strategy)
+    if candidate_model_tasks:
+        # Clear base description to not interfere with candidate models
+        base_clear_task = Task("Clear_base_description", clear_description)
+        wb.add_task(base_clear_task, predecessors=base_fit)
+
+        wb.insert_workflow(wf_search, predecessors=base_clear_task)
+
+        if base_fit != start_task:
+            wb.add_task(task_result, predecessors=[start_task] + base_fit + candidate_model_tasks)
+        else:
+            wb.add_task(task_result, predecessors=[start_task] + candidate_model_tasks)
+    else:
+        if base_fit != start_task:
+            wb.add_task(task_result, predecessors=[start_task] + base_fit + candidate_model_tasks)
+        else:
+            wb.add_task(task_result, predecessors=[start_task] + candidate_model_tasks)
+
+    res = call_workflow(wb, 'run_candidate_models', context)
+
+    return res
 
 
-def start(model):
+def _start(model):
     return model
+
+
+def _results(res):
+    return res
+
+
+def clear_description(model):
+    return model.replace(description="")
+
+
+def filter_mfl_statements(mfl_statements: ModelFeatures, model: Model):
+    ss_funcs = mfl_statements.convert_to_funcs()
+    model_mfl = ModelFeatures.create_from_mfl_string(get_model_attributes(model))
+    model_funcs = model_mfl.convert_to_funcs()
+    res = {k: ss_funcs[k] for k in set(ss_funcs) - set(model_funcs)}
+    return {k: v for k, v in sorted(res.items(), key=lambda x: (x[0][0], x[0][1]))}
+
+
+def _update_results(base):
+    """
+    Changes the name and description of the connected ModelfitResults object
+    to match the one found in the model object"""
+    base_results = base.modelfit_results
+    # Workaround due to not having a replace method
+    return base.replace(
+        modelfit_results=ModelfitResults(
+            name=base.name,
+            description=base.description,
+            ofv=base_results.ofv,
+            ofv_iterations=base_results.ofv_iterations,
+            parameter_estimates=base_results.parameter_estimates,
+            parameter_estimates_sdcorr=base_results.parameter_estimates_sdcorr,
+            parameter_estimates_iterations=base_results.parameter_estimates_iterations,
+            covariance_matrix=base_results.covariance_matrix,
+            correlation_matrix=base_results.correlation_matrix,
+            precision_matrix=base_results.precision_matrix,
+            standard_errors=base_results.standard_errors,
+            standard_errors_sdcorr=base_results.standard_errors_sdcorr,
+            relative_standard_errors=base_results.relative_standard_errors,
+            minimization_successful=base_results.minimization_successful,
+            minimization_successful_iterations=base_results.minimization_successful_iterations,
+            estimation_runtime=base_results.estimation_runtime,
+            estimation_runtime_iterations=base_results.estimation_runtime_iterations,
+            individual_ofv=base_results.individual_ofv,
+            individual_estimates=base_results.individual_estimates,
+            individual_estimates_covariance=base_results.individual_estimates_covariance,
+            residuals=base_results.residuals,
+            predictions=base_results.predictions,
+            runtime_total=base_results.runtime_total,
+            termination_cause=base_results.termination_cause,
+            termination_cause_iterations=base_results.termination_cause,
+            function_evaluations=base_results.function_evaluations,
+            function_evaluations_iterations=base_results.function_evaluations_iterations,
+            significant_digits=base_results.significant_digits,
+            significant_digits_iterations=base_results.significant_digits_iterations,
+            log_likelihood=base_results.log_likelihood,
+            log=base_results.log,
+            evaluation=base_results.evaluation,
+        )
+    )
+
+
+def create_base_model(ss, model):
+    base = model
+
+    model_mfl = get_model_attributes(model, supress_warnings=True)
+    model_mfl = ModelFeatures.create_from_mfl_string(model_mfl)
+    added_features = ""
+    lnt = model_mfl.least_number_of_transformations(ss)
+    for name, func in lnt.items():
+        base = func(base)
+        added_features = f';{name[0]}({name[1]})'
+
+    # UPDATE_DESCRIPTION
+    # FIXME : Need to be its own parent if the input model shouldn't be ranked with the others
+    base = base.replace(name="BASE", description=added_features[1:], parent_model="BASE")
+
+    return base
 
 
 def post_process(rank_type, cutoff, *models):
     res_models = []
     input_model = None
+    base_model = False
     for model in models:
-        if not model.name.startswith('modelsearch_run'):
+        if not model.name.startswith('modelsearch_run') and model.name == "BASE":
+            base_model = True
             input_model = model
+            base_model = model
+        elif not model.name.startswith('modelsearch_run') and model.name != "BASE":
+            user_input_model = model
         else:
             res_models.append(model)
-
+    if not base_model:
+        input_model = user_input_model
+        base_model = user_input_model
     if not input_model:
         raise ValueError('Error in workflow: No input model')
 
-    summary_input = summarize_modelfit_results(input_model.modelfit_results)
-    summary_candidates = summarize_modelfit_results(
-        [model.modelfit_results for model in res_models]
-    )
+    summary_user_input = summarize_modelfit_results(user_input_model.modelfit_results)
+    if user_input_model != base_model:
+        summary_base = summarize_modelfit_results(base_model.modelfit_results)
+        summary_models = [summary_user_input, summary_base]
+        keys = [0, 1]
+    else:
+        summary_models = [summary_user_input]
+        keys = [0]
+
+    if res_models:
+        summary_candidates = summarize_modelfit_results(
+            [model.modelfit_results for model in res_models]
+        )
+        summary_models = pd.concat(
+            summary_models + [summary_candidates], keys=keys + [keys[-1] + 1], names=['step']
+        )
+    else:
+        summary_models = pd.concat(summary_models, keys=keys + [keys[-1] + 1], names=['step'])
 
     return create_results(
         ModelSearchResults,
         input_model,
-        input_model,
+        base_model,
         res_models,
         rank_type,
         cutoff,
-        summary_models=pd.concat([summary_input, summary_candidates], keys=[0, 1], names=['step']),
+        summary_models=summary_models,
     )
 
 

--- a/tests/modeling/test_odes.py
+++ b/tests/modeling/test_odes.py
@@ -2639,7 +2639,7 @@ def test_multi_dose_change_absorption(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'modeling' / 'pheno_advan1.mod')
     ode = model.statements.ode_system
     cb = CompartmentalSystemBuilder(ode)
-    cb.set_dose(cb.find_compartment("CENTRAL"), Bolus(sympy.Symbol('AMT'), admid=1), replace=False)
+    cb.set_dose(cb.find_compartment("CENTRAL"), Bolus(sympy.Symbol('AMT'), admid=2), replace=False)
     ode = CompartmentalSystem(cb)
     model = model.replace(
         statements=model.statements.before_odes + ode + model.statements.after_odes
@@ -2652,7 +2652,7 @@ def test_multi_dose_change_absorption(load_model_for_test, testdata):
     central = model.statements.ode_system.find_compartment("CENTRAL")
 
     assert depot.doses[0] == Bolus(sympy.Symbol('AMT'), admid=1)
-    assert central.doses[0] == Bolus(sympy.Symbol('AMT'), admid=1)
+    assert central.doses[0] == Bolus(sympy.Symbol('AMT'), admid=2)
 
     model = set_zero_order_absorption(model)
     central = model.statements.ode_system.find_compartment("CENTRAL")

--- a/tests/tools/test_mfl.py
+++ b/tests/tools/test_mfl.py
@@ -212,8 +212,10 @@ from pharmpy.tools.mfl.stringify import stringify
                 ('PERIPHERALS', 5),
             ),
         ),
-        ('LAGTIME()', (('LAGTIME',),)),
-        ('LAGTIME ( )', (('LAGTIME',),)),
+        ('LAGTIME(ON)', (('LAGTIME', 'ON'),)),
+        ('LAGTIME ( ON )', (('LAGTIME', 'ON'),)),
+        ('LAGTIME(OFF)', (('LAGTIME', 'OFF'),)),
+        ('LAGTIME([ON, OFF])', (('LAGTIME', 'OFF'), ('LAGTIME', 'ON'))),
         (
             'TRANSITS(1, *)',
             (
@@ -480,13 +482,13 @@ def test_illegal_mfl(code):
             (
                 Absorption((Name('ZO'), Name('SEQ-ZO-FO'))),
                 Elimination((Name('MM'), Name('MIX-FO-MM'))),
-                LagTime(),
+                LagTime((Name('ON'),)),
                 Transits((1, 3, 10), Wildcard()),
                 Peripherals((1,)),
             ),
             'ABSORPTION([ZO,SEQ-ZO-FO]);'
             'ELIMINATION([MM,MIX-FO-MM]);'
-            'LAGTIME();'
+            'LAGTIME(ON);'
             'TRANSITS([1,3,10],*);'
             'PERIPHERALS(1)',
         ),

--- a/tests/tools/test_mfl.py
+++ b/tests/tools/test_mfl.py
@@ -20,12 +20,21 @@ from pharmpy.tools.mfl.stringify import stringify
     ('source', 'expected'),
     (
         (
+            'ABSORPTION(INST)',
+            (('ABSORPTION', 'INST'),),
+        ),
+        (
             'ABSORPTION(FO)',
             (('ABSORPTION', 'FO'),),
         ),
         (
             'ABSORPTION(* )',
-            (('ABSORPTION', 'FO'), ('ABSORPTION', 'ZO'), ('ABSORPTION', 'SEQ-ZO-FO')),
+            (
+                ('ABSORPTION', 'FO'),
+                ('ABSORPTION', 'ZO'),
+                ('ABSORPTION', 'SEQ-ZO-FO'),
+                ('ABSORPTION', 'INST'),
+            ),
         ),
         (
             'ABSORPTION([ZO,FO])',

--- a/tests/tools/test_modelsearch.py
+++ b/tests/tools/test_modelsearch.py
@@ -2,6 +2,7 @@ import functools
 
 import pytest
 
+from pharmpy.model import Model
 from pharmpy.modeling import (
     add_peripheral_compartment,
     set_mixed_mm_fo_elimination,
@@ -9,6 +10,7 @@ from pharmpy.modeling import (
     set_zero_order_absorption,
     set_zero_order_elimination,
 )
+from pharmpy.tools.mfl.helpers import funcs, modelsearch_features
 from pharmpy.tools.mfl.parse import parse
 from pharmpy.tools.mfl.parse import parse as mfl_parse
 from pharmpy.tools.modelsearch.algorithms import (
@@ -28,6 +30,7 @@ MINIMAL_VALID_MFL_STRING = 'LAGTIME(ON)'
 def test_exhaustive_algorithm():
     mfl = 'ABSORPTION(ZO);PERIPHERALS(1)'
     search_space = mfl_parse(mfl)
+    search_space = funcs(Model(), search_space, modelsearch_features)
     wf, _ = exhaustive(search_space, iiv_strategy='no_add')
     fit_tasks = [task.name for task in wf.tasks if task.name.startswith('run')]
 
@@ -99,6 +102,7 @@ def test_exhaustive_algorithm():
 )
 def test_exhaustive_stepwise_algorithm(mfl: str, iiv_strategy: str, no_of_models: int):
     search_space = mfl_parse(mfl)
+    search_space = funcs(Model(), search_space, modelsearch_features)
     wf, _ = exhaustive_stepwise(search_space, iiv_strategy=iiv_strategy)
     fit_tasks = [task.name for task in wf.tasks if task.name.startswith('run')]
 
@@ -126,6 +130,7 @@ def test_exhaustive_stepwise_algorithm(mfl: str, iiv_strategy: str, no_of_models
 )
 def test_reduced_stepwise_algorithm(mfl: str, no_of_models: int):
     search_space = mfl_parse(mfl)
+    search_space = funcs(Model(), search_space, modelsearch_features)
     wf, _ = reduced_stepwise(search_space, iiv_strategy='no_add')
     fit_tasks = [task.name for task in wf.tasks if task.name.startswith('run')]
 
@@ -169,12 +174,14 @@ $ESTIMATION METHOD=1 INTERACTION
 
 def test_is_allowed():
     features = parse('ABSORPTION(ZO);PERIPHERALS(1)')
+    features = funcs(Model(), features, modelsearch_features)
     feat_previous = []
     feat_current, func_current = 'ABSORPTION(ZO)', set_zero_order_absorption
     assert _is_allowed(feat_current, func_current, feat_previous, features)
     assert _is_allowed(feat_current, func_current, feat_current, features) is False
 
     features = parse('ABSORPTION([ZO,SEQ-ZO-FO])')
+    features = funcs(Model(), features, modelsearch_features)
     feat_previous = [
         (
             'ABSORPTION',
@@ -185,6 +192,7 @@ def test_is_allowed():
     assert _is_allowed(feat_current, func_current, feat_previous, features) is False
 
     features = parse('PERIPHERALS([1,2])')
+    features = funcs(Model(), features, modelsearch_features)
     feat_previous = []
     feat_current, func_current = ('PERIPHERALS', 1), functools.partial(
         set_peripheral_compartments, n=1
@@ -197,6 +205,7 @@ def test_is_allowed():
     assert _is_allowed(feat_current, func_current, feat_previous, features)
 
     features = parse('PERIPHERALS([1,2])')
+    features = funcs(Model(), features, modelsearch_features)
     feat_previous = [('PERIPHERALS', 1)]
     feat_current, func_current = ('PERIPHERALS', 1), functools.partial(
         set_peripheral_compartments, n=1
@@ -204,6 +213,7 @@ def test_is_allowed():
     assert _is_allowed(feat_current, func_current, feat_previous, features) is False
 
     features = parse('PERIPHERALS([1,2])')
+    features = funcs(Model(), features, modelsearch_features)
     feat_previous = []
     feat_current, func_current = ('PERIPHERALS', 2), functools.partial(
         set_peripheral_compartments, n=2
@@ -211,6 +221,7 @@ def test_is_allowed():
     assert _is_allowed(feat_current, func_current, feat_previous, features) is False
 
     features = parse('PERIPHERALS(2)')
+    features = funcs(Model(), features, modelsearch_features)
     feat_previous = []
     feat_current, func_current = ('PERIPHERALS', 2), functools.partial(
         set_peripheral_compartments, n=2

--- a/tests/tools/test_modelsearch.py
+++ b/tests/tools/test_modelsearch.py
@@ -22,7 +22,7 @@ from pharmpy.tools.modelsearch.tool import create_workflow, validate_input
 from pharmpy.workflows import Workflow
 
 MINIMAL_INVALID_MFL_STRING = ''
-MINIMAL_VALID_MFL_STRING = 'LAGTIME()'
+MINIMAL_VALID_MFL_STRING = 'LAGTIME(ON)'
 
 
 def test_exhaustive_algorithm():
@@ -54,22 +54,22 @@ def test_exhaustive_algorithm():
             8,
         ),
         (
-            'ABSORPTION(SEQ-ZO-FO);LAGTIME()',
+            'ABSORPTION(SEQ-ZO-FO);LAGTIME(ON)',
             'no_add',
             2,
         ),
         (
-            'ABSORPTION(ZO);LAGTIME();PERIPHERALS(1)',
+            'ABSORPTION(ZO);LAGTIME(ON);PERIPHERALS(1)',
             'no_add',
             15,
         ),
         (
-            'ABSORPTION(ZO);LAGTIME();PERIPHERALS([1,2]);ELIMINATION(ZO)',
+            'ABSORPTION(ZO);LAGTIME(ON);PERIPHERALS([1,2]);ELIMINATION(ZO)',
             'no_add',
             170,
         ),
         (
-            'LAGTIME();TRANSITS(1);PERIPHERALS(1)',
+            'LAGTIME(ON);TRANSITS(1);PERIPHERALS(1)',
             'diagonal',
             7,
         ),
@@ -80,7 +80,7 @@ def test_exhaustive_algorithm():
         ),
         ('ABSORPTION([ZO,SEQ-ZO-FO]);PERIPHERALS(1)', 0, 7),
         (
-            'LAGTIME();TRANSITS(1)',
+            'LAGTIME(ON);TRANSITS(1)',
             'no_add',
             2,
         ),
@@ -90,7 +90,7 @@ def test_exhaustive_algorithm():
             3,
         ),
         (
-            'ABSORPTION([ZO,SEQ-ZO-FO]);LAGTIME();TRANSITS([1,3,10],*);'
+            'ABSORPTION([ZO,SEQ-ZO-FO]);LAGTIME(ON);TRANSITS([1,3,10],*);'
             'PERIPHERALS(1);ELIMINATION([MM,MIX-FO-MM])',
             'no_add',
             246,
@@ -109,16 +109,16 @@ def test_exhaustive_stepwise_algorithm(mfl: str, iiv_strategy: str, no_of_models
     'mfl, no_of_models',
     [
         (
-            'ABSORPTION(ZO);LAGTIME();PERIPHERALS(1)',
+            'ABSORPTION(ZO);LAGTIME(ON);PERIPHERALS(1)',
             12,
         ),
         (
-            'ABSORPTION(ZO);LAGTIME();PERIPHERALS([1,2]);ELIMINATION(ZO)',
+            'ABSORPTION(ZO);LAGTIME(ON);PERIPHERALS([1,2]);ELIMINATION(ZO)',
             52,
         ),
         ('ABSORPTION([ZO,SEQ-ZO-FO]);ELIMINATION(MM)', 7),
         (
-            'ABSORPTION([ZO,SEQ-ZO-FO]);LAGTIME();TRANSITS([1,3,10],*);'
+            'ABSORPTION([ZO,SEQ-ZO-FO]);LAGTIME(ON);TRANSITS([1,3,10],*);'
             'PERIPHERALS(1);ELIMINATION([MM,MIX-FO-MM])',
             143,
         ),


### PR DESCRIPTION
Implementation of a new ModelFeatures class allowing for easier handling of MFL attributes within the different tools. Currently implemented for allowing modelsearch to be rerun (or run with any model as a start model).

The MFL string in modelsearch is now representing the entire search space for modelsearch and if the input model is not part of said search space. A base model will be created which is part of it. If the input model is part of the search space, the base model will be the same as the input model.