### PR TITLE
Pre-defined strategies for order in AMD

### DIFF
--- a/src/pharmpy/tools/mfl/parse.py
+++ b/src/pharmpy/tools/mfl/parse.py
@@ -341,7 +341,7 @@ class ModelFeatures:
         else:
             return funcs(model, self.mfl_statement_list(attribute_type), modelsearch_features)
 
-    def contain_subset(self, mfl, model: Optional[Model] = None):
+    def contain_subset(self, mfl, model: Optional[Model] = None, tool: Optional[str] = None):
         """See if class contain specified subset"""
         transits = self._subset_transits(mfl)
 
@@ -353,12 +353,14 @@ class ModelFeatures:
             and all([s in self.peripherals.counts for s in mfl.peripherals.counts])
             and all([s in self.lagtime.eval.modes for s in mfl.lagtime.eval.modes])
         ):
-            if self.covariate != tuple() or mfl.covariate != tuple():
-                if model is None:
-                    warnings.warn("Need argument 'model' in order to compare covariates")
-                else:
-                    return True if self._subset_covariate else False
-            return True
+            if tool is None or tool in ["modelsearch"]:
+                return True
+            else:
+                if self.covariate != tuple() or mfl.covariate != tuple():
+                    if model is None:
+                        warnings.warn("Need argument 'model' in order to compare covariates")
+                    else:
+                        return True if self._subset_covariate(mfl, model) else False
         else:
             return False
 

--- a/src/pharmpy/tools/modelsearch/tool.py
+++ b/src/pharmpy/tools/modelsearch/tool.py
@@ -109,7 +109,7 @@ def start(
     # Add base model task
     model_mfl = get_model_features(model, supress_warnings=True)
     model_mfl = ModelFeatures.create_from_mfl_string(model_mfl)
-    if not mfl_statements.contain_subset(model_mfl):
+    if not mfl_statements.contain_subset(model_mfl, tool="modelsearch"):
         base_task = Task("create_base_model", create_base_model, mfl_statements)
         wb.add_task(base_task, predecessors=start_task)
 


### PR DESCRIPTION
Remove the order option from AMD and instead implement new argument "strategy" for defining how to run the tools. Currently there are two strategies implemented:

- SIRIAC (Structural IIVsearch, RUVsearch, IOVsearch, Allometry, Covariate)
- SIRIACIR (Structural IIVsearch, RUVsearch, IOVsearch, Allometry, Covariate IIVsearch, RUVsearch)

Any other ideas for naming of said strategies are much appreciated.

As order was removed, some reformatting of the validation of the input arguments of AMD has also been done (in order to ease testing of the arguments among other things)