### PR TITLE
Correctly expand covariate mfl statements

### DIFF
--- a/src/pharmpy/tools/mfl/parse.py
+++ b/src/pharmpy/tools/mfl/parse.py
@@ -195,6 +195,7 @@ class ModelFeatures:
                     else let[cov.covariate.name],
                     fp=cov.fp,
                     op=cov.op,
+                    optional=cov.optional,
                 )
 
             covariate = tuple([_let_subs(cov, let) for cov in covariate])


### PR DESCRIPTION
Correctly expand optional/non-optional covariates in MFL class