### PR TITLE
Make changes to structsearch for pkpd

### DIFF
--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -50,7 +50,7 @@ def create_pkpd_models(
     ests: pd.Series = None,
     emax_init: Optional[Union[int, float]] = None,
     ec50_init: Optional[Union[int, float]] = None,
-    mat_init: Optional[Union[int, float]] = None,
+    met_init: Optional[Union[int, float]] = None,
 ):
     """Create pkpd models
 
@@ -68,7 +68,7 @@ def create_pkpd_models(
         Initial estimate for E_max
     ec50_init : float
         Initial estimate for EC_50
-    mat_init : float
+    met_init : float
         Initial estimate for MAT (mean equilibration time)
 
     Returns
@@ -91,28 +91,29 @@ def create_pkpd_models(
 
         # Initial values
         if b_init is not None:
-            pkpd_model = set_initial_estimates(pkpd_model, b_init)
+            pkpd_model = set_initial_estimates(pkpd_model, {'POP_B': b_init})
         if ests is not None:
             pkpd_model = fix_parameters_to(pkpd_model, ests)
-
-        if emax_init is not None and ec50_init is not None:
+        if emax_init is not None:
             pkpd_model = set_initial_estimates(pkpd_model, {'POP_E_MAX': emax_init})
+        if ec50_init is not None:
             pkpd_model = set_initial_estimates(pkpd_model, {'POP_EC_50': ec50_init})
+        if emax_init is not None and ec50_init is not None:
             pkpd_model = set_initial_estimates(pkpd_model, {'POP_SLOPE': emax_init / ec50_init})
-        if mat_init is not None:
-            pkpd_model = set_initial_estimates(pkpd_model, {'POP_MET': mat_init})
+        if met_init is not None:
+            pkpd_model = set_initial_estimates(pkpd_model, {'POP_MET': met_init})
 
-        pkpd_model = unconstrain_parameters(pkpd_model, ['SLOPE'])
-        pkpd_model = set_lower_bounds(pkpd_model, {'POP_E_MAX': -1})
+        pkpd_model = unconstrain_parameters(pkpd_model, ['POP_SLOPE'])
+        pkpd_model = set_lower_bounds(pkpd_model, {'POP_E_MAX': -1.0})
 
         # Set iiv
         for parameter in ["E_MAX", "SLOPE"]:
             try:
-                pkpd_model = add_iiv(pkpd_model, [parameter], "prop")
+                pkpd_model = add_iiv(pkpd_model, [parameter], "prop", initial_estimate=0.1)
             except ValueError:
                 pass
         try:
-            pkpd_model = add_iiv(pkpd_model, 'B', "exp")
+            pkpd_model = add_iiv(pkpd_model, 'B', "exp", initial_estimate=0.1)
         except ValueError:
             pass
 

--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -69,7 +69,7 @@ def create_pkpd_models(
     ec50_init : float
         Initial estimate for EC_50
     met_init : float
-        Initial estimate for MAT (mean equilibration time)
+        Initial estimate for MET (mean equilibration time)
 
     Returns
     -------

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -131,7 +131,7 @@ def run_pkpd(context, model, b_init, emax_init, ec50_init, met_init, search_spac
     pkpd_models = create_pkpd_models(
         model,
         search_space,
-        pd_baseline_fit[0].modelfit_results.parameter_estimates,
+        b_init,
         model.modelfit_results.parameter_estimates,
         emax_init,
         ec50_init,

--- a/tests/tools/test_structsearch.py
+++ b/tests/tools/test_structsearch.py
@@ -73,10 +73,9 @@ def test_pkpd(load_model_for_test, testdata):
     search_space = "DIRECTEFFECT(*); EFFECTCOMP(*); INDIRECTEFFECT(*,*)"
     res = read_modelfit_results(testdata / "nonmem" / "pheno.mod")
     ests = res.parameter_estimates
-    e0_init = pd.Series({'POP_B': 5.75, 'IIV_B': 0.01, 'sigma': 0.33})
     model = load_model_for_test(testdata / "nonmem" / "pheno_pd.mod")
     pkpd_models = create_pkpd_models(
-        model, search_space, e0_init, ests, emax_init=2.0, ec50_init=1.0, mat_init=0.5
+        model, search_space, b_init=5.75, ests=ests, emax_init=2.0, ec50_init=1.0, met_init=0.5
     )
 
     assert len(pkpd_models) == 12


### PR DESCRIPTION
Changes to structsearch for PKPD models:

- initial estimate for baseline is used for all PKPD models
- initial estimates for IIVs is set to 0.1
- mat -> met