### PR TITLE
Avoid removing allometry scaling in covsearch

### DIFF
--- a/src/pharmpy/modeling/allometry.py
+++ b/src/pharmpy/modeling/allometry.py
@@ -30,6 +30,9 @@ def add_allometry(
     P=P*(X/Z)**T where P is the parameter, X the allometric_variable, Z the reference_value
     and T is a theta. Default is to automatically use clearance and volume parameters.
 
+    If there already exists a covariate effect (or allometric scaling) on a parameter
+    with the specified allometric variable, nothing will be added.
+
     If no allometric variable is specified, it will be extracted from the dataset based on
     the descriptor "body weight".
 
@@ -59,16 +62,18 @@ def add_allometry(
 
     Examples
     --------
-    >>> from pharmpy.modeling import load_example_model, add_allometry
+    >>> from pharmpy.modeling import load_example_model, add_allometry, remove_covariate_effect
     >>> model = load_example_model("pheno")
+    >>> model = remove_covariate_effect(model, 'CL', 'WGT')
+    >>> model = remove_covariate_effect(model, 'V', 'WGT')
     >>> model = add_allometry(model, allometric_variable='WGT')
     >>> model.statements.before_odes
             ⎧TIME  for AMT > 0
             ⎨
     BTIME = ⎩ 0     otherwise
     TAD = -BTIME + TIME
-    TVCL = PTVCL⋅WGT
-    TVV = PTVV⋅WGT
+    TVCL = PTVCL
+    TVV = PTVV
           ⎧TVV⋅(THETA₃ + 1)  for APGR < 5
           ⎨
     TVV = ⎩      TVV           otherwise

--- a/src/pharmpy/modeling/covariate_effect.py
+++ b/src/pharmpy/modeling/covariate_effect.py
@@ -67,6 +67,29 @@ def get_covariates(model: Model) -> dict[list]:
 def get_covariate_effect(model: Model, symbol, covariate):
     param_expr = model.statements.before_odes.full_expression(symbol)
 
+    # Piecewise statement can interfer with .match() of expression
+    full_expr = param_expr
+    function_counter = 1
+
+    def extract_parameters_recursive(expr_list, expr, full_expr, counter):
+        for a in expr.args:
+            if a.is_Function:
+                full_expr = full_expr.subs({a: sympy.Wild(f"f{counter}")})
+                counter += 1
+                if a.is_Piecewise:
+                    for e, _ in a.args:
+                        extract_parameters_recursive(expr_list, e, e, counter)
+                else:
+                    for e in a.args:
+                        extract_parameters_recursive(expr_list, e, e, counter)
+        expr_list.insert(0, full_expr)
+        return expr_list
+
+    param_expr_list = extract_parameters_recursive([], param_expr, full_expr, function_counter)
+    param_expr_list.append(param_expr)
+    for i in param_expr_list:
+        print(i)
+
     eff = 'custom'
     op = '*'
     for effect in ['lin', 'cat', 'piece_lin', 'exp', 'pow']:
@@ -84,23 +107,30 @@ def get_covariate_effect(model: Model, symbol, covariate):
                 wild_dict["median"].append(wild_symbol)
         rest_of_expression = sympy.Wild('reo')
 
-        match = param_expr.match(rest_of_expression + template)
-        if match:
-            if _assert_cov_effect_match(wild_dict, match, model, effect=effect):
-                eff = effect
-                op = '+'
+        for pe in param_expr_list:
+            found_match = False
+            match = pe.match(rest_of_expression * template)
+            if match:
+                if _assert_cov_effect_match(wild_dict, match, model, covariate, effect=effect):
+                    eff = effect
+                    op = '*'
+                    found_match = True
+            if found_match:
                 break
-        match = param_expr.match(rest_of_expression * template)
-        if match:
-            if _assert_cov_effect_match(wild_dict, match, model, effect=effect):
-                eff = effect
-                op = '*'
+        for pe in param_expr_list:
+            found_match = False
+            match = pe.match(rest_of_expression + template)
+            if match:
+                if _assert_cov_effect_match(wild_dict, match, model, covariate, effect=effect):
+                    eff = effect
+                    op = '+'
+                    found_match = True
+            if found_match:
                 break
-
     return eff, op
 
 
-def _assert_cov_effect_match(symbols, match, model, effect):
+def _assert_cov_effect_match(symbols, match, model, covariate, effect):
     if effect == "pow":
         if isinstance(match[sympy.Wild("cov")], sympy.Number) and isinstance(
             match[sympy.Wild("median")], sympy.Pow
@@ -115,9 +145,8 @@ def _assert_cov_effect_match(symbols, match, model, effect):
             if any(match[value] not in thetas for value in values):
                 return False
         if key == "cov":
-            covariates = get_model_covariates(model)
-            covariates.extend([1 / c for c in covariates])
-            if all(match[value] not in covariates for value in values):
+            covariate = sympy.Symbol(covariate)
+            if all(match[value] not in [covariate, 1 / covariate] for value in values):
                 return False
         if key == "median":
             if not all(isinstance(match[value], sympy.Number) for value in values):

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -323,11 +323,29 @@ def run_amd(
         if modeltype == 'drug_metabolite' and tool_name == "structsearch":
             next_model = next_model.replace(dataset=orig_dataset)
         subresults = func(next_model)
+
         if subresults is None:
             sum_models.append(None)
             sum_inds_counts.append(None)
         else:
             if subresults.final_model.name != next_model.name:
+                if tool_name == "allometry" and 'allometry' in order[: order.index('covariates')]:
+                    cov_before = ModelFeatures.create_from_mfl_string(
+                        get_model_features(next_model)
+                    )
+                    cov_after = ModelFeatures.create_from_mfl_string(
+                        get_model_features(subresults.final_model)
+                    )
+                    cov_differences = (cov_after - cov_before).covariate
+                    if cov_differences:
+                        covsearch_features += cov_differences
+                        func = _subfunc_covariates(
+                            amd_start_model=model,
+                            search_space=covsearch_features,
+                            strictness=strictness,
+                            path=db.path,
+                        )
+                        run_subfuncs['covsearch'] = func
                 next_model = subresults.final_model
                 results = subresults.tool_database.model_database.retrieve_modelfit_results(
                     subresults.final_model.name
@@ -462,6 +480,7 @@ def _subfunc_modelsearch(search_space: Tuple[Statement, ...], strictness, path) 
             path=path / 'modelsearch',
         )
         assert isinstance(res, Results)
+
         return res
 
     return _run_modelsearch
@@ -622,18 +641,19 @@ def _subfunc_covariates(
     return _run_covariates
 
 
+def _allometric_variable(model: Model, input_allometric_variable):
+    if input_allometric_variable is not None:
+        return input_allometric_variable
+
+    for col in model.datainfo:
+        if col.descriptor == 'body weight':
+            return col.name
+
+    return None
+
+
 def _subfunc_allometry(amd_start_model: Model, input_allometric_variable, path) -> SubFunc:
-    def _allometric_variable(model: Model):
-        if input_allometric_variable is not None:
-            return input_allometric_variable
-
-        for col in model.datainfo:
-            if col.descriptor == 'body weight':
-                return col.name
-
-        return None
-
-    allometric_variable = _allometric_variable(amd_start_model)
+    allometric_variable = _allometric_variable(amd_start_model, input_allometric_variable)
 
     if allometric_variable is None:
         warnings.warn(
@@ -645,7 +665,7 @@ def _subfunc_allometry(amd_start_model: Model, input_allometric_variable, path) 
         validate_allometric_variable(amd_start_model, allometric_variable)
 
     def _run_allometry(model):
-        allometric_variable = _allometric_variable(model)
+        allometric_variable = _allometric_variable(model, input_allometric_variable)
 
         if allometric_variable is None:
             warnings.warn(


### PR DESCRIPTION
Added allometric scaling effects are now extracted and added to the covsearch search space in order to be left in the model when allometry is performed before covsearch

Also implemented better determination technique for covariate effects in order to more accurately be able to determine the effect type in more complex expressions.