### PR TITLE
Fix least number of transformations for transits

### DIFF
--- a/src/pharmpy/tools/mfl/parse.py
+++ b/src/pharmpy/tools/mfl/parse.py
@@ -320,7 +320,8 @@ class ModelFeatures:
                         lnt[('TRANSITS', diff[0], depot.name)] = func_dict[
                             ('TRANSITS', diff[0], depot.name)
                         ]
-                        break
+
+                        return lnt
 
             # else take first count value of non matching depot
             depot = next(d for d in rhs_depot if d not in lhs_depot)


### PR DESCRIPTION
Fix issue where the least number of transformation encountered an error will trying to determine the LNT for search spaces where both search spaces only had one depot option for the transit argument, and it was the same for both search spaces.