### PR TITLE
Calculate the correct BIC for drug metabolite

### DIFF
--- a/src/pharmpy/tools/structsearch/drugmetabolite.py
+++ b/src/pharmpy/tools/structsearch/drugmetabolite.py
@@ -55,6 +55,8 @@ def create_drug_metabolite_models(model: Model) -> List[Model]:
         candidate_model = set_name(
             candidate_model, f'{"presystemic" if presystemic else "base_metabolite"}_peripheral'
         )
+        if presystemic:
+            candidate_model = candidate_model.replace(parent_model='presystemic')
 
         models.append(candidate_model)
 

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -188,7 +188,7 @@ def run_drug_metabolite(context, model):
         StructSearchResults,
         model,
         base_drug_metabolite_fit[0],
-        candidate_drug_metabolite,
+        list(drug_metabolite_models_fit),
         rank_type='bic',
         cutoff=None,
         summary_models=pd.concat(


### PR DESCRIPTION
Fix an error where the OFV value of candidate models used the OFV from the input model in drug metabolite structsearch. Also corrected so the right parent model per model is set