### PR TITLE
Implement strictness to other tools

### DIFF
--- a/src/pharmpy/tools/__init__.py
+++ b/src/pharmpy/tools/__init__.py
@@ -6,6 +6,7 @@ __all__ = (
     'create_report',  # pyright: ignore [reportUnsupportedDunderAll]
     'create_results',  # pyright: ignore [reportUnsupportedDunderAll]
     'fit',  # pyright: ignore [reportUnsupportedDunderAll]
+    'is_strictness_fulfilled',  # pyright: ignore [reportUnsupportedDunderAll]
     'load_example_modelfit_results',  # pyright: ignore [reportUnsupportedDunderAll]
     'predict_influential_individuals',  # pyright: ignore [reportUnsupportedDunderAll]
     'predict_influential_outliers',  # pyright: ignore [reportUnsupportedDunderAll]
@@ -46,6 +47,7 @@ _not_wrapped = {
     '.run': (
         'create_results',
         'fit',
+        'is_strictness_fulfilled',
         'load_example_modelfit_results',
         'print_fit_summary',
         'rank_models',

--- a/src/pharmpy/tools/common.py
+++ b/src/pharmpy/tools/common.py
@@ -90,11 +90,13 @@ def create_results(
         [base_model.modelfit_results] + [m.modelfit_results for m in res_models]
     )
 
-    try:
+    if summary_tool['rank'].isnull().all():
+        best_model = None
+    else:
         best_model_name = summary_tool['rank'].idxmin()
-    except FutureWarning:
-        raise Warning('No models to rank. Please check strictness criteria.')
-    best_model = next(filter(lambda model: model.name == best_model_name, res_models), base_model)
+        best_model = next(
+            filter(lambda model: model.name == best_model_name, res_models), base_model
+        )
 
     if base_model.name != input_model.name:
         models = [base_model] + res_models

--- a/src/pharmpy/tools/common.py
+++ b/src/pharmpy/tools/common.py
@@ -90,7 +90,10 @@ def create_results(
         [base_model.modelfit_results] + [m.modelfit_results for m in res_models]
     )
 
-    best_model_name = summary_tool['rank'].idxmin()
+    try:
+        best_model_name = summary_tool['rank'].idxmin()
+    except FutureWarning:
+        raise Warning('No models to rank. Please check strictness criteria.')
     best_model = next(filter(lambda model: model.name == best_model_name, res_models), base_model)
 
     if base_model.name != input_model.name:

--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -24,6 +24,7 @@ from pharmpy.tools.mfl.feature.covariate import (
 )
 from pharmpy.tools.mfl.parse import parse as mfl_parse
 from pharmpy.tools.modelfit import create_fit_workflow
+from pharmpy.tools.run import _is_strictness_fulfilled
 from pharmpy.tools.scm.results import candidate_summary_dataframe, ofv_summary_dataframe
 from pharmpy.workflows import Task, Workflow, WorkflowBuilder, call_workflow
 from pharmpy.workflows.results import ModelfitResults
@@ -106,6 +107,7 @@ def create_workflow(
     algorithm: str = 'scm-forward-then-backward',
     results: Optional[ModelfitResults] = None,
     model: Optional[Model] = None,
+    strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs>=0)",
 ):
     """Run COVsearch tool. For more details, see :ref:`covsearch`.
 
@@ -126,6 +128,8 @@ def create_workflow(
         Results of model
     model : Model
         Pharmpy model
+    strictness : str or None
+        Strictness criteria
 
     Returns
     -------
@@ -153,6 +157,7 @@ def create_workflow(
         effects,
         p_forward,
         max_steps,
+        strictness,
     )
 
     wb.add_task(forward_search_task, predecessors=init_task)
@@ -164,6 +169,7 @@ def create_workflow(
             task_greedy_backward_search,
             p_backward,
             max_steps,
+            strictness,
         )
 
         wb.add_task(backward_search_task, predecessors=search_output)
@@ -174,6 +180,7 @@ def create_workflow(
         task_results,
         p_forward,
         p_backward,
+        strictness,
     )
 
     wb.add_task(results_task, predecessors=search_output)
@@ -199,6 +206,7 @@ def task_greedy_forward_search(
     effects: str,
     p_forward: float,
     max_steps: int,
+    strictness: Optional[str],
     state: SearchState,
 ) -> SearchState:
     candidate = state.best_candidate_so_far
@@ -223,6 +231,7 @@ def task_greedy_forward_search(
         candidate_effects,
         p_forward,
         max_steps,
+        strictness,
     )
 
 
@@ -230,6 +239,7 @@ def task_greedy_backward_search(
     context,
     p_backward: float,
     max_steps: int,
+    strictness: Optional[str],
     state: SearchState,
 ) -> SearchState:
     def handle_effects(
@@ -253,6 +263,7 @@ def task_greedy_backward_search(
         candidate_effects,
         p_backward,
         min(max_steps, n_removable_effects) if max_steps >= 0 else n_removable_effects,
+        strictness,
     )
 
 
@@ -262,6 +273,7 @@ def _greedy_search(
     candidate_effects: List[EffectLiteral],
     alpha: float,
     max_steps: int,
+    strictness: Optional[str],
 ) -> SearchState:
     best_candidate_so_far = state.best_candidate_so_far
     all_candidates_so_far = list(state.all_candidates_so_far)  # NOTE: This includes start model
@@ -281,7 +293,10 @@ def _greedy_search(
 
         parent = best_candidate_so_far.model
         ofvs = [
-            np.nan if (mfr := model.modelfit_results) is None else mfr.ofv
+            np.nan
+            if (mfr := model.modelfit_results) is None
+            or not _is_strictness_fulfilled(mfr, strictness)
+            else mfr.ofv
             for model in new_candidate_models
         ]
         # NOTE: We assume parent.modelfit_results is not None
@@ -423,12 +438,13 @@ def task_remove_covariate_effect(
     return model_with_removed_effect
 
 
-def task_results(p_forward: float, p_backward: float, state: SearchState):
+def task_results(p_forward: float, p_backward: float, strictness: str, state: SearchState):
     candidates = state.all_candidates_so_far
     models = list(map(lambda candidate: candidate.model, candidates))
     base_model, *res_models = models
     assert base_model is state.start_model
     best_model = state.best_candidate_so_far.model
+    is_strict = [_is_strictness_fulfilled(model.modelfit_results, strictness) for model in models]
 
     res = create_results(
         COVSearchResults, base_model, base_model, res_models, 'lrt', (p_forward, p_backward)
@@ -441,14 +457,14 @@ def task_results(p_forward: float, p_backward: float, state: SearchState):
         steps=steps,
         candidate_summary=candidate_summary_dataframe(steps),
         ofv_summary=ofv_summary_dataframe(steps, final_included=True, iterations=True),
-        summary_tool=_modify_summary_tool(res.summary_tool, steps),
+        summary_tool=_modify_summary_tool(res.summary_tool, steps, is_strict),
         summary_models=_summarize_models(models, steps),
     )
 
     return res
 
 
-def _modify_summary_tool(summary_tool, steps):
+def _modify_summary_tool(summary_tool, steps, is_strict):
     step_cols_to_keep = ['step', 'pvalue', 'goal_pvalue', 'is_backward', 'selected', 'model']
     steps_df = steps.reset_index()[step_cols_to_keep].set_index(['step', 'model'])
 
@@ -456,6 +472,7 @@ def _modify_summary_tool(summary_tool, steps):
     column_to_move = summary_tool_new.pop('description')
 
     summary_tool_new.insert(0, 'description', column_to_move)
+    summary_tool_new['strictness_fulfilled'] = is_strict
     return summary_tool_new.drop(['rank'], axis=1)
 
 
@@ -576,7 +593,7 @@ def _make_df_steps_row(
 
 @with_runtime_arguments_type_check
 @with_same_arguments_as(create_workflow)
-def validate_input(effects, p_forward, p_backward, algorithm, model):
+def validate_input(effects, p_forward, p_backward, algorithm, model, strictness):
     if algorithm not in ALGORITHMS:
         raise ValueError(
             f'Invalid `algorithm`: got `{algorithm}`, must be one of {sorted(ALGORITHMS)}.'
@@ -645,3 +662,8 @@ def validate_input(effects, p_forward, p_backward, algorithm, model):
                     f' effects: got `{effect.operation}`,'
                     f' must be in {sorted(allowed_ops)}.'
                 )
+    if strictness is not None and "rse" in strictness.lower():
+        if model.estimation_steps[-1].parameter_uncertainty_method is None:
+            raise ValueError(
+                'parameter_uncertainty_method not set for model, cannot calculate relative standard errors.'
+            )

--- a/src/pharmpy/tools/run.py
+++ b/src/pharmpy/tools/run.py
@@ -876,7 +876,7 @@ class ArrayEvaluator:
         return all(e > value for e in self.x)
 
 
-def _is_strictness_fulfilled(res: ModelfitResults, statement: str) -> bool:
+def is_strictness_fulfilled(res: ModelfitResults, statement: str) -> bool:
     """Takes a ModelfitResults object  and a statement as input and returns True/False
     if the evaluation of the statement is True/False.
     """
@@ -938,7 +938,7 @@ def _is_strictness_fulfilled(res: ModelfitResults, statement: str) -> bool:
 
 
 def _get_rankval(model, strictness, rank_type, bic_type, **kwargs):
-    if not _is_strictness_fulfilled(model.modelfit_results, strictness):
+    if not is_strictness_fulfilled(model.modelfit_results, strictness):
         return np.nan
     if rank_type in ['ofv', 'lrt']:
         return model.modelfit_results.ofv

--- a/src/pharmpy/tools/ruvsearch/tool.py
+++ b/src/pharmpy/tools/ruvsearch/tool.py
@@ -55,6 +55,7 @@ def create_workflow(
     skip: Optional[List[str]] = None,
     max_iter: int = 3,
     dv: Optional[int] = None,
+    strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs>=0)",
 ):
     """Run the ruvsearch tool. For more details, see :ref:`ruvsearch`.
 
@@ -74,6 +75,8 @@ def create_workflow(
         Number of iterations to run (1, 2, or 3). For models with BLQ only one iteration is supported.
     dv : int
         Which DV to assess the error model for.
+    strictness : str or None
+        Strictness criteria
 
     Returns
     -------
@@ -91,7 +94,9 @@ def create_workflow(
     """
 
     wb = WorkflowBuilder(name="ruvsearch")
-    start_task = Task('start_ruvsearch', start, model, groups, p_value, skip, max_iter, dv)
+    start_task = Task(
+        'start_ruvsearch', start, model, groups, p_value, skip, max_iter, dv, strictness
+    )
     wb.add_task(start_task)
     task_results = Task('results', _results)
     wb.add_task(task_results, predecessors=[start_task])
@@ -180,7 +185,7 @@ def _change_proportional_name(model):
     return model
 
 
-def start(context, model, groups, p_value, skip, max_iter, dv):
+def start(context, model, groups, p_value, skip, max_iter, dv, strictness):
     cutoff = float(stats.chi2.isf(q=p_value, df=1))
     if skip is None:
         skip = []
@@ -231,7 +236,7 @@ def start(context, model, groups, p_value, skip, max_iter, dv):
     sum_models = summarize_modelfit_results(model_results)
     sum_models['step'] = list(range(len(sum_models)))
     summf = sum_models.reset_index().set_index(['step', 'model'])
-    summary_tool = _create_summary_tool(selected_models, cutoff)
+    summary_tool = _create_summary_tool(selected_models, cutoff, strictness)
     summary_errors = summarize_errors(m.modelfit_results for m in selected_models)
 
     res = RUVSearchResults(
@@ -247,14 +252,14 @@ def start(context, model, groups, p_value, skip, max_iter, dv):
     return res
 
 
-def _create_summary_tool(selected_models, cutoff):
+def _create_summary_tool(selected_models, cutoff, strictness):
     model_names = [model.name for model in selected_models]
     iteration_map = {model.name: model_names.index(model.name) for model in selected_models}
 
     base_model = selected_models[0]
     ruvsearch_models = selected_models[1:]
 
-    sum_tool = summarize_tool(ruvsearch_models, base_model, 'ofv', cutoff).reset_index()
+    sum_tool = summarize_tool(ruvsearch_models, base_model, 'ofv', cutoff, strictness).reset_index()
     sum_tool['step'] = sum_tool['model'].map(iteration_map)
     sum_tool_by_iter = sum_tool.set_index(['step', 'model']).sort_index()
 
@@ -512,7 +517,7 @@ def _create_best_model(model, res, current_iteration, dv, groups=4, cutoff=3.84)
 
 @with_runtime_arguments_type_check
 @with_same_arguments_as(create_workflow)
-def validate_input(model, groups, p_value, skip, max_iter, dv):
+def validate_input(model, groups, p_value, skip, max_iter, dv, strictness):
     if groups <= 0:
         raise ValueError(f'Invalid `groups`: got `{groups}`, must be >= 1.')
 
@@ -555,3 +560,9 @@ def validate_input(model, groups, p_value, skip, max_iter, dv):
             else:
                 if dv not in set(model.dataset['DVID']):
                     raise ValueError(f"No DVID = {dv} in dataset.")
+
+    if strictness is not None and "rse" in strictness.lower():
+        if model.estimation_steps[-1].parameter_uncertainty_method is None:
+            raise ValueError(
+                'parameter_uncertainty_method not set for model, cannot calculate relative standard errors.'
+            )

--- a/tests/integration/test_amd.py
+++ b/tests/integration/test_amd.py
@@ -31,6 +31,7 @@ def test_amd(tmp_path, testdata):
             administration='oral',
             search_space='PERIPHERALS(1)',
             occasion='VISI',
+            strictness='minimization_successful or rounding_errors',
         )
 
         rundir = tmp_path / 'amd_dir1'

--- a/tests/tools/test_run.py
+++ b/tests/tools/test_run.py
@@ -15,8 +15,8 @@ from pharmpy.tools.run import (  # retrieve_final_model,; retrieve_models,
     _create_metadata_common,
     _create_metadata_tool,
     _get_run_setup,
-    _is_strictness_fulfilled,
     import_tool,
+    is_strictness_fulfilled,
     load_example_modelfit_results,
     rank_models,
     read_modelfit_results,
@@ -531,4 +531,4 @@ def test_load_example_modelfit_results():
 )
 def test_strictness(testdata, path, statement, expected):
     res = read_modelfit_results(testdata / path)
-    assert _is_strictness_fulfilled(res, statement) == expected
+    assert is_strictness_fulfilled(res, statement) == expected


### PR DESCRIPTION
Add strictness to
- IIVSearch
- IOVSearch
- COVSearch
- RUVSearch
- AMD

Add a warning when all models fail the strictness criteria.

COVSearch: Add column 'strictness_fulfilled' to summarize_tool table that states whether the model is passing or failing the strictness criteria.