### PR TITLE
Fix parameter issue for models with mixed-fo-mm elimination

### DIFF
--- a/src/pharmpy/modeling/odes.py
+++ b/src/pharmpy/modeling/odes.py
@@ -184,7 +184,13 @@ def set_first_order_elimination(model: Model):
         v = sympy.Symbol('V')
         rate = odes.get_flow(central, output)
         if v not in rate.free_symbols:
-            v = sympy.Symbol('VC')
+            # take first parameter that starts with 'V' and is no longer than 2 characters
+            v = [
+                idx
+                for idx in list(map(lambda x: str(x), rate.free_symbols))
+                if idx[0] == 'V' and len(idx) <= 2
+            ]
+            v = sympy.Symbol(v[0])
         cb = CompartmentalSystemBuilder(odes)
         cb.remove_flow(central, output)
         cb.add_flow(central, output, sympy.Symbol('CL') / v)
@@ -201,7 +207,12 @@ def set_first_order_elimination(model: Model):
         v = sympy.Symbol('V')
         rate = odes.get_flow(central, output)
         if v not in rate.free_symbols:
-            v = sympy.Symbol('VC')
+            v = [
+                idx
+                for idx in list(map(lambda x: str(x), rate.free_symbols))
+                if idx[0] == 'V' and len(idx) <= 2
+            ]
+            v = sympy.Symbol(v[0])
         cb = CompartmentalSystemBuilder(odes)
         cb.remove_flow(central, output)
         cb.add_flow(central, output, sympy.Symbol('CL') / v)

--- a/src/pharmpy/modeling/tmdd.py
+++ b/src/pharmpy/modeling/tmdd.py
@@ -11,6 +11,7 @@ from pharmpy.model import (
     output,
 )
 
+from .expressions import _replace_trivial_redefinitions
 from .odes import add_individual_parameter, set_first_order_elimination, set_initial_condition
 from .parameter_variability import add_iiv
 
@@ -44,6 +45,7 @@ def set_tmdd(model: Model, type: str):
     type = type.upper()
 
     if type != "MMAPP":
+        model = _replace_trivial_redefinitions(model)
         model = set_first_order_elimination(model)
 
     odes = model.statements.ode_system

--- a/tests/modeling/test_tmdd.py
+++ b/tests/modeling/test_tmdd.py
@@ -1,6 +1,6 @@
 import sympy
 
-from pharmpy.modeling import add_peripheral_compartment, set_tmdd
+from pharmpy.modeling import add_peripheral_compartment, set_mixed_mm_fo_elimination, set_tmdd
 
 
 def test_full(pheno_path, load_model_for_test):
@@ -25,7 +25,7 @@ def test_qss_1c(pheno_path, load_model_for_test):
     tmdd_model = set_tmdd(model, type="qss")
     assert (
         str(tmdd_model.statements.ode_system.eqs[0].rhs)
-        == """-CL*LAFREE/V1 - KINT*LAFREE*A_TARGET(t)/(KD + LAFREE) - LAFREE*Q/V1 + Q*A_PERIPHERAL1(t)/V2"""
+        == """-CL*LAFREE/V1 - KINT*LAFREE*A_TARGET(t)/(KD + LAFREE) - LAFREE*QP1/V1 + QP1*A_PERIPHERAL1(t)/VP1"""
     )
 
     model2 = add_peripheral_compartment(model)
@@ -65,3 +65,11 @@ def test_wagner(pheno_path, load_model_for_test):
     model = load_model_for_test(pheno_path)
     model = add_peripheral_compartment(model)
     model = set_tmdd(model, type="wagner")
+
+
+def test_tmdd_with_mixed_fo_mm_elimination(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    model = add_peripheral_compartment(model)
+    model = set_mixed_mm_fo_elimination(model)
+    qss = set_tmdd(model, 'qss')
+    assert qss


### PR DESCRIPTION
There was an issue when creating QSS models from a model with mixed MM FO elimination. 
One problem was that in `set_first_order_elimination` the volume parameter was either 'V' or 'VC' but could not be e.g. 'V1'. This created problems in some cases.
Another problem was that for some models too many statements for the volume parameter were added. E.g. 
`VC = ...`
`V = VC`
`V1 = V`
That caused problems. 

