### PR TITLE
Drug metabolite default search space and correct candidate models

### DIFF
--- a/docs/structsearch.rst
+++ b/docs/structsearch.rst
@@ -34,6 +34,8 @@ This will take an input model ``model`` with a ``search_space`` that includes al
 
 .. note::
     For PKPD models the input model has to be a PK model with a PKPD dataset. 
+.. note::
+    For drug_metabolite models, the argument 'route' need to be set according to the table below.
 
 
 Arguments
@@ -44,6 +46,9 @@ The arguments of the structsearch tool are listed below.
 | Argument                                        | Description                                                         |
 +=================================================+=====================================================================+
 | :ref:`type<the model types>`                    | Type of model. Can be either pkpd or drug_metabolite                |
++-------------------------------------------------+---------------------------------------------------------------------+
+| route                                           | Type of administration. Currently 'oral', 'iv' and 'ivoral'         |
+|                                                 | (currently only for drug_metabolite models)                         |
 +-------------------------------------------------+---------------------------------------------------------------------+
 | :ref:`search_space<the search space>`           | Search space of models to test (currently only for PKPD models)     |
 +-------------------------------------------------+---------------------------------------------------------------------+
@@ -137,6 +142,9 @@ Currently implemented drug metabolite models are:
     * Presystemic metabolite compartment with parent -> metabolite conversion of 100%
 
 * Presystemic drug metabolite with a (metabolite) peripheral compartment
+
+.. note::
+    Presystemic drug metabolite models are only created if route is set to 'oral' or 'ivoral'
 
 .. graphviz::
 

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -185,7 +185,7 @@ def run_amd(
         )
     )
     if not modelsearch_features:
-        if modeltype == 'basic_pk' and administration == 'oral':
+        if modeltype in ('basic_pk', 'drug_metabolite') and administration == 'oral':
             modelsearch_features = (
                 Absorption((Name('FO'), Name('ZO'), Name('SEQ-ZO-FO'))),
                 Elimination((Name('FO'),)),
@@ -193,7 +193,7 @@ def run_amd(
                 Transits((0, 1, 3, 10), Wildcard()),
                 Peripherals((0, 1)),
             )
-        elif modeltype == 'basic_pk' and administration == 'ivoral':
+        elif modeltype in ('basic_pk', 'drug_metabolite') and administration == 'ivoral':
             modelsearch_features = (
                 Absorption((Name('FO'), Name('ZO'), Name('SEQ-ZO-FO'))),
                 Elimination((Name('FO'),)),

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -253,7 +253,7 @@ def run_amd(
                 run_subfuncs['modelsearch'] = func
             # Perfomed 'after' modelsearch
             if modeltype == 'drug_metabolite':
-                func = _subfunc_structsearch(type=modeltype, path=db.path)
+                func = _subfunc_structsearch(type=modeltype, route=administration, path=db.path)
                 run_subfuncs['structsearch'] = func
         elif section == 'iivsearch':
             func = _subfunc_iiv(iiv_strategy=iiv_strategy, path=db.path)

--- a/src/pharmpy/tools/structsearch/drugmetabolite.py
+++ b/src/pharmpy/tools/structsearch/drugmetabolite.py
@@ -26,7 +26,7 @@ def create_base_metabolite(model: Model) -> Model:
     return model
 
 
-def create_drug_metabolite_models(model: Model) -> List[Model]:
+def create_drug_metabolite_models(model: Model, route: str) -> List[Model]:
     """
     Create candidate models for drug metabolite model structsearch.
     Currently applies a PLAIN metabolite model with and without a connected
@@ -36,6 +36,8 @@ def create_drug_metabolite_models(model: Model) -> List[Model]:
     ----------
     model : Model
         Base model for search.
+    route : str
+        Type of administration. Currently 'oral', 'iv' and 'ivoral'
 
     Returns
     -------
@@ -43,7 +45,11 @@ def create_drug_metabolite_models(model: Model) -> List[Model]:
         A list of candidate models.
     """
     models = []
-    for presystemic in [False, True]:
+    if route not in ('oral', 'ivoral'):
+        presystemic_option = [False]
+    else:
+        presystemic_option = [False, True]
+    for presystemic in presystemic_option:
         candidate_model = add_metabolite(model, presystemic=presystemic)
         candidate_model = set_name(candidate_model, 'presystemic')
 

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -9,7 +9,7 @@ from pharmpy.internals.fn.signature import with_same_arguments_as
 from pharmpy.internals.fn.type import with_runtime_arguments_type_check
 from pharmpy.model import Model
 from pharmpy.tools import summarize_modelfit_results
-from pharmpy.tools.common import ToolResults, create_results
+from pharmpy.tools.common import ToolResults, create_results, update_initial_estimates
 from pharmpy.tools.modelfit import create_fit_workflow
 from pharmpy.workflows import Task, Workflow, WorkflowBuilder, call_workflow
 from pharmpy.workflows.results import ModelfitResults
@@ -168,6 +168,7 @@ def run_pkpd(context, model, search_space, b_init, emax_init, ec50_init, met_ini
 
 
 def run_drug_metabolite(context, model, route):
+    model = update_initial_estimates(model)
     base_drug_metabolite = create_base_metabolite(model)
     candidate_drug_metabolite = create_drug_metabolite_models(model, route)
 

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -19,10 +19,12 @@ from .pkpd import create_baseline_pd_model, create_pkpd_models
 from .tmdd import create_qss_models, create_remaining_models
 
 TYPES = frozenset(('pkpd', 'drug_metabolite', 'tmdd'))
+routes = frozenset(('iv', 'oral', 'ivoral'))
 
 
 def create_workflow(
     type: str,
+    route: Optional[str] = 'oral',
     search_space: Optional[str] = None,
     b_init: Optional[Union[int, float]] = None,
     emax_init: Optional[Union[int, float]] = None,
@@ -38,6 +40,8 @@ def create_workflow(
     ----------
     type : str
         Type of model. Currently only 'drug_metabolite' and 'pkpd'
+    route : str
+        Type of administration. Currently 'oral', 'iv' and 'ivoral'
     search_space : str
         Search space to test
     b_init: float
@@ -77,7 +81,7 @@ def create_workflow(
             'run_pkpd', run_pkpd, model, search_space, b_init, emax_init, ec50_init, met_init
         )
     elif type == 'drug_metabolite':
-        start_task = Task('run_drug_metabolite', run_drug_metabolite, model)
+        start_task = Task('run_drug_metabolite', run_drug_metabolite, model, route)
     wb.add_task(start_task)
     return Workflow(wb)
 
@@ -163,9 +167,9 @@ def run_pkpd(context, model, search_space, b_init, emax_init, ec50_init, met_ini
     )
 
 
-def run_drug_metabolite(context, model):
+def run_drug_metabolite(context, model, route):
     base_drug_metabolite = create_base_metabolite(model)
-    candidate_drug_metabolite = create_drug_metabolite_models(model)
+    candidate_drug_metabolite = create_drug_metabolite_models(model, route)
 
     # Run workflow for base model
     wf = create_fit_workflow(base_drug_metabolite)
@@ -211,11 +215,11 @@ def _results(model):
 
 @with_runtime_arguments_type_check
 @with_same_arguments_as(create_workflow)
-def validate_input(
-    type,
-):
+def validate_input(type, route):
     if type not in TYPES:
         raise ValueError(f'Invalid `type`: got `{type}`, must be one of {sorted(TYPES)}.')
+    if route not in routes:
+        raise ValueError(f'Invalid `route`: got `{route}`, must be one of {sorted(routes)}.')
 
 
 @dataclass(frozen=True)

--- a/tests/tools/test_structsearch.py
+++ b/tests/tools/test_structsearch.py
@@ -98,8 +98,14 @@ def test_pkpd(load_model_for_test, testdata):
 
 def test_drug_metabolite(load_example_model_for_test):
     model = load_example_model_for_test("pheno")
-    models = create_drug_metabolite_models(model)
+    models = create_drug_metabolite_models(model, "oral")
     assert len(models) == 3
+
+    models = create_drug_metabolite_models(model, "ivoral")
+    assert len(models) == 3
+
+    models = create_drug_metabolite_models(model, "iv")
+    assert len(models) == 1
 
 
 def test_create_workflow():


### PR DESCRIPTION
Drug metabolite models will now run with the default modelsearch search space for the parent drug metabolite
Candidate models is also dependent on the administration route and presystemic drug metabolite models are only created for oral/ivoral administration