### PR TITLE
New requirements.txt for pip and tox (and deps)

### DIFF
--- a/.github/actions/setup-tox/action.yml
+++ b/.github/actions/setup-tox/action.yml
@@ -13,10 +13,6 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: pip
 
-    - name: Upgrade pip
-      shell: bash
-      run: python -m pip install --upgrade pip
-
     - name: Install tox
       shell: bash
-      run: pip install tox
+      run: pip install -r pretest-requirements.txt

--- a/pretest-requirements.txt
+++ b/pretest-requirements.txt
@@ -1,0 +1,15 @@
+# Direct dependencies
+pip==23.3.1
+tox==4.11.3
+# Indirect dependencies
+cachetools==5.3.2
+chardet==5.2.0
+colorama==0.4.6
+distlib==0.3.7
+filelock==3.13.1
+packaging==23.2
+platformdirs==3.11.0
+pluggy==1.3.0
+pyproject-api==1.6.1
+tomli==2.0.1
+virtualenv==20.24.6


### PR DESCRIPTION
We currently have no control over which version of tox gets installed in the continuous integration tests.