### PR TITLE
Implement drug metabolite within AMD

### DIFF
--- a/src/pharmpy/modeling/odes.py
+++ b/src/pharmpy/modeling/odes.py
@@ -2038,13 +2038,29 @@ def _find_rate(sset: Statements):
     odes = sset.ode_system
     assert isinstance(odes, CompartmentalSystem)
     central = odes.central_compartment
-    elimination_rate = odes.get_flow(central, output)
-    rate_list.append(elimination_rate)
-    for periph in odes.find_peripheral_compartments():
-        rate1 = odes.get_flow(central, periph)
-        rate_list.append(rate1)
-        rate2 = odes.get_flow(periph, central)
-        rate_list.append(rate2)
+    # FIXME : How to specify metabolite compartment?
+    metacomp = odes.find_compartment("METABOLITE")
+    if metacomp:
+        central_to_metabolite = odes.get_flow(central, metacomp)
+        rate_list.append(central_to_metabolite)
+        elimination_rate = odes.get_flow(metacomp, output)
+        rate_list.append(elimination_rate)
+
+    else:
+        elimination_rate = odes.get_flow(central, output)
+        rate_list.append(elimination_rate)
+
+    comp_peripherals = {}
+    comp_peripherals[central] = odes.find_peripheral_compartments()
+    if metacomp:
+        comp_peripherals[metacomp] = odes.find_peripheral_compartments(name=metacomp.name)
+
+    for comp, peripherals in comp_peripherals.items():
+        for periph in peripherals:
+            rate1 = odes.get_flow(comp, periph)
+            rate_list.append(rate1)
+            rate2 = odes.get_flow(periph, comp)
+            rate_list.append(rate2)
     return rate_list
 
 

--- a/src/pharmpy/tools/structsearch/drugmetabolite.py
+++ b/src/pharmpy/tools/structsearch/drugmetabolite.py
@@ -4,6 +4,28 @@ from pharmpy.model import Model
 from pharmpy.modeling import add_metabolite, add_peripheral_compartment, set_name
 
 
+def create_base_metabolite(model: Model) -> Model:
+    """
+    Create a plain metabolite models from an input model. This is used
+    as the base model when searching for candidate drug metabolite model
+
+    Parameters
+    ----------
+    model : Model
+        Input model for search
+
+    Returns
+    -------
+    Model
+        Base model for drug metabolite model search
+
+    """
+    model = add_metabolite(model)
+    model = set_name(model, "base_metabolite")
+    model = model.replace(parent_model="base_metabolite")
+    return model
+
+
 def create_drug_metabolite_models(model: Model) -> List[Model]:
     """
     Create candidate models for drug metabolite model structsearch.
@@ -23,13 +45,15 @@ def create_drug_metabolite_models(model: Model) -> List[Model]:
     models = []
     for presystemic in [False, True]:
         candidate_model = add_metabolite(model, presystemic=presystemic)
-        candidate_model = set_name(candidate_model, f'{"presystemic" if presystemic else "plain"}')
+        candidate_model = set_name(candidate_model, 'presystemic')
 
-        models.append(candidate_model)
+        candidate_model = candidate_model.replace(parent_model='base_metabolite')
+        if presystemic:
+            models.append(candidate_model)
 
         candidate_model = add_peripheral_compartment(candidate_model, "METABOLITE")
         candidate_model = set_name(
-            candidate_model, f'{"presystemic" if presystemic else "plain"}_peripheral'
+            candidate_model, f'{"presystemic" if presystemic else "base_metabolite"}_peripheral'
         )
 
         models.append(candidate_model)

--- a/tests/tools/test_structsearch.py
+++ b/tests/tools/test_structsearch.py
@@ -99,7 +99,7 @@ def test_pkpd(load_model_for_test, testdata):
 def test_drug_metabolite(load_example_model_for_test):
     model = load_example_model_for_test("pheno")
     models = create_drug_metabolite_models(model)
-    assert len(models) == 4
+    assert len(models) == 3
 
 
 def test_create_workflow():


### PR DESCRIPTION
Possibility of specifying "drug_metabolite" modeltype within the AMD tool which will run structsearch for drug_metabolite.
Also updated structsearch for drug_metabolite to always return a drug metabolite model by using a "plain" type model as base.

In addition to these implementations. Functionality for extracting CL, V and Q parameters connected to a metabolite has been introduced for accurate extraction of all parameters of interest when running drug metabolite models.