### PR TITLE
Add `$DESIGN` (EFIM) support

### DIFF
--- a/src/pharmpy/model/estimation.py
+++ b/src/pharmpy/model/estimation.py
@@ -18,7 +18,7 @@ class EstimationStep(Immutable):
     """
     supported_methods = frozenset(('FO', 'FOCE', 'ITS', 'IMPMAP', 'IMP', 'SAEM', 'BAYES'))
     supported_solvers = frozenset(('CVODES', 'DGEAR', 'DVERK', 'IDA', 'LSODA', 'LSODI'))
-    supported_parameter_uncertainty_methods = frozenset(('SANDWICH', 'CPG', 'OFIM'))
+    supported_parameter_uncertainty_methods = frozenset(('SANDWICH', 'CPG', 'OFIM', 'EFIM'))
 
     def __init__(
         self,
@@ -196,6 +196,8 @@ class EstimationStep(Immutable):
         | Cross-product gradient     | $COVARIANCE MATRIX=S  |
         +----------------------------+-----------------------+
         | Observed FIM               | $COVARIANCE MATRIX=R  |
+        +----------------------------+-----------------------+
+        | Expected FIM               | $DESIGN               |
         +----------------------------+-----------------------+
 
         by default the following options are appended:

--- a/src/pharmpy/model/external/nonmem/nmtran_parser.py
+++ b/src/pharmpy/model/external/nonmem/nmtran_parser.py
@@ -89,14 +89,14 @@ class NMTranControlStream:
         self._active_problem = 0
         self.abbreviated = Abbreviated(self)
 
-    def get_records(self, name):
+    def get_records(self, name, problem_no=0):
         """Return a list of all records of a certain type in the current $PROBLEM"""
         current_problem = -1
         found = []
         for record in self.records:
             if record.name == 'PROBLEM':
                 current_problem += 1
-            if current_problem == self._active_problem and record.name == name:
+            if current_problem == problem_no and record.name == name:
                 found.append(record)
         return found
 

--- a/tests/modeling/test_estimation_steps.py
+++ b/tests/modeling/test_estimation_steps.py
@@ -100,11 +100,40 @@ def test_add_parameter_uncertainty_step(testdata, load_model_for_test):
         model.model_code.split('\n')[-2] == '$COVARIANCE MATRIX=S UNCONDITIONAL PRINT=E PRECOND=1'
     )
 
+    model = remove_parameter_uncertainty_step(model)
+
+    model = add_parameter_uncertainty_step(model, "EFIM")
+    assert len(model.estimation_steps) == 1
+    assert (
+        "$ESTIMATION METHOD=COND INTER MAXEVAL=9990 PRINT=2 POSTHOC MSFO=efim.msf\n"
+        "$PROBLEM DESIGN\n"
+        "$DATA file.csv IGNORE=@ REWIND\n"
+        "$INPUT ID DV TIME\n"
+        "$MSFI efim.msf\n"
+        "$DESIGN APPROX=FO FIMDIAG=1 GROUPSIZE=1 OFVTYPE=1\n" in model.model_code
+    )
+
 
 def test_remove_parameter_uncertainty_step(testdata, load_model_for_test):
     model = load_model_for_test(testdata / 'nonmem' / 'minimal.mod')
     model = add_parameter_uncertainty_step(model, 'SANDWICH')
     assert model.model_code.split('\n')[-2] == '$COVARIANCE UNCONDITIONAL PRINT=E PRECOND=1'
+    model = remove_parameter_uncertainty_step(model)
+    assert (
+        model.model_code.split('\n')[-2]
+        == '$ESTIMATION METHOD=COND INTER MAXEVAL=9990 PRINT=2 POSTHOC'
+    )
+
+    model = add_parameter_uncertainty_step(model, "EFIM")
+    assert len(model.estimation_steps) == 1
+    assert (
+        "$ESTIMATION METHOD=COND INTER MAXEVAL=9990 PRINT=2 POSTHOC MSFO=efim.msf\n"
+        "$PROBLEM DESIGN\n"
+        "$DATA file.csv IGNORE=@ REWIND\n"
+        "$INPUT ID DV TIME\n"
+        "$MSFI efim.msf\n"
+        "$DESIGN APPROX=FO FIMDIAG=1 GROUPSIZE=1 OFVTYPE=1\n" in model.model_code
+    )
     model = remove_parameter_uncertainty_step(model)
     assert (
         model.model_code.split('\n')[-2]

--- a/tests/nonmem/test_parser.py
+++ b/tests/nonmem/test_parser.py
@@ -61,8 +61,7 @@ def test_round_trip(pheno_path):
 def test_table_columns(buf, columns):
     parser = NMTranParser()
 
-    cs = parser.parse(buf)
-    cs._active_problem = -1  # To trick cs.get_records
+    cs = parser.parse(f'$PROBLEM\n{buf}')
     parsed_columns = parse_table_columns(cs, netas=2)
     assert parsed_columns == columns
 


### PR DESCRIPTION
This PR adds EFIM (Expected Fisher Information Matrix) support.
Add 'EFIM' to `supported_parameter_uncertainty_methods` in `estimation.py`.
Introduce a new function `add_efim_records` that manipulates the control stream for EFIM calculations.

Resolves Issue #2004 