### PR TITLE
Revert "Bump pytest-xdist from 2.5.0 to 3.3.1"

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,5 +5,5 @@ packaging==23.2
 pluggy==1.3.0
 pytest==7.4.3
 pytest-asyncio==0.21.1
-pytest-xdist==3.3.1
+pytest-xdist==2.5.0
 tomli==2.0.1


### PR DESCRIPTION
Reverts pharmpy/pharmpy#2276