### PR TITLE
Don't always add `IMP EONLY=1` when running `estmethod`

### DIFF
--- a/tests/integration/test_estmethod.py
+++ b/tests/integration/test_estmethod.py
@@ -10,7 +10,8 @@ from pharmpy.tools import run_estmethod
         ('exhaustive', ['foce', 'imp'], None, 2, 'ADVAN2'),
         ('exhaustive_only_eval', ['foce', 'imp'], None, 2, 'ADVAN2'),
         ('exhaustive', ['foce'], ['sandwich', 'cpg'], 2, 'ADVAN2'),
-        ('exhaustive_with_update', ['foce'], ['sandwich', 'cpg'], 3, 'ADVAN2'),
+        ('exhaustive_with_update', ['foce'], ['sandwich', 'cpg'], 4, 'ADVAN2'),
+        ('exhaustive_with_update', ['imp'], ['sandwich', 'cpg'], 5, 'ADVAN2'),
     ],
 )
 def test_estmethod(

--- a/tests/tools/test_estmethod.py
+++ b/tests/tools/test_estmethod.py
@@ -48,11 +48,25 @@ def test_algorithm(algorithm, methods, solvers, parameter_uncertainty_methods, n
         ),
     ],
 )
-def test_create_candidate_model(load_model_for_test, pheno_path, method, est_rec, eval_rec):
+def test_create_candidate_model(
+    load_model_for_test,
+    pheno_path,
+    method,
+    est_rec,
+    eval_rec,
+    parameter_uncertainty_method=None,
+    add_eval_after_est=True,
+):
     model = load_model_for_test(pheno_path)
     assert len(model.estimation_steps) == 1
     candidate_model = _create_candidate_model(
-        method, None, None, model=model, update_inits=False, only_evaluation=False
+        method,
+        None,
+        parameter_uncertainty_method,
+        add_eval_after_est,
+        update_inits=False,
+        only_evaluation=False,
+        model=model,
     )
     assert len(candidate_model.estimation_steps) == 2
     assert candidate_model.model_code.split('\n')[-5] == est_rec

--- a/tests/tools/test_estmethod.py
+++ b/tests/tools/test_estmethod.py
@@ -48,15 +48,15 @@ def test_algorithm(algorithm, methods, solvers, parameter_uncertainty_methods, n
         ),
     ],
 )
-def test_create_est_model(load_model_for_test, pheno_path, method, est_rec, eval_rec):
+def test_create_candidate_model(load_model_for_test, pheno_path, method, est_rec, eval_rec):
     model = load_model_for_test(pheno_path)
     assert len(model.estimation_steps) == 1
-    est_model = _create_candidate_model(
+    candidate_model = _create_candidate_model(
         method, None, None, model=model, update_inits=False, only_evaluation=False
     )
-    assert len(est_model.estimation_steps) == 2
-    assert est_model.model_code.split('\n')[-5] == est_rec
-    assert est_model.model_code.split('\n')[-4] == eval_rec
+    assert len(candidate_model.estimation_steps) == 2
+    assert candidate_model.model_code.split('\n')[-5] == est_rec
+    assert candidate_model.model_code.split('\n')[-4] == eval_rec
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_estmethod.py
+++ b/tests/tools/test_estmethod.py
@@ -12,6 +12,7 @@ from pharmpy.tools.estmethod.tool import SOLVERS, create_workflow, validate_inpu
         ('exhaustive', ['foce', 'imp'], ['lsoda'], None, 2),
         ('exhaustive', ['foce'], 'all', None, len(SOLVERS)),
         ('exhaustive_with_update', ['foce'], None, None, 2),
+        ('exhaustive_with_update', ['foce'], None, 'all', 6),
         ('exhaustive_with_update', ['foce', 'laplace'], None, None, 4),
         ('exhaustive_with_update', ['laplace'], None, None, 3),
         ('exhaustive_with_update', ['foce'], ['lsoda'], None, 3),


### PR DESCRIPTION
With the modifications in this PR, `IMP EONLY=1` will only be added when multiple estimation methods are to be compared or when the `exhaustive_only_eval` is used.

Previously, the IMP evaluation was automatically added to every model during the run of the `estmethod` tool when only evaluating different `$COV`, and it couldn't be disabled.

Resolves: First point in issue #1899 