### PR TITLE
Correct drug metabolite filtration

### DIFF
--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -293,7 +293,7 @@ def run_amd(
     if modeltype == "drug_metabolite":
         orig_dataset = model.dataset
         # FIXME : remove
-        model = filter_dataset(model, 'DVID == 1')
+        model = filter_dataset(model, 'DVID != 2')
 
     if results is None:
         model = run_tool('modelfit', model, path=db.path / 'modelfit', resume=resume)


### PR DESCRIPTION
When implementing filter_dataset() for drug metabolite models, it was accidentally  filtered for only DVID=1 instead of all DVID different from 2. This causes an incorrect filtration of drug metabolite models and an error when running AMD.