### PR TITLE
Add MFL for drug metabolite

### DIFF
--- a/docs/structsearch.rst
+++ b/docs/structsearch.rst
@@ -34,8 +34,6 @@ This will take an input model ``model`` with a ``search_space`` that includes al
 
 .. note::
     For PKPD models the input model has to be a PK model with a PKPD dataset. 
-.. note::
-    For drug_metabolite models, the argument 'route' need to be set according to the table below.
 
 
 Arguments
@@ -47,10 +45,7 @@ The arguments of the structsearch tool are listed below.
 +=================================================+=====================================================================+
 | :ref:`type<the model types>`                    | Type of model. Can be either pkpd or drug_metabolite                |
 +-------------------------------------------------+---------------------------------------------------------------------+
-| route                                           | Type of administration. Currently 'oral', 'iv' and 'ivoral'         |
-|                                                 | (currently only for drug_metabolite models)                         |
-+-------------------------------------------------+---------------------------------------------------------------------+
-| :ref:`search_space<the search space>`           | Search space of models to test (currently only for PKPD models)     |
+| :ref:`search_space<the search space>`           | Search space of models to test                                      |
 +-------------------------------------------------+---------------------------------------------------------------------+
 | b_init (optional, default is 0.1)               | Initial estimate for baseline effect (only for PKPD models)         |
 +-------------------------------------------------+---------------------------------------------------------------------+
@@ -139,20 +134,25 @@ Drug metabolite
 
 Currently implemented drug metabolite models are:
 
-* Base metabolite
+* Basic metabolite
 
     * Single metabolite compartment with parent -> metabolite conversion of 100%
 
-* Base metabolite with a (metabolite) peripheral compartment
+* Basic metabolite with a (metabolite) peripheral compartment(s)
 
-* Presystemic drug metabolite
+* Presystemic drug metabolite (PSC)
 
     * Presystemic metabolite compartment with parent -> metabolite conversion of 100%
 
-* Presystemic drug metabolite with a (metabolite) peripheral compartment
+* Presystemic drug metabolite with a (metabolite) peripheral compartment(s)
 
-.. note::
-    Presystemic drug metabolite models are only created if route is set to 'oral' or 'ivoral'
+The graph below show how the drug metabolite models are built, with each of the two types 
+of drug metabolite models (basic and pre-systemic) with and without added peripherals.
+For reasons explained above, one of the created candidate models will be chosen as 
+the base model (shown by a square). The base model is chosen as one of the candidate models
+with the fewewst amount of peripheral compartments as possible, with "BASIC" being chosen over
+"PSC". If the inputed model is a drug_metabolite model, this will be used as the base model 
+instead.
 
 .. graphviz::
 
@@ -160,15 +160,22 @@ Currently implemented drug metabolite models are:
             node [fontname="Arial"]
             base [label="Base model"]
             s1 [label="Base metabolite";shape = rect;]
-            s2 [label="Base metabolite with peripheral"]
-            s3 [label="Presystemic metabolite"]
-            s4 [label="Presystemic metabolite with peripheral"]
+            s2 [label="PERIPHERALS(0)"]
+            s3 [label="PERIPHERALS(1)"]
+            s4 [label="Presystemic metabolite"]
+            s5 [label="PERIPHERALS(0)"]
+            s6 [label="PERIPHERALS(1)"]
 
             base -> s1
             s1 -> s2
-            base -> s3
-            s3 -> s4
+            s1 -> s3
+            base -> s4
+            s4 -> s5
+            s4 -> s6
     }
+
+.. note::
+    Peripheral compartments are added using the see :ref:`exhaustive stepwise search algorithm<algorithms_modelsearch>`.
 
 Regarding DVID, DVID=1 is connected to the parent drug while DVID=2 is representing the metabolite.
 
@@ -246,10 +253,6 @@ The model feature search space is a set of possible combinations of model featur
 the input model. The supported features cover absorption, absorption delay, elimination, and distribution. The search
 space is given as a string with a specific grammar, according to the `Model Feature Language` (MFL) (see :ref:`detailed description<mfl>`).
 
-.. note::
-    At the moment a search space is only defined for PKPD models.
-
-
 PKPD
 ~~~~
 
@@ -284,9 +287,48 @@ Search space for testing linear and emax models for direct effect and effect com
     DIRECTEFFECT([linear, emax])
     EFFECTCOMP([linear, emax])
 
+Drug metabolite
+~~~~
+
+MFL support the following model features:
+
++---------------+-------------------------------+--------------------------------------------------------------------+
+| Category      | Options                       | Description                                                        |
++===============+===============================+====================================================================+
+| METABOLITE    | :code:`PSC, BASIC`            | Type of drug metabolite model to add. PSC is for presystemic       |
++---------------+-------------------------------+--------------------------------------------------------------------+
+| PERIPHERALS    | `number`, MET                | Regular PERIPHERALS with second option set to MET                  |
++---------------+-------------------------------+--------------------------------------------------------------------+
+
+A search space for testing both BASIC and PSC (presystemic) drug metabolite models with 0 or 1 peripheral compartments 
+for the metabolite compartment would look like:
+.. code-block::
+
+    METABOLITE([BASIC,PSC]);PERIPHERALS(0..1,MET)
+
+
+This can be combined with the search space for the modelsearch tool by simply adding the drug metabolite features to it.
+Please see the example below. Note that two peripherals statements are present, one for the drug and one for the metabolite.
+
+.. code-block::
+
+    ABSORPTION(FO);ELIMINATION(FO);PERIPHERALS(0,1);METABOLITE(PSC);PERIPHERAL(0..1,MET)
+
+When running through AMD, if a search space is not specified, a default one will be taken based on the administration type.
+
+If administration is oral or ivoral, the search space will be as follows:
+
+.. code-block::
+
+    METABOLITE([BASIC,PSC]);PERIPHERALS(0..1,MET)
+
+But with an iv administration instead, the default search space becomes:
+
+.. code-block::
+
+    METABOLITE(BASIC);PERIPHERALS(0..1,MET)
 
 .. _the structsearch results:
-
 
 ~~~~~~~~~~~~~~~~~~~~~~~~
 The Structsearch results

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -239,7 +239,10 @@ MFL support the following model features:
 | ELIMINATION   | :code:`FO, ZO, MM, MIX-FO-MM`  | Elimination rate (first order, zero order, Michaelis-Menten,       |
 |               |                                | mixed first order Michaelis-Menten)                                |
 +---------------+--------------------------------+--------------------------------------------------------------------+
-| PERIPHERALS   | `number`                       | Number of peripheral compartments                                  |
+| PERIPHERALS   | `number`, DRUG/MET             | Number of peripheral compartments. If the peripherals compartment  |
+|               |                                | should be added for the drug compartment (default) or to the       |
+|               |                                | metabolite compartment (if any). Only applicable to drug_metabolite|
+|               |                                | models.                                                            |
 +---------------+--------------------------------+--------------------------------------------------------------------+
 | TRANSITS      | `number`, DEPOT/NODEPOT        | Number of absorption transit compartments. Whether convert depot   |
 |               |                                | compartment into a transit compartment                             |

--- a/src/pharmpy/modeling/odes.py
+++ b/src/pharmpy/modeling/odes.py
@@ -1742,8 +1742,11 @@ def _get_absorption_init(model, param_name) -> float:
     raise NotImplementedError('param_name must be MDT or MAT')
 
 
-def set_peripheral_compartments(model: Model, n: int):
-    """Sets the number of peripheral compartments to a specified number.
+def set_peripheral_compartments(model: Model, n: int, name: str = None):
+    """Sets the number of peripheral compartments for central compartment to a specified number.
+
+    If name is set, the peripheral compartment will be added to the compartment
+    with the specified name instead.
 
     Parameters
     ----------
@@ -1751,6 +1754,8 @@ def set_peripheral_compartments(model: Model, n: int):
         Pharmpy model
     n : int
         Number of transit compartments
+    name : str
+        Name of compartment to add peripheral to.
 
     Return
     ------
@@ -1796,10 +1801,10 @@ def set_peripheral_compartments(model: Model, n: int):
     per = len(odes.find_peripheral_compartments())
     if per < n:
         for _ in range(n - per):
-            model = add_peripheral_compartment(model)
+            model = add_peripheral_compartment(model, name=name)
     elif per > n:
         for _ in range(per - n):
-            model = remove_peripheral_compartment(model)
+            model = remove_peripheral_compartment(model, name=name)
     return model
 
 

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -16,9 +16,9 @@ from pharmpy.tools.allometry.tool import validate_allometric_variable
 from pharmpy.tools.mfl.feature.covariate import covariates as extract_covariates
 from pharmpy.tools.mfl.feature.covariate import spec as covariate_spec
 from pharmpy.tools.mfl.filter import (
-    covsearch_statement_types,
-    modelsearch_statement_types,
-    structsearch_statement_types,
+    COVSEARCH_STATEMENT_TYPES,
+    STRUCTSEARCH_STATEMENT_TYPES,
+    mfl_filtering,
 )
 from pharmpy.tools.mfl.parse import ModelFeatures, get_model_features
 from pharmpy.tools.mfl.parse import parse as mfl_parse
@@ -144,7 +144,7 @@ def run_amd(
 
         structsearch_features = tuple(
             filter(
-                lambda statement: isinstance(statement, structsearch_statement_types),
+                lambda statement: isinstance(statement, STRUCTSEARCH_STATEMENT_TYPES),
                 input_search_space_features,
             )
         )
@@ -232,7 +232,7 @@ def run_amd(
 
     covsearch_features = tuple(
         filter(
-            lambda statement: isinstance(statement, covsearch_statement_types),
+            lambda statement: isinstance(statement, COVSEARCH_STATEMENT_TYPES),
             input_search_space_features,
         )
     )

--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -28,7 +28,7 @@ from pharmpy.tools.scm.results import candidate_summary_dataframe, ofv_summary_d
 from pharmpy.workflows import Task, Workflow, WorkflowBuilder, call_workflow
 from pharmpy.workflows.results import ModelfitResults
 
-from ..mfl.filter import covsearch_statement_types
+from ..mfl.filter import COVSEARCH_STATEMENT_TYPES
 from ..mfl.parse import ModelFeatures, get_model_features
 from .results import COVSearchResults
 
@@ -662,7 +662,7 @@ def validate_input(effects, p_forward, p_backward, algorithm, model, strictness)
 
         bad_statements = list(
             filter(
-                lambda statement: not isinstance(statement, covsearch_statement_types),
+                lambda statement: not isinstance(statement, COVSEARCH_STATEMENT_TYPES),
                 statements,
             )
         )

--- a/src/pharmpy/tools/mfl/feature/metabolite.py
+++ b/src/pharmpy/tools/mfl/feature/metabolite.py
@@ -1,0 +1,24 @@
+from functools import partial
+from typing import Iterable
+
+from pharmpy.model import Model
+from pharmpy.modeling import add_metabolite
+
+from ..statement.feature.metabolite import Metabolite
+from ..statement.feature.symbols import Name, Wildcard
+from ..statement.statement import Statement
+from .feature import Feature
+
+
+def features(model: Model, statements: Iterable[Statement]) -> Iterable[Feature]:
+    for statement in statements:
+        if isinstance(statement, Metabolite):
+            modes = (
+                [Name('BASIC'), Name('PSC')]
+                if isinstance(statement.modes, Wildcard)
+                else statement.modes
+            )
+            for mode in modes:
+                yield ('METABOLITE', mode.name), partial(
+                    add_metabolite, presystemic=True if mode.name == "PSC" else False
+                )

--- a/src/pharmpy/tools/mfl/feature/peripherals.py
+++ b/src/pharmpy/tools/mfl/feature/peripherals.py
@@ -13,4 +13,16 @@ def features(model: Model, statements: Iterable[Statement]) -> Iterable[Feature]
     for statement in statements:
         if isinstance(statement, Peripherals):
             for count in statement.counts:
-                yield ('PERIPHERALS', count), partial(set_peripheral_compartments, n=count)
+                for mode in statement.modes:
+                    if mode.name == "DRUG":
+                        yield ('PERIPHERALS', count), partial(set_peripheral_compartments, n=count)
+                    elif mode.name == "MET":
+                        # TODO: Update how we find name of metabolite compartment
+                        name = "METABOLITE"
+                        yield ('PERIPHERALS', count), partial(
+                            set_peripheral_compartments, n=count, name=name
+                        )
+                    else:
+                        raise ValueError(
+                            f"Unknown mode ({mode.name}) for peripheral compartment specified"
+                        )

--- a/src/pharmpy/tools/mfl/filter.py
+++ b/src/pharmpy/tools/mfl/filter.py
@@ -6,14 +6,16 @@ from pharmpy.tools.mfl.statement.feature.effect_comp import EffectComp
 from pharmpy.tools.mfl.statement.feature.elimination import Elimination
 from pharmpy.tools.mfl.statement.feature.indirect_effect import IndirectEffect
 from pharmpy.tools.mfl.statement.feature.lagtime import LagTime
+from pharmpy.tools.mfl.statement.feature.metabolite import Metabolite
 from pharmpy.tools.mfl.statement.feature.peripherals import Peripherals
 from pharmpy.tools.mfl.statement.feature.transits import Transits
+
+from .statement.feature.symbols import Name
 
 modelsearch_statement_types = (
     Absorption,
     Elimination,
     LagTime,
-    Peripherals,
     Transits,
 )
 
@@ -23,4 +25,23 @@ covsearch_statement_types = (
 )
 
 
-structsearch_statement_types = (DirectEffect, EffectComp, IndirectEffect)
+structsearch_statement_types = (DirectEffect, EffectComp, IndirectEffect, Metabolite)
+
+
+def mfl_filtering(statements, tool_name):
+    assert tool_name in ["structsearch", "modelsearch"]
+
+    if tool_name == "modelsearch":
+        statement_types = modelsearch_statement_types
+        peripheral_name = Name('DRUG')
+    elif tool_name == "structsearch":
+        statement_types = structsearch_statement_types
+        peripheral_name = Name('MET')
+
+    filtered_statements = []
+    for statement in statements:
+        if isinstance(statement, statement_types):
+            filtered_statements.append(statement)
+        elif isinstance(statement, Peripherals) and peripheral_name in statement.modes:
+            filtered_statements.append(Peripherals(statement.counts, peripheral_name))
+    return tuple(filtered_statements)

--- a/src/pharmpy/tools/mfl/filter.py
+++ b/src/pharmpy/tools/mfl/filter.py
@@ -12,30 +12,30 @@ from pharmpy.tools.mfl.statement.feature.transits import Transits
 
 from .statement.feature.symbols import Name
 
-modelsearch_statement_types = (
+MODELSEARCH_STATEMENT_TYPES = (
     Absorption,
     Elimination,
     LagTime,
     Transits,
 )
 
-covsearch_statement_types = (
+COVSEARCH_STATEMENT_TYPES = (
     Let,
     Covariate,
 )
 
 
-structsearch_statement_types = (DirectEffect, EffectComp, IndirectEffect, Metabolite)
+STRUCTSEARCH_STATEMENT_TYPES = (DirectEffect, EffectComp, IndirectEffect, Metabolite)
 
 
 def mfl_filtering(statements, tool_name):
     assert tool_name in ["structsearch", "modelsearch"]
 
     if tool_name == "modelsearch":
-        statement_types = modelsearch_statement_types
+        statement_types = MODELSEARCH_STATEMENT_TYPES
         peripheral_name = Name('DRUG')
     elif tool_name == "structsearch":
-        statement_types = structsearch_statement_types
+        statement_types = STRUCTSEARCH_STATEMENT_TYPES
         peripheral_name = Name('MET')
 
     filtered_statements = []

--- a/src/pharmpy/tools/mfl/grammar.py
+++ b/src/pharmpy/tools/mfl/grammar.py
@@ -31,7 +31,7 @@ _feature: absorption | elimination | peripherals | transits | lagtime
 
 absorption: "ABSORPTION"i "(" (_absorption_option) ")"
 elimination: "ELIMINATION"i "(" (_elimination_option) ")"
-peripherals: "PERIPHERALS"i "(" (_counts) ")"
+peripherals: "PERIPHERALS"i "(" (_counts) ["," _peripheral_comp] ")"
 transits: "TRANSITS"i "(" _counts ["," _depot_option] ")"
 lagtime: "LAGTIME"i "(" (_lagtime_option) ")"
 covariate: "COVARIATE"i "(" parameter_option "," covariate_option "," fp_option ["," op_option] ")"
@@ -69,6 +69,10 @@ _depot_option: depot_modes | depot_wildcard
 depot_modes: DEPOT_MODE | "[" [DEPOT_MODE ("," DEPOT_MODE)*] "]"
 DEPOT_MODE: "DEPOT"i |"NODEPOT"i
 depot_wildcard: WILDCARD
+_peripheral_comp: peripheral_modes | peripheral_wildcard
+peripheral_modes: PERIPHERAL_MODE | "[" [PERIPHERAL_MODE ("," PERIPHERAL_MODE)*] "]"
+PERIPHERAL_MODE: "DRUG"i | "MET"i
+peripheral_wildcard: WILDCARD
 _lagtime_option: lagtime_modes | lagtime_wildcard
 lagtime_modes: LAGTIME_MODE | "[" [LAGTIME_MODE ("," LAGTIME_MODE)*] "]"
 lagtime_wildcard: WILDCARD

--- a/src/pharmpy/tools/mfl/grammar.py
+++ b/src/pharmpy/tools/mfl/grammar.py
@@ -27,6 +27,7 @@ definition: "LET"i "(" VARIABLE_NAME "," values ")"
 
 _feature: absorption | elimination | peripherals | transits | lagtime
             | covariate | direct_effect | effect_comp | indirect_effect
+            | metabolite
 
 absorption: "ABSORPTION"i "(" (_absorption_option) ")"
 elimination: "ELIMINATION"i "(" (_elimination_option) ")"
@@ -39,6 +40,8 @@ direct_effect: "DIRECTEFFECT"i "(" (_pdtype_option) ")"
 effect_comp: "EFFECTCOMP"i "(" (_pdtype_option) ")"
 indirect_effect: "INDIRECTEFFECT"i "(" _pdtype_option "," _production_option ")"
 
+metabolite: "METABOLITE"i "(" (_metabolite_option) ")"
+
 _pdtype_option: pdtype_modes | pdtype_wildcard
 pdtype_modes: PDTYPE_MODE | "[" [PDTYPE_MODE ("," PDTYPE_MODE)*] "]"
 PDTYPE_MODE: "linear"i | "Emax"i | "sigmoid"i
@@ -48,6 +51,11 @@ _production_option: production_modes | production_wildcard
 production_modes: PRODUCTION_MODE
 PRODUCTION_MODE: "production"i | "degradation"i
 production_wildcard: WILDCARD
+
+_metabolite_option: metabolite_modes | metabolite_wildcard
+metabolite_modes: METABOLITE_MODE | "[" [METABOLITE_MODE ("," METABOLITE_MODE)*] "]"
+METABOLITE_MODE: "basic"i | "psc"i
+metabolite_wildcard: WILDCARD
 
 _absorption_option: absorption_modes | absorption_wildcard
 absorption_modes: ABSORPTION_MODE | "[" [ABSORPTION_MODE ("," ABSORPTION_MODE)*] "]"

--- a/src/pharmpy/tools/mfl/helpers.py
+++ b/src/pharmpy/tools/mfl/helpers.py
@@ -12,6 +12,7 @@ from .feature.elimination import features as elimination_features
 from .feature.feature import Feature, FeatureFn, FeatureKey
 from .feature.indirect_effect import features as indirect_effect_features
 from .feature.lagtime import features as lagtime_features
+from .feature.metabolite import features as metabolite_features
 from .feature.peripherals import features as peripherals_features
 from .feature.transits import features as transits_features
 from .statement.statement import Statement
@@ -26,13 +27,19 @@ modelsearch_features = (
     lagtime_features,
 )
 structsearch_pd_features = (direct_effect_features, effect_comp_features, indirect_effect_features)
+structsearch_metabolite_features = (metabolite_features, peripherals_features)
 
 
 def all_funcs(model: Model, statements: Iterable[Statement]):
     return funcs(
         model,
         statements,
-        (*modelsearch_features, covariate_features, *structsearch_pd_features),
+        (
+            *modelsearch_features,
+            covariate_features,
+            *structsearch_pd_features,
+            *structsearch_metabolite_features,
+        ),
     )
 
 

--- a/src/pharmpy/tools/mfl/interpreter.py
+++ b/src/pharmpy/tools/mfl/interpreter.py
@@ -10,6 +10,7 @@ from .statement.feature.effect_comp import EffectCompInterpreter
 from .statement.feature.elimination import EliminationInterpreter
 from .statement.feature.indirect_effect import IndirectEffectInterpreter
 from .statement.feature.lagtime import LagTimeInterpreter
+from .statement.feature.metabolite import MetaboliteInterpreter
 from .statement.feature.peripherals import PeripheralsInterpreter
 from .statement.feature.transits import TransitsInterpreter
 from .statement.statement import Statement
@@ -48,3 +49,6 @@ class MFLInterpreter(Interpreter):
 
     def indirect_effect(self, tree):
         return IndirectEffectInterpreter().interpret(tree)
+
+    def metabolite(self, tree):
+        return MetaboliteInterpreter().interpret(tree)

--- a/src/pharmpy/tools/mfl/statement/feature/metabolite.py
+++ b/src/pharmpy/tools/mfl/statement/feature/metabolite.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Literal, Tuple, Union
+
+from lark.visitors import Interpreter
+
+from .feature import ModelFeature, feature
+from .symbols import Name, Wildcard
+
+
+@dataclass(frozen=True)
+class Metabolite(ModelFeature):
+    modes: Union[Tuple[Name[Literal['PSC', 'BASIC']], ...], Wildcard]
+
+
+class MetaboliteInterpreter(Interpreter):
+    def interpret(self, tree):
+        children = self.visit_children(tree)
+        assert len(children) == 1
+        return feature(Metabolite, children)
+
+    def metabolite_modes(self, tree):
+        children = self.visit_children(tree)
+        return list(Name(child.value.upper()) for child in children)
+
+    def metabolite_wildcard(self, tree):
+        return Wildcard()

--- a/src/pharmpy/tools/mfl/statement/feature/peripherals.py
+++ b/src/pharmpy/tools/mfl/statement/feature/peripherals.py
@@ -1,33 +1,45 @@
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Literal, Tuple, Union
 
 from .count_interpreter import CountInterpreter
 from .feature import ModelFeature, feature
+from .symbols import Name, Wildcard
 
 
 @dataclass(frozen=True)
 class Peripherals(ModelFeature):
     counts: Tuple[int, ...]
+    modes: Union[Tuple[Name[Literal['DRUG', 'MET']], ...], Wildcard] = (Name('DRUG'),)
 
     def __add__(self, other):
         return Peripherals(
-            tuple(set(self.counts + tuple([a for a in other.counts if a not in self.counts])))
+            tuple(set(self.counts + other.counts)), tuple(set(self.modes + other.modes))
         )
 
     def __sub__(self, other):
         all_counts = tuple([a for a in self.counts if a not in other.counts])
+        all_modes = tuple([a for a in self.modes if a not in other.modes])
 
         if len(all_counts) == 0:
             all_counts = (0,)
+        if len(all_modes) == 0:
+            all_modes = (Name('DRUG'),)
 
-        return Peripherals(all_counts)
+        return Peripherals(all_counts, all_modes)
 
     def __eq__(self, other):
-        return set(self.counts) == set(other.counts)
+        return set(self.counts) == set(other.counts) and set(self.modes) == set(other.modes)
 
 
 class PeripheralsInterpreter(CountInterpreter):
     def interpret(self, tree):
         children = self.visit_children(tree)
-        assert len(children) == 1
+        assert 1 <= len(children) <= 2
         return feature(Peripherals, children)
+
+    def peripheral_modes(self, tree):
+        children = self.visit_children(tree)
+        return list(Name(child.value.upper()) for child in children)
+
+    def peripheral_wildcard(self, tree):
+        return Wildcard()

--- a/src/pharmpy/tools/modelsearch/algorithms.py
+++ b/src/pharmpy/tools/modelsearch/algorithms.py
@@ -37,8 +37,9 @@ def exhaustive(mfl_funcs, iiv_strategy: str):
     return Workflow(wb_search), model_tasks
 
 
-def exhaustive_stepwise(mfl_funcs, iiv_strategy: str):
-    wb_search = WorkflowBuilder()
+def exhaustive_stepwise(mfl_funcs, iiv_strategy: str, wb_search=None, tool_name="modelsearch"):
+    if not wb_search:
+        wb_search = WorkflowBuilder()
     model_tasks = []
 
     while True:
@@ -47,7 +48,7 @@ def exhaustive_stepwise(mfl_funcs, iiv_strategy: str):
         for task_parent, feat_new in actions.items():
             for feat in feat_new:
                 model_no = len(model_tasks) + 1
-                model_name = f'modelsearch_run{model_no}'
+                model_name = f'{tool_name}_run{model_no}'
 
                 task_create_candidate = Task(
                     key_to_str(feat),

--- a/src/pharmpy/tools/modelsearch/tool.py
+++ b/src/pharmpy/tools/modelsearch/tool.py
@@ -12,7 +12,7 @@ from pharmpy.tools.modelfit import create_fit_workflow
 from pharmpy.workflows import ModelEntry, Task, Workflow, WorkflowBuilder, call_workflow
 from pharmpy.workflows.results import ModelfitResults
 
-from ..mfl.filter import modelsearch_statement_types
+from ..mfl.filter import MODELSEARCH_STATEMENT_TYPES
 from ..mfl.parse import parse as mfl_parse
 
 
@@ -319,7 +319,7 @@ def validate_input(
         raise ValueError(f'Invalid `search_space`, could not be parsed: "{search_space}"')
 
     bad_statements = list(
-        filter(lambda statement: not isinstance(statement, modelsearch_statement_types), statements)
+        filter(lambda statement: not isinstance(statement, MODELSEARCH_STATEMENT_TYPES), statements)
     )
 
     if bad_statements:

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -11,20 +11,18 @@ from pharmpy.model import Model
 from pharmpy.tools import summarize_modelfit_results
 from pharmpy.tools.common import ToolResults, create_results, update_initial_estimates
 from pharmpy.tools.modelfit import create_fit_workflow
-from pharmpy.workflows import Task, Workflow, WorkflowBuilder, call_workflow
+from pharmpy.workflows import ModelEntry, Task, Workflow, WorkflowBuilder, call_workflow
 from pharmpy.workflows.results import ModelfitResults
 
-from .drugmetabolite import create_base_metabolite, create_drug_metabolite_models
+from .drugmetabolite import create_drug_metabolite_models
 from .pkpd import create_baseline_pd_model, create_pkpd_models
 from .tmdd import create_qss_models, create_remaining_models
 
 TYPES = frozenset(('pkpd', 'drug_metabolite', 'tmdd'))
-routes = frozenset(('iv', 'oral', 'ivoral'))
 
 
 def create_workflow(
     type: str,
-    route: str = 'oral',
     search_space: Optional[str] = None,
     b_init: Optional[Union[int, float]] = None,
     emax_init: Optional[Union[int, float]] = None,
@@ -41,8 +39,6 @@ def create_workflow(
     ----------
     type : str
         Type of model. Currently only 'drug_metabolite' and 'pkpd'
-    route : str
-        Type of administration. Currently 'oral', 'iv' and 'ivoral'
     search_space : str
         Search space to test
     b_init: float
@@ -92,7 +88,9 @@ def create_workflow(
             strictness,
         )
     elif type == 'drug_metabolite':
-        start_task = Task('run_drug_metabolite', run_drug_metabolite, model, route, strictness)
+        start_task = Task(
+            'run_drug_metabolite', run_drug_metabolite, model, search_space, results, strictness
+        )
     wb.add_task(start_task)
     return Workflow(wb)
 
@@ -192,42 +190,83 @@ def run_pkpd(context, model, search_space, b_init, emax_init, ec50_init, met_ini
     )
 
 
-def run_drug_metabolite(context, model, route, strictness):
-    model = update_initial_estimates(model)
-    base_drug_metabolite = create_base_metabolite(model)
-    candidate_drug_metabolite = create_drug_metabolite_models(model, route)
-
-    # Run workflow for base model
-    wf = create_fit_workflow(base_drug_metabolite)
-    wb = WorkflowBuilder(wf)
-    task_results = Task('results', bundle_results)
-    wb.add_task(task_results, predecessors=wf.output_tasks)
-    base_drug_metabolite_fit = call_workflow(wb, 'results_remaining', context)
-
-    # Run workflow for candidate models
-    wf = create_fit_workflow(candidate_drug_metabolite)
-    wb = WorkflowBuilder(wf)
-    task_results = Task('results', bundle_results)
-    wb.add_task(task_results, predecessors=wf.output_tasks)
-    drug_metabolite_models_fit = call_workflow(wb, 'results_remaining', context)
-
-    summary_input = summarize_modelfit_results(model.modelfit_results)
-    summary_candidates = summarize_modelfit_results(
-        [model.modelfit_results for model in base_drug_metabolite_fit + drug_metabolite_models_fit]
+def run_drug_metabolite(context, model, search_space, results, strictness):
+    model = update_initial_estimates(model, results)
+    wb, candidate_model_tasks, base_model_description = create_drug_metabolite_models(
+        model, results, search_space
     )
+
+    task_results = Task(
+        'Results',
+        post_process_drug_metabolite,
+        ModelEntry.create(model=model, modelfit_results=results),
+        base_model_description,
+        "bic",
+        None,
+        strictness,
+    )
+
+    wb.add_task(task_results, predecessors=candidate_model_tasks)
+    results = call_workflow(Workflow(wb), "results_remaining", context)
+
+    return results
+
+
+def post_process_drug_metabolite(
+    user_input_model_entry, base_model_description, rank_type, cutoff, strictness, *model_entries
+):
+    # NOTE : The base model is part of the model_entries but not the user_input_model
+    res_models = []
+    input_model_entry = None
+    base_model_entry = None
+    for model_entry in model_entries:
+        model = model_entry.model
+        if model.description == base_model_description:
+            model_entry = ModelEntry.create(
+                model=model_entry.model, parent=None, modelfit_results=model_entry.modelfit_results
+            )
+            input_model_entry = model_entry
+            base_model_entry = model_entry
+        else:
+            res_models.append(model_entry)
+    if not base_model_entry:
+        # No base model found indicate user_input_model is base
+        input_model_entry = user_input_model_entry
+        base_model_entry = user_input_model_entry
+    if not input_model_entry:
+        raise ValueError('Error in workflow: No input model')
+
+    if base_model_entry != user_input_model_entry:
+        # Change parent model to base model instead of temporary model names or input model
+        res_models = [
+            me
+            if me.parent.name
+            not in ("TEMP", user_input_model_entry.model.name)  # TEMP name for drug-met models
+            else ModelEntry.create(
+                model=me.model, parent=base_model_entry.model, modelfit_results=me.modelfit_results
+            )
+            for me in res_models
+        ]
+
+    results_to_summarize = [user_input_model_entry.modelfit_results]
+
+    if user_input_model_entry != base_model_entry:
+        results_to_summarize.append(base_model_entry.modelfit_results)
+    if res_models:
+        results_to_summarize.extend(me.modelfit_results for me in res_models)
+
+    summary_models = summarize_modelfit_results(results_to_summarize)
+    summary_models['step'] = [0] + [1] * (len(summary_models) - 1)
+    summary_models = summary_models.reset_index().set_index(['step', 'model'])
 
     return create_results(
         StructSearchResults,
-        model,
-        base_drug_metabolite_fit[0],
-        list(drug_metabolite_models_fit),
-        rank_type='bic',
-        cutoff=None,
-        summary_models=pd.concat(
-            [summary_input, summary_candidates],
-            keys=[0, 1],
-            names=['step'],
-        ),
+        input_model_entry,
+        base_model_entry,
+        res_models,
+        rank_type,
+        cutoff,
+        summary_models=summary_models,
         strictness=strictness,
     )
 
@@ -246,12 +285,9 @@ def validate_input(
     type,
     strictness,
     model,
-    route,
 ):
     if type not in TYPES:
         raise ValueError(f'Invalid `type`: got `{type}`, must be one of {sorted(TYPES)}.')
-    if route not in routes:
-        raise ValueError(f'Invalid `route`: got `{route}`, must be one of {sorted(routes)}.')
 
     if strictness is not None and "rse" in strictness.lower():
         if model.estimation_steps[-1].parameter_uncertainty_method is None:

--- a/tests/tools/test_mfl.py
+++ b/tests/tools/test_mfl.py
@@ -327,6 +327,22 @@ from pharmpy.tools.mfl.stringify import stringify
             'COVARIATE(@BIOAVAIL, APGR, CAT)',
             (),
         ),
+        (
+            'METABOLITE([BASIC, PSC]);' 'PERIPHERALS(1..2, MET)',
+            (
+                ('METABOLITE', 'BASIC'),
+                ('METABOLITE', 'PSC'),
+                ('PERIPHERALS', 1),
+                ('PERIPHERALS', 2),
+            ),
+        ),
+        (
+            'METABOLITE(*)',
+            (
+                ('METABOLITE', 'BASIC'),
+                ('METABOLITE', 'PSC'),
+            ),
+        ),
     ),
     ids=repr,
 )

--- a/tests/tools/test_structsearch.py
+++ b/tests/tools/test_structsearch.py
@@ -103,16 +103,27 @@ def test_pkpd(load_model_for_test, testdata):
     assert models3[1].parameters['POP_EC_50'].fix is False
 
 
-def test_drug_metabolite(load_example_model_for_test):
-    model = load_example_model_for_test("pheno")
-    models = create_drug_metabolite_models(model, "oral")
-    assert len(models) == 3
+def test_drug_metabolite(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / "nonmem" / "pheno_pd.mod")
+    res = read_modelfit_results(testdata / "nonmem" / "pheno.mod")
+    search_space = "METABOLITE([PSC, BASIC]);PERIPHERALS([0,1], MET)"
+    wb, candidate_tasks, base_model_description = create_drug_metabolite_models(
+        model, res, search_space
+    )
+    assert base_model_description == "METABOLITE_BASIC;PERIPHERALS(0)"
+    assert len(candidate_tasks) == 4
 
-    models = create_drug_metabolite_models(model, "ivoral")
-    assert len(models) == 3
+    wb, candidate_tasks, base_model_description = create_drug_metabolite_models(
+        model, res, "METABOLITE([PSC, BASIC])"
+    )
+    assert base_model_description == "METABOLITE_BASIC"
+    assert len(candidate_tasks) == 2
 
-    models = create_drug_metabolite_models(model, "iv")
-    assert len(models) == 1
+    wb, candidate_tasks, base_model_description = create_drug_metabolite_models(
+        model, res, "METABOLITE(BASIC);PERIPHERALS([0,1], MET)"
+    )
+    assert base_model_description == "METABOLITE_BASIC;PERIPHERALS(0)"
+    assert len(candidate_tasks) == 2
 
 
 def test_create_workflow():


### PR DESCRIPTION
Added "METABOLITE" option within MFL with two options
- PSC (pre-systemic circulation)
- BASIC (simple 100 conversion from of parent to metabolite)

Also updated "PERIPHERALS" to handle a second (optional) argument with two possible entries, either "DRUG" which would add peripherals to the central compartment, or "MET" which would instead add the peripherals to the present METABOLITE compartment. This is based on DVID for the moment, with DVID=2 representing the metabolite