### PR TITLE
Update $COVARIANCE command with new default options

### DIFF
--- a/src/pharmpy/model/estimation.py
+++ b/src/pharmpy/model/estimation.py
@@ -193,6 +193,11 @@ class EstimationStep(Immutable):
         +----------------------------+-----------------------+
         | Observed FIM               | $COVARIANCE MATRIX=R  |
         +----------------------------+-----------------------+
+
+        by default the following options are appended:
+        UNCONDITIONAL: The uncertainty step is implemented regardless of how the estimation step terminates.
+        PRINT=E: Print the eigenvalues of the correlation matrix.
+        PRECOND=1: Perform up to 1 preconditioning cycle on the R matrix.
         """
         return self._parameter_uncertainty_method
 

--- a/src/pharmpy/model/external/nonmem/update.py
+++ b/src/pharmpy/model/external/nonmem/update.py
@@ -1585,19 +1585,19 @@ def update_estimation(control_stream, model):
         new_parameter_uncertainty_method = est.parameter_uncertainty_method
 
     if old_parameter_uncertainty_method is None and new_parameter_uncertainty_method is not None:
-        # Add $COV
+        # Add $COVARIANCE
         last_est_rec = control_stream.get_records('ESTIMATION')[-1]
         idx_cov = control_stream.records.index(last_est_rec)
         if new_parameter_uncertainty_method == 'SANDWICH':
-            covrec_ = '$COVARIANCE'
+            covrec_ = '$COVARIANCE UNCONDITIONAL PRINT=E PRECOND=1'
         elif new_parameter_uncertainty_method == 'CPG':
-            covrec_ = '$COVARIANCE MATRIX=S'
+            covrec_ = '$COVARIANCE MATRIX=S UNCONDITIONAL PRINT=E PRECOND=1'
         elif new_parameter_uncertainty_method == 'OFIM':
-            covrec_ = '$COVARIANCE MATRIX=R'
+            covrec_ = '$COVARIANCE MATRIX=R UNCONDITIONAL PRINT=E PRECOND=1'
         covrec = create_record(f'{covrec_}\n')
         control_stream = control_stream.insert_record(covrec, at_index=idx_cov + 1)
     elif old_parameter_uncertainty_method is not None and new_parameter_uncertainty_method is None:
-        # Remove $COV
+        # Remove $COVARIANCE
         covrecs = control_stream.get_records('COVARIANCE')
         control_stream = control_stream.remove_records(covrecs)
 

--- a/tests/modeling/test_estimation_steps.py
+++ b/tests/modeling/test_estimation_steps.py
@@ -53,7 +53,7 @@ def test_set_estimation_step_est_middle(testdata, load_model_for_test):
         model, 'FOCE', interaction=True, parameter_uncertainty_method='SANDWICH', idx=0
     )
     assert (
-        '$ESTIMATION METHOD=COND INTER MAXEVAL=9990 PRINT=2 POSTHOC\n$COVARIANCE'
+        '$ESTIMATION METHOD=COND INTER MAXEVAL=9990 PRINT=2 POSTHOC\n$COVARIANCE UNCONDITIONAL PRINT=E PRECOND=1'
         in model.model_code
     )
 
@@ -92,17 +92,19 @@ def test_add_parameter_uncertainty_step(testdata, load_model_for_test):
     assert len(model.estimation_steps) == 1
     model = add_parameter_uncertainty_step(model, 'SANDWICH')
     assert len(model.estimation_steps) == 1
-    assert model.model_code.split('\n')[-2] == '$COVARIANCE'
+    assert model.model_code.split('\n')[-2] == '$COVARIANCE UNCONDITIONAL PRINT=E PRECOND=1'
     model = remove_parameter_uncertainty_step(model)
     model = add_parameter_uncertainty_step(model, 'CPG')
     assert len(model.estimation_steps) == 1
-    assert model.model_code.split('\n')[-2] == '$COVARIANCE MATRIX=S'
+    assert (
+        model.model_code.split('\n')[-2] == '$COVARIANCE MATRIX=S UNCONDITIONAL PRINT=E PRECOND=1'
+    )
 
 
 def test_remove_parameter_uncertainty_step(testdata, load_model_for_test):
     model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     model = add_parameter_uncertainty_step(model, 'SANDWICH')
-    assert model.model_code.split('\n')[-2] == '$COVARIANCE'
+    assert model.model_code.split('\n')[-2] == '$COVARIANCE UNCONDITIONAL PRINT=E PRECOND=1'
     model = remove_parameter_uncertainty_step(model)
     assert (
         model.model_code.split('\n')[-2]

--- a/tests/nonmem/test_nonmem_model.py
+++ b/tests/nonmem/test_nonmem_model.py
@@ -696,9 +696,21 @@ $ESTIMATION METHOD=1 SADDLE_RESET=1
     [
         ('$EST METH=COND INTER', {'method': 'fo'}, '$ESTIMATION METHOD=ZERO INTER'),
         ('$EST METH=COND INTER', {'interaction': False}, '$ESTIMATION METHOD=COND'),
-        ('$EST METH=COND INTER', {'parameter_uncertainty_method': 'sandwich'}, '$COVARIANCE'),
-        ('$EST METH=COND INTER', {'parameter_uncertainty_method': 'cpg'}, '$COVARIANCE MATRIX=S'),
-        ('$EST METH=COND INTER', {'parameter_uncertainty_method': 'ofim'}, '$COVARIANCE MATRIX=R'),
+        (
+            '$EST METH=COND INTER',
+            {'parameter_uncertainty_method': 'sandwich'},
+            '$COVARIANCE UNCONDITIONAL PRINT=E PRECOND=1',
+        ),
+        (
+            '$EST METH=COND INTER',
+            {'parameter_uncertainty_method': 'cpg'},
+            '$COVARIANCE MATRIX=S UNCONDITIONAL PRINT=E PRECOND=1',
+        ),
+        (
+            '$EST METH=COND INTER',
+            {'parameter_uncertainty_method': 'ofim'},
+            '$COVARIANCE MATRIX=R UNCONDITIONAL PRINT=E PRECOND=1',
+        ),
         (
             '$EST METH=COND INTER MAXEVAL=99999',
             {'method': 'fo'},


### PR DESCRIPTION
This commit enriches the $COVARIANCE command with more detailed default options (UNCONDITIONAL, PRINT=E, PRECOND=1), enhancing the output and success rate of the covariance step.

* Modified docstring in estimation.py to explain the new default options.
* Updated update.py to incorporate the new default options in the $COVARIANCE command.
* Adjusted test cases in test_estimation_steps.py and test_nonmem_model.py to reflect and test the new defaults.

These improvements aim to facilitate more insightful and stable model development.