### PR TITLE
Avoid removing allometry scaling in AMD

### DIFF
--- a/src/pharmpy/modeling/allometry.py
+++ b/src/pharmpy/modeling/allometry.py
@@ -30,6 +30,9 @@ def add_allometry(
     P=P*(X/Z)**T where P is the parameter, X the allometric_variable, Z the reference_value
     and T is a theta. Default is to automatically use clearance and volume parameters.
 
+    If there already exists a covariate effect (or allometric scaling) on a parameter
+    with the specified allometric variable, nothing will be added.
+
     Parameters
     ----------
     model : Model
@@ -56,16 +59,18 @@ def add_allometry(
 
     Examples
     --------
-    >>> from pharmpy.modeling import load_example_model, add_allometry
+    >>> from pharmpy.modeling import load_example_model, add_allometry, remove_covariate_effect
     >>> model = load_example_model("pheno")
+    >>> model = remove_covariate_effect(model, 'CL', 'WGT')
+    >>> model = remove_covariate_effect(model, 'V', 'WGT')
     >>> model = add_allometry(model, allometric_variable='WGT')
     >>> model.statements.before_odes
             ⎧TIME  for AMT > 0
             ⎨
     BTIME = ⎩ 0     otherwise
     TAD = -BTIME + TIME
-    TVCL = PTVCL⋅WGT
-    TVV = PTVV⋅WGT
+    TVCL = PTVCL
+    TVV = PTVV
           ⎧TVV⋅(THETA₃ + 1)  for APGR < 5
           ⎨
     TVV = ⎩      TVV           otherwise

--- a/src/pharmpy/modeling/allometry.py
+++ b/src/pharmpy/modeling/allometry.py
@@ -84,6 +84,8 @@ def add_allometry(
     S₁ = V
 
     """
+    from pharmpy.modeling import has_covariate_effect
+
     variable = parse_expr(allometric_variable)
     reference = parse_expr(reference_value)
 
@@ -121,15 +123,16 @@ def add_allometry(
     sset = model.statements
     params = list(model.parameters)
     for p, init, lower, upper in zip(parsed_parameters, initials, lower_bounds, upper_bounds):
-        symb = _create_symbol(
-            sset, params, model.random_variables, model.datainfo, f'ALLO_{p.name}', False
-        )
-        param = Parameter(symb.name, init=init, lower=lower, upper=upper, fix=fixed)
-        params.append(param)
-        expr = p * (variable / reference) ** param.symbol
-        new_ass = Assignment(p, expr)
-        ind = sset.find_assignment_index(p)
-        sset = sset[0 : ind + 1] + new_ass + sset[ind + 1 :]
+        if not has_covariate_effect(model, str(p), str(variable)):
+            symb = _create_symbol(
+                sset, params, model.random_variables, model.datainfo, f'ALLO_{p.name}', False
+            )
+            param = Parameter(symb.name, init=init, lower=lower, upper=upper, fix=fixed)
+            params.append(param)
+            expr = p * (variable / reference) ** param.symbol
+            new_ass = Assignment(p, expr)
+            ind = sset.find_assignment_index(p)
+            sset = sset[0 : ind + 1] + new_ass + sset[ind + 1 :]
     parameters = Parameters.create(params)
     model = model.replace(statements=sset, parameters=parameters)
     model = model.update_source()

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -323,11 +323,29 @@ def run_amd(
         if modeltype == 'drug_metabolite' and tool_name == "structsearch":
             next_model = next_model.replace(dataset=orig_dataset)
         subresults = func(next_model)
+
         if subresults is None:
             sum_models.append(None)
             sum_inds_counts.append(None)
         else:
             if subresults.final_model.name != next_model.name:
+                if tool_name == "allometry" and 'allometry' in order[: order.index('covariates')]:
+                    cov_before = ModelFeatures.create_from_mfl_string(
+                        get_model_features(next_model)
+                    )
+                    cov_after = ModelFeatures.create_from_mfl_string(
+                        get_model_features(subresults.final_model)
+                    )
+                    cov_differences = (cov_after - cov_before).covariate
+                    if cov_differences:
+                        covsearch_features += cov_differences
+                        func = _subfunc_covariates(
+                            amd_start_model=model,
+                            search_space=covsearch_features,
+                            strictness=strictness,
+                            path=db.path,
+                        )
+                        run_subfuncs['covsearch'] = func
                 next_model = subresults.final_model
                 results = subresults.tool_database.model_database.retrieve_modelfit_results(
                     subresults.final_model.name
@@ -462,6 +480,7 @@ def _subfunc_modelsearch(search_space: Tuple[Statement, ...], strictness, path) 
             path=path / 'modelsearch',
         )
         assert isinstance(res, Results)
+
         return res
 
     return _run_modelsearch
@@ -622,18 +641,19 @@ def _subfunc_covariates(
     return _run_covariates
 
 
+def _allometric_variable(model: Model, input_allometric_variable):
+    if input_allometric_variable is not None:
+        return input_allometric_variable
+
+    for col in model.datainfo:
+        if col.descriptor == 'body weight':
+            return col.name
+
+    return None
+
+
 def _subfunc_allometry(amd_start_model: Model, input_allometric_variable, path) -> SubFunc:
-    def _allometric_variable(model: Model):
-        if input_allometric_variable is not None:
-            return input_allometric_variable
-
-        for col in model.datainfo:
-            if col.descriptor == 'body weight':
-                return col.name
-
-        return None
-
-    allometric_variable = _allometric_variable(amd_start_model)
+    allometric_variable = _allometric_variable(amd_start_model, input_allometric_variable)
 
     if allometric_variable is None:
         warnings.warn(
@@ -645,7 +665,7 @@ def _subfunc_allometry(amd_start_model: Model, input_allometric_variable, path) 
         validate_allometric_variable(amd_start_model, allometric_variable)
 
     def _run_allometry(model):
-        allometric_variable = _allometric_variable(model)
+        allometric_variable = _allometric_variable(model, input_allometric_variable)
 
         if allometric_variable is None:
             warnings.warn(


### PR DESCRIPTION
Automatically adds the allometry scaled covariate effect to the covsearch searchspace (which prevents them from being removed)
Also changed to not add allometric scaling if covariate effect already exist for the parameter, using the allometric variable as covariate