### PR TITLE
Rework covsearch for structural/mechanistic and exploratory covariates

### DIFF
--- a/docs/amd.rst
+++ b/docs/amd.rst
@@ -82,6 +82,10 @@ Arguments
 |                                                   | Default is "minimization_successful or                                                                          |
 |                                                   | (rounding_errors and sigdigs>= 0.1)"                                                                            |
 +---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+|``mechanistic_covariates``                         | List of covariates to run in a separate prioritezed covsearch run.                                              |
+|                                                   | The effects are extracted from the given search space                                                           |
+|                                                   |                                                                                                                 |
++---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 
 .. _input_amd:
 
@@ -129,8 +133,8 @@ default is:
     LAGTIME([OFF,ON])
     TRANSITS([0,1,3,10],*)
     PERIPHERALS(0,1)
-    COVARIATE(@IIV, @CONTINUOUS, *)
-    COVARIATE(@IIV, @CATEGORICAL, CAT)
+    COVARIATE?(@IIV, @CONTINUOUS, *)
+    COVARIATE?(@IIV, @CATEGORICAL, CAT)
 
 For a PK IV model, the default is:
 
@@ -138,8 +142,8 @@ For a PK IV model, the default is:
 
     ELIMINATION(FO)
     PERIPHERALS([0,1,2])
-    COVARIATE(@IIV, @CONTINUOUS, *)
-    COVARIATE(@IIV, @CATEGORICAL, CAT)
+    COVARIATE?(@IIV, @CONTINUOUS, *)
+    COVARIATE?(@IIV, @CATEGORICAL, CAT)
     
 For a PK IV+ORAL model, the default is:
 
@@ -150,8 +154,8 @@ For a PK IV+ORAL model, the default is:
     LAGTIME([OFF,ON])
     TRANSITS([0,1,3,10],*)
     PERIPHERALS([0,1,2])
-    COVARIATE(@IIV, @CONTINUOUS, *)
-    COVARIATE(@IIV, @CATEGORICAL, CAT)
+    COVARIATE?(@IIV, @CONTINUOUS, *)
+    COVARIATE?(@IIV, @CATEGORICAL, CAT)
 
 Note that defaults are overriden selectively: structural model features
 defaults will be ignored as soon as one structural model feature is explicitly
@@ -162,8 +166,8 @@ search space will be as follows:
 .. code-block::
 
     LAGTIME()
-    COVARIATE(@IIV, @CONTINUOUS, *)
-    COVARIATE(@IIV, @CATEGORICAL, CAT)
+    COVARIATE?(@IIV, @CONTINUOUS, *)
+    COVARIATE?(@IIV, @CATEGORICAL, CAT)
 
 .. _order_amd:
 
@@ -295,6 +299,8 @@ Structural
 ~~~~~~~~~~
 
 This subtool selects the best structural model, see :ref:`modelsearch` or :ref:`structsearch` for more details about the tool.
+In this stage, structural covariate effects are also added (all at once) to the starting model. Please see :ref:`covsearch` 
+for more information of this.
 
 Modelsearch
 ===========
@@ -430,6 +436,23 @@ settings that the AMD tool uses for this subtool can be seen in the table below.
 +---------------+----------------------------------------------------------------------------------------------------+
 | algorithm     | ``'scm-forward-then-backward'``                                                                    |
 +---------------+----------------------------------------------------------------------------------------------------+
+
+For an entire AMD run, it is possible to get a maximum of three covsearch runs, which are described below:
+
++---------------------+-----------------------------------------------------------------------------------------+
+| Type of covsearch   | Description                                                                             |
++=====================+=========================================================================================+
+| Structural          | Performed in the structural part of the AMD run. The structural covariates are added    |
+|                     | directly to the starting model.                                                         |
+|                     | If these cannot be added here (due to missing parameters for instance) they will        |
+|                     | be tested once more at the start of the next covsearch run.                             |
++---------------------+-----------------------------------------------------------------------------------------+
+| Mechanistic         | If any mechanistic covariates have been given as input to the AMD tool, the specified   |
+|                     | covariate effects for these covariates is run in a separate initial covsearch run When  |
+|                     | adding covariates.                                                                      |
++---------------------+-----------------------------------------------------------------------------------------+
+| Exploratory         | The remaining covariates are tested after all mechanistic covariates have been tested.  |
++---------------------+-----------------------------------------------------------------------------------------+
 
 ~~~~~~~
 Results

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -249,7 +249,10 @@ MFL support the following model features:
 +---------------+--------------------------------+--------------------------------------------------------------------+
 | LAGTIME       | :code:`OFF, ON`                | Absorption lagtime                                                 |
 +---------------+--------------------------------+--------------------------------------------------------------------+
-| COVARIATE     | `parameter`, `covariate`,      | Covariate effects                                                  |
+| COVARIATE     | `parameter`, `covariate`,      | Structural covariate effects (will be tested)                     |
+|               | `effect`                       |                                                                    |
++---------------+--------------------------------+--------------------------------------------------------------------+
+| COVARIATE?    | `parameter`, `covariate`,      | Exploratory covariate effects (will always be added)                |
 |               | `effect`                       |                                                                    |
 +---------------+--------------------------------+--------------------------------------------------------------------+
 | DIRECTEFFECT  | `model`                        | Direct effect PD models.                                           |

--- a/src/pharmpy/modeling/covariate_effect.py
+++ b/src/pharmpy/modeling/covariate_effect.py
@@ -183,6 +183,8 @@ def remove_covariate_effect(model: Model, parameter: str, covariate: str):
     False
 
     """
+    if not has_covariate_effect(model, parameter, covariate):
+        return model
     kept_thetas, before_odes = simplify_model(
         model,
         model.statements.before_odes,

--- a/src/pharmpy/modeling/lrt.py
+++ b/src/pharmpy/modeling/lrt.py
@@ -1,12 +1,22 @@
-from typing import Iterable
+from typing import Iterable, Union
 
 from pharmpy.deps import numpy as np
 from pharmpy.deps.scipy import stats
 from pharmpy.model import Model
+from pharmpy.workflows import ModelEntry
 
 
-def degrees_of_freedom(parent: Model, child: Model) -> int:
-    return len(child.parameters) - len(parent.parameters)
+def degrees_of_freedom(parent: Union[Model, ModelEntry], child: Union[Model, ModelEntry]) -> int:
+    if isinstance(child, ModelEntry):
+        child_parameters = child.model.parameters
+    else:
+        child_parameters = child.parameters
+
+    if isinstance(child, ModelEntry):
+        parent_parameters = parent.model.parameters
+    else:
+        parent_parameters = parent.parameters
+    return len(child_parameters) - len(parent_parameters)
 
 
 def cutoff(parent: Model, child: Model, alpha: float) -> float:

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -27,7 +27,7 @@ from pharmpy.tools.mfl.statement.feature.covariate import Covariate, Ref
 from pharmpy.tools.mfl.statement.feature.elimination import Elimination
 from pharmpy.tools.mfl.statement.feature.lagtime import LagTime
 from pharmpy.tools.mfl.statement.feature.peripherals import Peripherals
-from pharmpy.tools.mfl.statement.feature.symbols import Name, Wildcard
+from pharmpy.tools.mfl.statement.feature.symbols import Name, Option, Wildcard
 from pharmpy.tools.mfl.statement.feature.transits import Transits
 from pharmpy.tools.mfl.statement.statement import Statement
 from pharmpy.tools.mfl.stringify import stringify as mfl_stringify
@@ -238,18 +238,25 @@ def run_amd(
     )
     if not any(map(lambda statement: isinstance(statement, Covariate), covsearch_features)):
         def_cov_search_feature = (
-            Covariate(Ref('IIV'), Ref('CONTINUOUS'), ('exp',), '*'),
-            Covariate(Ref('IIV'), Ref('CATEGORICAL'), ('cat',), '*'),
+            Covariate(Ref('IIV'), Ref('CONTINUOUS'), ('exp',), '*', Option(True)),
+            Covariate(Ref('IIV'), Ref('CATEGORICAL'), ('cat',), '*', Option(True)),
         )
         if modeltype == 'basic_pk' and administration == 'ivoral':
             def_cov_search_feature = def_cov_search_feature + (
-                Covariate(('RUV',), ('ADMID',), ('cat',), '*'),
+                Covariate(('RUV',), ('ADMID',), ('cat',), '*', Option(True)),
             )
 
         covsearch_features = def_cov_search_feature + covsearch_features
 
     db = default_tool_database(toolname='amd', path=path, exist_ok=resume)
     run_subfuncs = {}
+    # Always add?
+    run_subfuncs['structural_covariates'] = _subfunc_structural_covariates(
+        amd_start_model=model,
+        search_space=covsearch_features,
+        strictness=strictness,
+        path=db.path,
+    )
     for section in order:
         if section == 'structural':
             if modeltype == 'pkpd':

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -59,6 +59,7 @@ def run_amd(
     path: Optional[Union[str, Path]] = None,
     resume: bool = False,
     strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs>=0.1)",
+    mechanistic_covariates: Optional[List[str]] = None,
 ):
     """Run Automatic Model Development (AMD) tool
 
@@ -106,6 +107,9 @@ def run_amd(
         Whether to allow resuming previous run
     strictness : str or None
         Strictness criteria
+    mechanistic_covariates : list
+        List of covariates to run in a separate proioritized covsearch run. The effects are extracted
+        from the search space for covsearch
 
     Returns
     -------
@@ -323,9 +327,10 @@ def run_amd(
             )
             run_subfuncs['allometry'] = func
         elif section == 'covariates':
-            func = _subfunc_covariates(
+            func = _subfunc_mechanistic_exploratory_covariates(
                 amd_start_model=model,
                 search_space=covsearch_features,
+                mechanistic_covariates=mechanistic_covariates,
                 strictness=strictness,
                 path=db.path,
             )
@@ -615,8 +620,75 @@ def _subfunc_ruvsearch(dv, strictness, path) -> SubFunc:
     return _run_ruvsearch
 
 
-def _subfunc_covariates(
-    amd_start_model: Model, search_space: Tuple[Statement, ...], strictness, path
+def _subfunc_structural_covariates(
+    amd_start_model: Model,
+    search_space: Tuple[Statement, ...],
+    strictness,
+    path,
+) -> SubFunc:
+    def _run_structural_covariates(model):
+        from pharmpy.modeling import get_pk_parameters
+
+        allowed_parameters = allowed_parameters = set(get_pk_parameters(model)).union(
+            str(statement.symbol) for statement in model.statements.before_odes
+        )
+        # Extract all forced
+        mfl = ModelFeatures.create_from_mfl_statement_list(search_space)
+        mfl_covariates = mfl.expand(model).covariate
+        structural_searchspace = []
+        skipped_parameters = set()
+        for cov_statement in mfl_covariates:
+            if not cov_statement.optional.option:
+                filtered_parameters = tuple(
+                    [p for p in cov_statement.parameter if p in allowed_parameters]
+                )
+                # Not optional -> Add to all search spaces (was added in structural run)
+                structural_searchspace.append(
+                    Covariate(
+                        filtered_parameters,
+                        cov_statement.covariate,
+                        cov_statement.fp,
+                        cov_statement.op,
+                        cov_statement.optional,
+                    )
+                )
+                skipped_parameters.union(set(cov_statement.parameter) - set(filtered_parameters))
+
+        # Ignore warning?
+        if skipped_parameters:
+            warnings.warn(
+                f'{skipped_parameters} missing in start model and structural covariate effect cannot be added'
+                ' Might be added during a later COVsearch step if possible.'
+            )
+        if not structural_searchspace and not skipped_parameters:
+            # Uneccessary to warn (?)
+            return None
+        elif not structural_searchspace:
+            warnings.warn(
+                'No applicable structural covariates found in search space. Skipping structural_COVsearch'
+            )
+            return None
+
+        res = run_tool(
+            'covsearch',
+            mfl_stringify(structural_searchspace),
+            model=model,
+            strictness=strictness,
+            results=model.modelfit_results,
+            path=path / 'covsearch_structural',
+        )
+        assert isinstance(res, Results)
+        return res
+
+    return _run_structural_covariates
+
+
+def _subfunc_mechanistic_exploratory_covariates(
+    amd_start_model: Model,
+    search_space: Tuple[Statement, ...],
+    mechanistic_covariates,
+    strictness,
+    path,
 ) -> SubFunc:
     covariates = set(extract_covariates(amd_start_model, search_space))
     if covariates:
@@ -635,7 +707,9 @@ def _subfunc_covariates(
             ' and .datainfo usage of "covariate" type and "continuous" flag.'
         )
 
-    def _run_covariates(model):
+    def _run_mechanistic_exploratory_covariates(model):
+        index_offset = 0  # For naming runs
+
         effects = list(covariate_spec(model, search_space))
 
         if not effects:
@@ -646,17 +720,92 @@ def _subfunc_covariates(
             )
             return None
 
+        if mechanistic_covariates:
+            # Extract them and all forced
+            mfl = ModelFeatures.create_from_mfl_statement_list(search_space)
+            mfl_covariates = mfl.expand(model).covariate
+            filtered_searchspace = []
+            mechanistic_searchspace = []
+            structural_searchspace = []
+            for cov_statement in mfl_covariates:
+                if not cov_statement.optional.option:
+                    # Not optional -> Add to all search spaces (was added in structural run)
+                    structural_searchspace.append(cov_statement)
+                    mechanistic_searchspace.append(cov_statement)
+                    filtered_searchspace.append(cov_statement)
+                else:
+                    current_cov = []
+                    for cov in cov_statement.covariate:
+                        if cov in mechanistic_covariates:
+                            current_cov.append(cov)
+                    if current_cov:
+                        mechanistic_cov = Covariate(
+                            cov_statement.parameter,
+                            tuple(current_cov),
+                            cov_statement.fp,
+                            cov_statement.op,
+                            cov_statement.optional,
+                        )
+                        mechanistic_searchspace.append(mechanistic_cov)
+                        if filtered_cov_set := tuple(
+                            set(cov_statement.covariate) - set(current_cov)
+                        ):
+                            filtered_cov = Covariate(
+                                cov_statement.parameter,
+                                filtered_cov_set,
+                                cov_statement.fp,
+                                cov_statement.op,
+                                cov_statement.optional,
+                            )
+                            filtered_searchspace.append(filtered_cov)
+                    else:
+                        filtered_searchspace.append(cov_statement)
+
+            if not mechanistic_searchspace:
+                warnings.warn(
+                    'No covariate effect for given mechanistic covariates found.'
+                    ' Skipping mechanistic COVsearch.'
+                )
+            else:
+                res = run_tool(
+                    'covsearch',
+                    mfl_stringify(mechanistic_searchspace),
+                    model=model,
+                    strictness=strictness,
+                    results=model.modelfit_results,
+                    path=path / 'covsearch_mechanistic',
+                )
+                index_offset = int(
+                    res.summary_tool.iloc[-1].name[-1][13:]
+                )  # Get largest number of run
+                if res.final_model.name != model.name:
+                    model = res.final_model
+                    model_results = res.tool_database.model_database.retrieve_modelfit_results(
+                        res.final_model.name
+                    )
+                    model = model.replace(modelfit_results=model_results)
+                    added_covs = ModelFeatures.create_from_mfl_string(
+                        get_model_features(model)
+                    ).covariate
+                    filtered_searchspace.extend(
+                        added_covs
+                    )  # Avoid removing added cov in exploratory
+        else:
+            filtered_searchspace = search_space
+
         res = run_tool(
             'covsearch',
-            mfl_stringify(search_space),
+            mfl_stringify(filtered_searchspace),
             model=model,
             strictness=strictness,
-            path=path / 'covsearch',
+            results=model.modelfit_results,
+            path=path / 'covsearch_exploratory',
+            naming_index_offset=index_offset,
         )
         assert isinstance(res, Results)
         return res
 
-    return _run_covariates
+    return _run_mechanistic_exploratory_covariates
 
 
 def _subfunc_allometry(amd_start_model: Model, input_allometric_variable, path) -> SubFunc:

--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -190,7 +190,6 @@ def _init_search_state(context, effects: str, model: Model) -> SearchState:
     if filtered_model.description != model.description:
         filtered_fit_wf = create_fit_workflow(models=[filtered_model])
         filtered_model = call_workflow(filtered_fit_wf, 'fit_filtered_model', context)
-        # TODO : Handle case where model with mandatory covariates
     else:
         filtered_model = model
     candidate = Candidate(filtered_model, ())

--- a/src/pharmpy/tools/mfl/grammar.py
+++ b/src/pharmpy/tools/mfl/grammar.py
@@ -34,7 +34,7 @@ elimination: "ELIMINATION"i "(" (_elimination_option) ")"
 peripherals: "PERIPHERALS"i "(" (_counts) ["," _peripheral_comp] ")"
 transits: "TRANSITS"i "(" _counts ["," _depot_option] ")"
 lagtime: "LAGTIME"i "(" (_lagtime_option) ")"
-covariate: "COVARIATE"i "(" parameter_option "," covariate_option "," fp_option ["," op_option] ")"
+covariate: "COVARIATE"i [optional_cov] "(" parameter_option "," covariate_option "," fp_option ["," op_option] ")"
 
 direct_effect: "DIRECTEFFECT"i "(" (_pdtype_option) ")"
 effect_comp: "EFFECTCOMP"i "(" (_pdtype_option) ")"
@@ -61,32 +61,40 @@ _absorption_option: absorption_modes | absorption_wildcard
 absorption_modes: ABSORPTION_MODE | "[" [ABSORPTION_MODE ("," ABSORPTION_MODE)*] "]"
 absorption_wildcard: WILDCARD
 ABSORPTION_MODE: "FO"i | "ZO"i | "SEQ-ZO-FO"i | "INST"i
+
 _elimination_option: elimination_modes | elimination_wildcard
 elimination_modes: ELIMINATION_MODE | "[" [ELIMINATION_MODE ("," ELIMINATION_MODE)*] "]"
 elimination_wildcard: WILDCARD
 ELIMINATION_MODE: "FO"i | "ZO"i | "MM"i | "MIX-FO-MM"i
+
 _depot_option: depot_modes | depot_wildcard
 depot_modes: DEPOT_MODE | "[" [DEPOT_MODE ("," DEPOT_MODE)*] "]"
 DEPOT_MODE: "DEPOT"i |"NODEPOT"i
 depot_wildcard: WILDCARD
+
 _peripheral_comp: peripheral_modes | peripheral_wildcard
 peripheral_modes: PERIPHERAL_MODE | "[" [PERIPHERAL_MODE ("," PERIPHERAL_MODE)*] "]"
 PERIPHERAL_MODE: "DRUG"i | "MET"i
 peripheral_wildcard: WILDCARD
+
 _lagtime_option: lagtime_modes | lagtime_wildcard
 lagtime_modes: LAGTIME_MODE | "[" [LAGTIME_MODE ("," LAGTIME_MODE)*] "]"
 lagtime_wildcard: WILDCARD
 LAGTIME_MODE: "ON"i | "OFF"i
+
 parameter_option: values | ref | parameter_wildcard
 covariate_option: values | ref | covariate_wildcard
 fp_option: values | fp_wildcard
 !op_option: "+" | "*"
+optional_cov: OPTIONAL
+
 ref: "@" VARIABLE_NAME
 parameter_wildcard: WILDCARD
 covariate_wildcard: WILDCARD
 fp_wildcard: WILDCARD
 
 WILDCARD: "*"
+OPTIONAL: "?"
 
 VARIABLE_NAME: /[a-zA-Z_]+/
 

--- a/src/pharmpy/tools/mfl/parse.py
+++ b/src/pharmpy/tools/mfl/parse.py
@@ -180,7 +180,7 @@ class ModelFeatures:
             elif isinstance(statement, Let):
                 let[statement.name] = statement.value
             else:
-                raise ValueError(f'Unknown statement ({statement}) given.')
+                raise ValueError(f'Unknown ({type(statement)} statement ({statement}) given.')
 
         # Substitute all Let statements (if any)
         if len(let) != 0:

--- a/src/pharmpy/tools/mfl/parse.py
+++ b/src/pharmpy/tools/mfl/parse.py
@@ -623,7 +623,7 @@ class ModelFeatures:
             for effect in cov.eval().fp:
                 for op in cov.op:
                     # TODO : Ignore using PROD and simply use tuple with one value each
-                    lhs[(effect, op)].update(set(product(cov.parameter, cov.covariate)))
+                    lhs[(effect.lower(), op)].update(set(product(cov.parameter, cov.covariate)))
 
         if len(lhs_ref) != 0:
             raise ValueError(

--- a/src/pharmpy/tools/mfl/parse.py
+++ b/src/pharmpy/tools/mfl/parse.py
@@ -34,6 +34,7 @@ from .grammar import grammar
 from .helpers import all_funcs, funcs, modelsearch_features
 from .interpreter import MFLInterpreter
 from .statement.feature.covariate import Ref
+from .statement.feature.symbols import Wildcard
 from .statement.statement import Statement
 from .stringify import stringify as mfl_stringify
 
@@ -67,12 +68,26 @@ def validate_mfl_list(mfl_statement_list):
     # TODO : Implement for other features as necessary
     optional_cov = set()
     mandatory_cov = set()
+    # FIXME (?) : Allow for same exact cov effect to be forced by multiple explicit statements
     for s in mfl_statement_list:
         if isinstance(s, Covariate):
-            if s.optional.option:
-                optional_cov.update(product(s.parameter, s.covariate))
-            else:
-                mandatory_cov.update(product(s.parameter, s.covariate))
+            if not s.optional.option and isinstance(s.fp, Wildcard):
+                raise ValueError(
+                    f"Error in {mfl_stringify([s])} :"
+                    f" Mandatory effects need to be explicit (not '*')"
+                )
+            if not isinstance(s.parameter, Ref) and not isinstance(s.covariate, Ref):
+                if s.optional.option:
+                    optional_cov.update(product(s.parameter, s.covariate))
+                else:
+                    if error := [
+                        e for e in product(s.parameter, s.covariate) if e in mandatory_cov
+                    ]:
+                        raise ValueError(
+                            f"Covariate effect(s) {error} is being forced by"
+                            f" multiple statements. Please force only once"
+                        )
+                    mandatory_cov.update(product(s.parameter, s.covariate))
     if error := [op for op in optional_cov if op in mandatory_cov]:
         raise ValueError(
             f"The covariate effect(s) {error} : are defined as both mandatory and optional"
@@ -249,13 +264,36 @@ class ModelFeatures:
         return self._covariate
 
     def expand(self, model):
+        explicit_covariates = set(
+            [
+                p
+                for c in self.covariate
+                if (not isinstance(c.parameter, Ref) and not isinstance(c.covariate, Ref))
+                for p in product(c.parameter, c.covariate)
+            ]
+        )  # Override @ reference with explicit value
+        covariate = tuple(
+            c for c in [c.eval(model, explicit_covariates) for c in self.covariate] if c is not None
+        )
+
+        param_cov = [
+            p for c in covariate for p in product(c.parameter, c.covariate) if not c.optional.option
+        ]
+        counts = [(c, param_cov.count(c)) for c in param_cov]
+        if any(c[1] > 1 for c in counts):
+            error = set(c[0] for c in filter(lambda c: c[1] > 1, counts))
+            raise ValueError(
+                f"Covariate effect(s) {error} is forced by multiple reference statements."
+                f" Please redefine the search space."
+            )
+
         return ModelFeatures.create(
             absorption=self.absorption.eval,
             elimination=self.elimination.eval,
             transits=tuple([t.eval for t in self.transits]),
             peripherals=self.peripherals,
             lagtime=self.lagtime.eval,
-            covariate=tuple([c.eval(model) for c in self.covariate]),
+            covariate=covariate,
         )
 
     def mfl_statement_list(self, attribute_type: Optional[List[str]] = []):

--- a/src/pharmpy/tools/mfl/statement/feature/covariate.py
+++ b/src/pharmpy/tools/mfl/statement/feature/covariate.py
@@ -63,8 +63,8 @@ class Covariate(ModelFeature):
                 p for p, c in param_cov.intersection(explicit_covariates) if c in covariate
             ]
             parameter = tuple([p for p in parameter if p not in explicit_to_remove])
-            if len(parameter) == 0:
-                return None
+        if len(parameter) == 0 or len(covariate) == 0:
+            return None
         return Covariate(parameter=parameter, covariate=covariate, fp=fp, op=op, optional=optional)
 
 

--- a/src/pharmpy/tools/mfl/statement/feature/symbols.py
+++ b/src/pharmpy/tools/mfl/statement/feature/symbols.py
@@ -16,3 +16,8 @@ class Name(Symbol, Generic[T]):
 @dataclass(frozen=True)
 class Wildcard(Symbol):
     pass
+
+
+@dataclass(frozen=True)
+class Option(Symbol):
+    option: bool

--- a/tests/integration/test_amd.py
+++ b/tests/integration/test_amd.py
@@ -45,12 +45,47 @@ def test_amd(tmp_path, testdata):
             'ruvsearch',
             'iovsearch',
             'allometry',
-            'covsearch',
+            'covsearch_exploratory',
         ]
         for dir in subrundir:
             dir = rundir / dir
             assert _model_count(dir) >= 1
 
         assert len(res.summary_tool) == len(subrundir)
+        assert len(res.summary_models) >= 1
+        assert len(res.summary_individuals_count) >= 1
+
+
+def test_structura_mechanistic_exploratory(tmp_path, testdata):
+    with chdir(tmp_path):
+        shutil.copy2(testdata / 'nonmem' / 'models' / 'moxo_simulated_amd.csv', '.')
+        shutil.copy2(testdata / 'nonmem' / 'models' / 'moxo_simulated_amd.datainfo', '.')
+        input = 'moxo_simulated_amd.csv'
+        res = run_amd(
+            input,
+            modeltype='basic_pk',
+            administration='oral',
+            search_space='COVARIATE(CL,WT,pow);COVARIATE?(VC,AGE,exp);COVARIATE?(MAT,SEX,cat)',
+            order=['covariates'],
+            mechanistic_covariates=["AGE"],
+            occasion='VISI',
+            strictness='minimization_successful or rounding_errors',
+        )
+
+        rundir = tmp_path / 'amd_dir1'
+        assert rundir.is_dir()
+        assert (rundir / 'results.json').exists()
+        assert (rundir / 'results.csv').exists()
+        subrundir = [
+            'modelfit',
+            'covsearch_structural',
+            'covsearch_mechanistic',
+            'covsearch_exploratory',
+        ]
+        for dir in subrundir:
+            dir = rundir / dir
+            assert _model_count(dir) >= 1
+
+        assert len(res.summary_tool) == len(subrundir) - 1  # Mechanistic/Exploratory grouped as one
         assert len(res.summary_models) >= 1
         assert len(res.summary_individuals_count) >= 1

--- a/tests/tools/test_mfl.py
+++ b/tests/tools/test_mfl.py
@@ -11,7 +11,7 @@ from pharmpy.tools.mfl.statement.feature.covariate import Covariate, Ref
 from pharmpy.tools.mfl.statement.feature.elimination import Elimination
 from pharmpy.tools.mfl.statement.feature.lagtime import LagTime
 from pharmpy.tools.mfl.statement.feature.peripherals import Peripherals
-from pharmpy.tools.mfl.statement.feature.symbols import Name, Wildcard
+from pharmpy.tools.mfl.statement.feature.symbols import Name, Option, Wildcard
 from pharmpy.tools.mfl.statement.feature.transits import Transits
 from pharmpy.tools.mfl.statement.statement import Statement
 from pharmpy.tools.mfl.stringify import stringify
@@ -232,28 +232,37 @@ from pharmpy.tools.mfl.stringify import stringify
             'COVARIATE([CL, MAT, VC], @CONTINUOUS, EXP, *)\n'
             'COVARIATE([CL, MAT, VC], @CATEGORICAL, CAT, +)',
             (
-                ('COVARIATE', 'CL', 'APGR', 'cat', '+'),
-                ('COVARIATE', 'CL', 'WGT', 'exp', '*'),
-                ('COVARIATE', 'MAT', 'APGR', 'cat', '+'),
-                ('COVARIATE', 'MAT', 'WGT', 'exp', '*'),
-                ('COVARIATE', 'VC', 'APGR', 'cat', '+'),
-                ('COVARIATE', 'VC', 'WGT', 'exp', '*'),
+                ('COVARIATE', 'CL', 'APGR', 'cat', '+', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'MAT', 'APGR', 'cat', '+', 'ADD'),
+                ('COVARIATE', 'MAT', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'VC', 'APGR', 'cat', '+', 'ADD'),
+                ('COVARIATE', 'VC', 'WGT', 'exp', '*', 'ADD'),
             ),
         ),
         (
             'LET(CONTINUOUS, [AGE, WT]); LET(CATEGORICAL, SEX)\n'
-            'COVARIATE([CL, MAT, VC], @CONTINUOUS, EXP, *)\n'
-            'COVARIATE([CL, MAT, VC], @CATEGORICAL, CAT, +)',
+            'COVARIATE?([CL, MAT, VC], @CONTINUOUS, EXP, *)\n'
+            'COVARIATE?([CL, MAT, VC], @CATEGORICAL, CAT, +)',
             (
-                ('COVARIATE', 'CL', 'AGE', 'exp', '*'),
-                ('COVARIATE', 'CL', 'SEX', 'cat', '+'),
-                ('COVARIATE', 'CL', 'WT', 'exp', '*'),
-                ('COVARIATE', 'MAT', 'AGE', 'exp', '*'),
-                ('COVARIATE', 'MAT', 'SEX', 'cat', '+'),
-                ('COVARIATE', 'MAT', 'WT', 'exp', '*'),
-                ('COVARIATE', 'VC', 'AGE', 'exp', '*'),
-                ('COVARIATE', 'VC', 'SEX', 'cat', '+'),
-                ('COVARIATE', 'VC', 'WT', 'exp', '*'),
+                ('COVARIATE', 'CL', 'AGE', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'SEX', 'cat', '+', 'ADD'),
+                ('COVARIATE', 'CL', 'WT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'MAT', 'AGE', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'MAT', 'SEX', 'cat', '+', 'ADD'),
+                ('COVARIATE', 'MAT', 'WT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'VC', 'AGE', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'VC', 'SEX', 'cat', '+', 'ADD'),
+                ('COVARIATE', 'VC', 'WT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'AGE', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'SEX', 'cat', '+', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'MAT', 'AGE', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'MAT', 'SEX', 'cat', '+', 'REMOVE'),
+                ('COVARIATE', 'MAT', 'WT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'VC', 'AGE', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'VC', 'SEX', 'cat', '+', 'REMOVE'),
+                ('COVARIATE', 'VC', 'WT', 'exp', '*', 'REMOVE'),
             ),
         ),
         (
@@ -261,57 +270,81 @@ from pharmpy.tools.mfl.stringify import stringify
             'COVARIATE([CL, MAT, VC], @CONTINUOUS, [EXP])\n'
             'COVARIATE([CL, MAT, VC], @CATEGORICAL, CAT, +)',
             (
-                ('COVARIATE', 'CL', 'AGE', 'exp', '*'),
-                ('COVARIATE', 'CL', 'SEX', 'cat', '+'),
-                ('COVARIATE', 'CL', 'WT', 'exp', '*'),
-                ('COVARIATE', 'MAT', 'AGE', 'exp', '*'),
-                ('COVARIATE', 'MAT', 'SEX', 'cat', '+'),
-                ('COVARIATE', 'MAT', 'WT', 'exp', '*'),
-                ('COVARIATE', 'VC', 'AGE', 'exp', '*'),
-                ('COVARIATE', 'VC', 'SEX', 'cat', '+'),
-                ('COVARIATE', 'VC', 'WT', 'exp', '*'),
+                ('COVARIATE', 'CL', 'AGE', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'SEX', 'cat', '+', 'ADD'),
+                ('COVARIATE', 'CL', 'WT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'MAT', 'AGE', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'MAT', 'SEX', 'cat', '+', 'ADD'),
+                ('COVARIATE', 'MAT', 'WT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'VC', 'AGE', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'VC', 'SEX', 'cat', '+', 'ADD'),
+                ('COVARIATE', 'VC', 'WT', 'exp', '*', 'ADD'),
             ),
         ),
         (
             'LET(CONTINUOUS, AGE); LET(CATEGORICAL, SEX)\n'
-            'COVARIATE([CL], @CONTINUOUS, *)\n'
+            'COVARIATE?([CL], @CONTINUOUS, *)\n'
             'COVARIATE([VC], @CATEGORICAL, CAT, +)',
             (
-                ('COVARIATE', 'CL', 'AGE', 'exp', '*'),
-                ('COVARIATE', 'CL', 'AGE', 'lin', '*'),
-                ('COVARIATE', 'CL', 'AGE', 'piece_lin', '*'),
-                ('COVARIATE', 'CL', 'AGE', 'pow', '*'),
-                ('COVARIATE', 'VC', 'SEX', 'cat', '+'),
+                ('COVARIATE', 'CL', 'AGE', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'AGE', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'AGE', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'AGE', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'AGE', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'AGE', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'AGE', 'piece_lin', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'AGE', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'VC', 'SEX', 'cat', '+', 'ADD'),
             ),
         ),
         (
-            'COVARIATE(@IIV, @CONTINUOUS, *);' 'COVARIATE(*, @CATEGORICAL, CAT, *)',
+            'COVARIATE?(@IIV, @CONTINUOUS, *);' 'COVARIATE?(*, @CATEGORICAL, CAT, *)',
             (
-                ('COVARIATE', 'CL', 'APGR', 'cat', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'exp', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'lin', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'pow', '*'),
-                ('COVARIATE', 'V', 'APGR', 'cat', '*'),
-                ('COVARIATE', 'V', 'WGT', 'exp', '*'),
-                ('COVARIATE', 'V', 'WGT', 'lin', '*'),
-                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*'),
-                ('COVARIATE', 'V', 'WGT', 'pow', '*'),
+                ('COVARIATE', 'CL', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'V', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'APGR', 'cat', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'APGR', 'cat', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*', 'REMOVE'),
             ),
         ),
         (
-            'COVARIATE(@PK, @CONTINUOUS, *);' 'COVARIATE(@PK, @CATEGORICAL, CAT, *)',
+            'COVARIATE?(@PK, @CONTINUOUS, *);' 'COVARIATE?(@PK, @CATEGORICAL, CAT, *)',
             (
-                ('COVARIATE', 'CL', 'APGR', 'cat', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'exp', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'lin', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'pow', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*'),
-                ('COVARIATE', 'V', 'APGR', 'cat', '*'),
-                ('COVARIATE', 'V', 'WGT', 'exp', '*'),
-                ('COVARIATE', 'V', 'WGT', 'lin', '*'),
-                ('COVARIATE', 'V', 'WGT', 'pow', '*'),
-                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*'),
+                ('COVARIATE', 'CL', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'V', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'APGR', 'cat', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'APGR', 'cat', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*', 'REMOVE'),
             ),
         ),
         (
@@ -319,8 +352,8 @@ from pharmpy.tools.mfl.stringify import stringify
             'COVARIATE(@DISTRIBUTION, WGT, EXP);'
             'COVARIATE(@ELIMINATION, SEX, CAT)',
             (
-                ('COVARIATE', 'CL', 'SEX', 'cat', '*'),
-                ('COVARIATE', 'V', 'WGT', 'exp', '*'),
+                ('COVARIATE', 'CL', 'SEX', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*', 'ADD'),
             ),
         ),
         (
@@ -358,33 +391,51 @@ def test_all_funcs(load_model_for_test, pheno_path, source, expected):
     ('source', 'expected'),
     (
         (
-            'COVARIATE(@PK, @CONTINUOUS, *);' 'COVARIATE(@PK, @CATEGORICAL, CAT, *)',
+            'COVARIATE?(@PK, @CONTINUOUS, *);' 'COVARIATE?(@PK, @CATEGORICAL, CAT, *)',
             (
-                ('COVARIATE', 'CL', 'APGR', 'cat', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'exp', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'lin', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'pow', '*'),
-                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*'),
-                ('COVARIATE', 'V', 'APGR', 'cat', '*'),
-                ('COVARIATE', 'V', 'WGT', 'exp', '*'),
-                ('COVARIATE', 'V', 'WGT', 'lin', '*'),
-                ('COVARIATE', 'V', 'WGT', 'pow', '*'),
-                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*'),
+                ('COVARIATE', 'CL', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'V', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'APGR', 'cat', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'APGR', 'cat', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*', 'REMOVE'),
             ),
         ),
         (
-            'COVARIATE(@PD, @CONTINUOUS, *);' 'COVARIATE(@PD, @CATEGORICAL, CAT, *)',
+            'COVARIATE?(@PD, @CONTINUOUS, *);' 'COVARIATE(@PD, @CATEGORICAL, CAT, *)',
             (
-                ('COVARIATE', 'B', 'APGR', 'cat', '*'),
-                ('COVARIATE', 'B', 'WGT', 'exp', '*'),
-                ('COVARIATE', 'B', 'WGT', 'lin', '*'),
-                ('COVARIATE', 'B', 'WGT', 'pow', '*'),
-                ('COVARIATE', 'B', 'WGT', 'piece_lin', '*'),
-                ('COVARIATE', 'SLOPE', 'APGR', 'cat', '*'),
-                ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*'),
-                ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*'),
-                ('COVARIATE', 'SLOPE', 'WGT', 'pow', '*'),
-                ('COVARIATE', 'SLOPE', 'WGT', 'piece_lin', '*'),
+                ('COVARIATE', 'B', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'B', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'B', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'B', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'B', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'B', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'B', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'B', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'B', 'WGT', 'piece_lin', '*', 'REMOVE'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'piece_lin', '*', 'REMOVE'),
             ),
         ),
     ),
@@ -399,65 +450,91 @@ def test_all_funcs_pd(load_model_for_test, pheno_path, source, expected):
     assert set(keys) == set(expected)
 
 
-# @pytest.mark.parametrize(
-#    ('source', 'expected'),
-#    (
-#        (
-#            'COVARIATE(@PD_IIV, @CONTINUOUS, *);' 'COVARIATE(@PD_IIV, @CATEGORICAL, CAT, *)',
-#            (
-#                ('COVARIATE', 'SLOPE', 'APGR', 'cat', '*'),
-#                ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*'),
-#                ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*'),
-#                ('COVARIATE', 'SLOPE', 'WGT', 'pow', '*'),
-#                ('COVARIATE', 'SLOPE', 'WGT', 'piece_lin', '*'),
-#            ),
-#        ),
-#        (
-#            'COVARIATE(@PK_IIV, @CONTINUOUS, *);' 'COVARIATE(@PK_IIV, @CATEGORICAL, CAT, *)',
-#            (
-#                ('COVARIATE', 'CL', 'APGR', 'cat', '*'),
-#                ('COVARIATE', 'CL', 'WGT', 'exp', '*'),
-#                ('COVARIATE', 'CL', 'WGT', 'lin', '*'),
-#                ('COVARIATE', 'CL', 'WGT', 'pow', '*'),
-#                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*'),
-#                ('COVARIATE', 'V', 'APGR', 'cat', '*'),
-#                ('COVARIATE', 'V', 'WGT', 'exp', '*'),
-#                ('COVARIATE', 'V', 'WGT', 'lin', '*'),
-#                ('COVARIATE', 'V', 'WGT', 'pow', '*'),
-#                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*'),
-#            ),
-#        ),
-#        (
-#            'COVARIATE(@IIV, @CONTINUOUS, *);' 'COVARIATE(@IIV, @CATEGORICAL, CAT, *)',
-#            (
-#                ('COVARIATE', 'SLOPE', 'APGR', 'cat', '*'),
-#                ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*'),
-#                ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*'),
-#                ('COVARIATE', 'SLOPE', 'WGT', 'pow', '*'),
-#                ('COVARIATE', 'SLOPE', 'WGT', 'piece_lin', '*'),
-#                ('COVARIATE', 'CL', 'APGR', 'cat', '*'),
-#                ('COVARIATE', 'CL', 'WGT', 'exp', '*'),
-#                ('COVARIATE', 'CL', 'WGT', 'lin', '*'),
-#                ('COVARIATE', 'CL', 'WGT', 'pow', '*'),
-#                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*'),
-#                ('COVARIATE', 'V', 'APGR', 'cat', '*'),
-#                ('COVARIATE', 'V', 'WGT', 'exp', '*'),
-#                ('COVARIATE', 'V', 'WGT', 'lin', '*'),
-#                ('COVARIATE', 'V', 'WGT', 'pow', '*'),
-#                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*'),
-#            ),
-#        ),
-#    ),
-#    ids=repr,
-# )
-# def test_all_funcs_pd_iiv(load_model_for_test, pheno_path, source, expected):
-#    model = load_model_for_test(pheno_path)
-#    model = set_direct_effect(model, 'linear')
-#    model = add_iiv(model, 'SLOPE', 'exp')
-#    statements = parse(source)
-#    funcs = all_funcs(model, statements)
-#    keys = funcs.keys()
-#    assert set(keys) == set(expected)
+@pytest.mark.parametrize(
+    ('source', 'expected'),
+    (
+        (
+            'COVARIATE?(@PD_IIV, @CONTINUOUS, *);' 'COVARIATE(@PD_IIV, @CATEGORICAL, CAT, *)',
+            (
+                ('COVARIATE', 'SLOPE', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'piece_lin', '*', 'REMOVE'),
+            ),
+        ),
+        (
+            'COVARIATE?(@PK_IIV, @CONTINUOUS, *);' 'COVARIATE(@PK_IIV, @CATEGORICAL, CAT, *)',
+            (
+                ('COVARIATE', 'CL', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'V', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*', 'REMOVE'),
+            ),
+        ),
+        (
+            'COVARIATE?(@IIV, @CONTINUOUS, *);' 'COVARIATE(@IIV, @CATEGORICAL, CAT, *)',
+            (
+                ('COVARIATE', 'SLOPE', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'V', 'APGR', 'cat', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*', 'ADD'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*', 'ADD'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'SLOPE', 'WGT', 'piece_lin', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'CL', 'WGT', 'piece_lin', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'exp', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'lin', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'pow', '*', 'REMOVE'),
+                ('COVARIATE', 'V', 'WGT', 'piece_lin', '*', 'REMOVE'),
+            ),
+        ),
+    ),
+    ids=repr,
+)
+def test_all_funcs_pd_iiv(load_model_for_test, pheno_path, source, expected):
+    from pharmpy.modeling import add_iiv
+
+    model = load_model_for_test(pheno_path)
+    model = set_direct_effect(model, 'linear')
+    model = add_iiv(model, 'SLOPE', 'exp')
+    statements = parse(source)
+    funcs = all_funcs(model, statements)
+    keys = funcs.keys()
+    assert set(keys) == set(expected)
 
 
 @pytest.mark.parametrize(
@@ -465,7 +542,7 @@ def test_all_funcs_pd(load_model_for_test, pheno_path, source, expected):
     (
         (
             'COVARIATE(@BIOAVAIL, APGR, CAT, +)',
-            (('COVARIATE', 'BIO', 'APGR', 'cat', '+'),),
+            (('COVARIATE', 'BIO', 'APGR', 'cat', '+', 'ADD'),),
         ),
     ),
     ids=repr,
@@ -479,13 +556,19 @@ def test_funcs_ivoral(source, expected):
 
 
 @pytest.mark.parametrize(
-    'code',
-    [
-        ('ABSORPTION(ILLEGAL)'),
-        ('ELIMINATION(ALSOILLEGAL)'),
-        ('LAGTIME(0)'),
-        ('TRANSITS(*)'),
-    ],
+    ('code'),
+    (
+        [
+            ('ABSORPTION(ILLEGAL)'),
+            ('ELIMINATION(ALSOILLEGAL)'),
+            ('LAGTIME(0)'),
+            ('TRANSITS(*)'),
+        ],
+        [
+            ('COVARIATE([V], WGT, *, +)'),
+            ('COVARIATE?(V, WGT, *, +)'),
+        ],
+    ),
 )
 def test_illegal_mfl(code):
     with pytest.raises(Exception):
@@ -522,6 +605,10 @@ def test_illegal_mfl(code):
                 Covariate(Ref('IIV'), Ref('CATEGORICAL'), ('CAT',), '*'),
             ),
             'COVARIATE(@IIV,@CONTINUOUS,EXP);' 'COVARIATE(@IIV,@CATEGORICAL,CAT)',
+        ),
+        (
+            (Covariate(('CL',), ('WGT',), Wildcard(), '+', Option(True)),),
+            'COVARIATE?(CL,WGT,*,+)',
         ),
     ),
 )
@@ -584,8 +671,8 @@ def test_ModelFeatures_add(load_model_for_test, pheno_path):
 
     assert mfl + model_mfl == expected_mfl
 
-    m1 = ModelFeatures.create_from_mfl_string("COVARIATE(V, WGT, *)")
-    m2 = ModelFeatures.create_from_mfl_string("COVARIATE(@ELIMINATION, WGT, *)")
+    m1 = ModelFeatures.create_from_mfl_string("COVARIATE?(V, WGT, *)")
+    m2 = ModelFeatures.create_from_mfl_string("COVARIATE?(@ELIMINATION, WGT, *)")
 
     with pytest.raises(
         ValueError,
@@ -645,8 +732,8 @@ def test_ModelFeatures_sub(load_model_for_test, pheno_path):
     res_mfl = model_mfl - mfl
     assert res_mfl == expected_mfl
 
-    m1 = ModelFeatures.create_from_mfl_string("COVARIATE([CL,V], WGT, *)")
-    m2 = ModelFeatures.create_from_mfl_string("COVARIATE(@ELIMINATION, WGT, *)")
+    m1 = ModelFeatures.create_from_mfl_string("COVARIATE?([CL,V], WGT, *)")
+    m2 = ModelFeatures.create_from_mfl_string("COVARIATE?(@ELIMINATION, WGT, *)")
 
     with pytest.raises(
         ValueError,
@@ -674,9 +761,9 @@ def test_least_number_of_transformations(load_model_for_test, pheno_path):
     assert ('ABSORPTION', 'FO') in lnt
     assert ('ELIMINATION', 'ZO') in lnt
     assert ('PERIPHERALS', 1) in lnt
-    assert ('COVARIATE', 'CL', 'WGT', 'custom', '*') in lnt
-    assert ('COVARIATE', 'V', 'WGT', 'custom', '*') in lnt
-    assert ('COVARIATE', 'V', 'APGR', 'custom', '*') in lnt
+    assert ('COVARIATE', 'CL', 'WGT', 'custom', '*', 'REMOVE') in lnt
+    assert ('COVARIATE', 'V', 'WGT', 'custom', '*', 'REMOVE') in lnt
+    assert ('COVARIATE', 'V', 'APGR', 'custom', '*', 'REMOVE') in lnt
 
     assert len(lnt) == 6
 


### PR DESCRIPTION
Updates to covsearch for handling of optional and mandatory covariates using the COVARIATE(...) vs COVARIATE?(...) notation
Also added possibility of defining mechanistic covariates as argument for AMD which would cause AMD to run a initial covsearch run with the specified covariates.
ModelEntry has also now been implemented for covsearch as a part of this update