### PR TITLE
Correct windows path for fix_eta file and updates to RxODE

### DIFF
--- a/src/pharmpy/model/external/rxode/model.py
+++ b/src/pharmpy/model/external/rxode/model.py
@@ -117,6 +117,10 @@ def create_model(cg, model):
 
 
 def add_true_statements(model, cg, statements):
+    comp_name_dict = {}
+    for name in model.statements.ode_system.compartment_names:
+        comp = model.statements.ode_system.find_compartment(name)
+        comp_name_dict[comp.amount] = comp.amount.name
     for s in statements:
         if model.statements.ode_system is not None and (
             s.symbol in get_bioavailability(model).values()
@@ -124,7 +128,7 @@ def add_true_statements(model, cg, statements):
         ):
             pass
         else:
-            expr = s.expression
+            expr = s.expression.subs(comp_name_dict)
             expr = convert_eps_to_sigma(expr, model)
             if expr.is_Piecewise:
                 add_piecewise(model, cg, s)

--- a/src/pharmpy/tools/external/nlmixr/run.py
+++ b/src/pharmpy/tools/external/nlmixr/run.py
@@ -71,7 +71,12 @@ def execute_model(model: pharmpy.model.Model, db, evaluate=False, path=None) -> 
     pre = f'library(nlmixr2)\n\ndataset <- read.csv("{dataset_path}")\n'
 
     if "fix_eta" in model.estimation_steps[0].tool_options:
-        pre += f'etas <- as.matrix(read.csv("{path}/fix_eta.csv"))'
+        fix_eta_filename = "fix_eta.csv"
+        if sys.platform == 'win32':
+            fix_eta_path = f"{path / fix_eta_filename}".replace("\\", "\\\\")
+        else:
+            fix_eta_path = f"{path / fix_eta_filename}"
+        pre += f'etas <- as.matrix(read.csv("{fix_eta_path}"))'
     pre += "\n"
 
     code = pre + model.model_code

--- a/src/pharmpy/tools/modelfit/tool.py
+++ b/src/pharmpy/tools/modelfit/tool.py
@@ -138,6 +138,8 @@ def get_execute_model(tool: Optional[SupportedPlugin]):
         from pharmpy.tools.external.nonmem.run import execute_model
     elif tool == 'nlmixr':
         from pharmpy.tools.external.nlmixr.run import execute_model
+    elif tool == 'rxode':
+        from pharmpy.tools.external.rxode.run import execute_model
     else:
         raise ValueError(f"Unknown estimation tool {tool}")
 


### PR DESCRIPTION
Fix backslash issue in file path for windows when running RxODE and nlmixr. Also added support for running fit(model, "rxode") and similar updates to RxODE as for nlmixr in #2303