### PR TITLE
Add model to is_strictness_fulfilled in covsearch

### DIFF
--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -342,7 +342,7 @@ def _greedy_search(
         ofvs = [
             np.nan
             if (mfr := model.modelfit_results) is None
-            or not is_strictness_fulfilled(mfr, strictness)
+            or not is_strictness_fulfilled(mfr, model, strictness)
             else mfr.ofv
             for model in new_candidate_models
         ]


### PR DESCRIPTION
Add model to `is_strictness_fulfilled` in covsearch after `is_strictness_fulfilled` has been updated.
Currently model is missing from that function and covsearch fails.
