### PR TITLE
Integrate parameter_sampling in retries tool

### DIFF
--- a/docs/amd.rst
+++ b/docs/amd.rst
@@ -85,7 +85,9 @@ Arguments
 |``mechanistic_covariates``                         | List of covariates to run in a separate prioritezed covsearch run.                                              |
 |                                                   | The effects are extracted from the given search space                                                           |
 +---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
-| ``retries_strategy``                               | Decide how to use the retries tool. Valid options are 'skip', 'all_final' or 'final'. Default is 'final'       |
+| ``retries_strategy``                              | Decide how to use the retries tool. Valid options are 'skip', 'all_final' or 'final'. Default is 'final'        |
++---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+| ``seed``                                          | A random number generator or seed to use for steps with random sampling.                                        |
 +---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 
 .. _input_amd:
@@ -461,14 +463,17 @@ Retries
 If ``retries_strategy`` is set to 'all_final', the retries tool will be run on the final model from each subtool.
 With the argument set to 'final', the retries tool will only be run on the final model from the last subtool.
 Finally, if the argument is set to 'skip', no retries will be performed. See :ref:`retries` for more details about the 
-tool. When running the tool from AMD, the settings below will be used
+tool. When running the tool from AMD, the settings below will be used.
+
+If argument ``seed`` is set, the chosen seed or random number generator will be used for the random sampling within the
+tool.
 
 +----------------------+----------------------------------------------------------------------------------------------------+
 | Argument             | Setting                                                                                            |
 +======================+====================================================================================================+
 | number_of_candidates | ``5``                                                                                              |
 +----------------------+----------------------------------------------------------------------------------------------------+
-| degree               | ``0.1``                                                                                            |
+| fraction             | ``0.1``                                                                                            |
 +----------------------+----------------------------------------------------------------------------------------------------+
 | scale                | ``UCP``                                                                                            |
 +----------------------+----------------------------------------------------------------------------------------------------+

--- a/docs/retries.rst
+++ b/docs/retries.rst
@@ -46,7 +46,7 @@ The arguments of the retries tool are listed below.
 +-------------------------------------------------+---------------------------------------------------------------------+
 | number_of_candidates                            | Number of retry-models to run. 5 is used as default                 |
 +-------------------------------------------------+---------------------------------------------------------------------+
-| degree                                          | Determine the allowed increase/decrease for the randomly generated  |
+| fraction                                          | Determine the allowed increase/decrease for the randomly generated|
 |                                                 | new initial estimates. Default is 0.1 (10%).                        |
 +-------------------------------------------------+---------------------------------------------------------------------+
 | :ref:`scale<scales_retries>`                    | Scale to use when randomizing the initial estimates. Currently      |
@@ -54,6 +54,8 @@ The arguments of the retries tool are listed below.
 +-------------------------------------------------+---------------------------------------------------------------------+
 | prefix_name                                     | String determining prefix of model names such that models are named |
 |                                                 | {prefix_name}_retries_run2 for instance.                            |
++-------------------------------------------------+---------------------------------------------------------------------+
+| seed                                            | A random number generator or seed to use for random sampling.       |
 +-------------------------------------------------+---------------------------------------------------------------------+
 
 .. _scales_retries:
@@ -119,7 +121,7 @@ An example of an entire retries run can be seen below
     res = run_structsearch(model = start_model,
                             results = start_model_results,
                             number_of_candidate = 5,
-                            degree = 0.1,
+                            fraction = 0.1,
                             scale = "UCP")
 
 The ``summary_tool`` table contains information of the model results and final ranking. It also contains information

--- a/src/pharmpy/modeling/parameter_sampling.py
+++ b/src/pharmpy/modeling/parameter_sampling.py
@@ -1,6 +1,6 @@
 import warnings
 from functools import partial
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Literal, Optional, Union
 
 from pharmpy.internals.math import is_posdef, nearest_postive_semidefinite
 from pharmpy.model import Model
@@ -129,6 +129,7 @@ def sample_parameters_uniformly(
     force_posdef_samples: Optional[int] = None,
     n: int = 1,
     seed: Optional[Union[np.random.Generator, int]] = None,
+    scale: Literal['UCP', 'normal'] = 'normal',
 ):
     """Sample parameter vectors using uniform sampling
 
@@ -150,6 +151,8 @@ def sample_parameters_uniformly(
         Number of samples
     seed : int or rng
         Random number generator or seed
+    scale : str
+        Scale to perform sampling on. Valid options are 'normal' and 'UCP'
 
     Returns
     -------
@@ -181,8 +184,12 @@ def sample_parameters_uniformly(
     def fn(pe, lower, upper, n, rng):
         samples = np.empty((n, len(lower)))
         for i, (x, a, b) in enumerate(zip(pe, lower, upper)):
-            lower = max(a, x - x * fraction)
-            upper = min(b, x + x * fraction)
+            if scale == 'normal':
+                lower = max(a, x - x * fraction)
+                upper = min(b, x + x * fraction)
+            elif scale == 'UCP':
+                lower = 0.1 - 0.1 * fraction
+                upper = 0.1 + 0.1 * fraction
             samples[:, i] = rng.uniform(lower, upper, n)
         return samples
 

--- a/src/pharmpy/modeling/parameter_sampling.py
+++ b/src/pharmpy/modeling/parameter_sampling.py
@@ -85,6 +85,9 @@ def _sample_from_function(
     """
     rng = create_rng(seed)
 
+    parameter_estimates = parameter_estimates[
+        parameter_estimates.index.isin(model.parameters.nonfixed.names)
+    ]
     pe = parameter_estimates.to_numpy()
 
     parameter_summary = model.parameters.to_dataframe().loc[parameter_estimates.keys()]

--- a/src/pharmpy/modeling/parameter_sampling.py
+++ b/src/pharmpy/modeling/parameter_sampling.py
@@ -72,7 +72,7 @@ def _sample_from_function(
     samplingfn,
     force_posdef_samples=None,
     n=1,
-    rng=None,
+    seed=None,
 ):
     """Sample parameter vectors using a general function
 
@@ -83,7 +83,7 @@ def _sample_from_function(
     - upper - upper bounds of parameters
     - n - number of samples
     """
-    rng = create_rng(rng)
+    rng = create_rng(seed)
 
     pe = parameter_estimates.to_numpy()
 
@@ -125,7 +125,7 @@ def sample_parameters_uniformly(
     fraction: float = 0.1,
     force_posdef_samples: Optional[int] = None,
     n: int = 1,
-    rng: Optional[Union[np.random.Generator, int]] = None,
+    seed: Optional[Union[np.random.Generator, int]] = None,
 ):
     """Sample parameter vectors using uniform sampling
 
@@ -145,7 +145,7 @@ def sample_parameters_uniformly(
         positive definite covariance matrices.
     n : int
         Number of samples
-    rng : int or rng
+    seed : int or rng
         Random number generator or seed
 
     Returns
@@ -161,7 +161,7 @@ def sample_parameters_uniformly(
     >>> results = load_example_modelfit_results("pheno")
     >>> rng = create_rng(23)
     >>> pe = results.parameter_estimates
-    >>> sample_parameters_uniformly(model, pe, n=3, rng=rng)
+    >>> sample_parameters_uniformly(model, pe, n=3, seed=rng)
           PTVCL      PTVV   THETA_3      IVCL       IVV  SIGMA_1_1
     0  0.004878  0.908216  0.149441  0.029179  0.025472   0.012947
     1  0.004828  1.014444  0.149958  0.028853  0.027653   0.013348
@@ -184,7 +184,7 @@ def sample_parameters_uniformly(
         return samples
 
     samples = _sample_from_function(
-        model, parameter_estimates, fn, force_posdef_samples=force_posdef_samples, n=n, rng=rng
+        model, parameter_estimates, fn, force_posdef_samples=force_posdef_samples, n=n, seed=seed
     )
     return samples
 
@@ -196,7 +196,7 @@ def sample_parameters_from_covariance_matrix(
     force_posdef_samples: Optional[int] = None,
     force_posdef_covmatrix: bool = False,
     n: int = 1,
-    rng: Optional[Union[np.random.Generator, int]] = None,
+    seed: Optional[Union[np.random.Generator, int]] = None,
 ):
     """Sample parameter vectors using the covariance matrix
 
@@ -217,7 +217,7 @@ def sample_parameters_from_covariance_matrix(
         Set to True to force the input covariance matrix to be positive definite
     n : int
         Number of samples
-    rng : Generator
+    seed : Generator
         Random number generator
 
     Returns
@@ -234,7 +234,7 @@ def sample_parameters_from_covariance_matrix(
     >>> rng = create_rng(23)
     >>> cov = results.covariance_matrix
     >>> pe = results.parameter_estimates
-    >>> sample_parameters_from_covariance_matrix(model, pe, cov, n=3, rng=rng)
+    >>> sample_parameters_from_covariance_matrix(model, pe, cov, n=3, seed=rng)
           PTVCL      PTVV   THETA_3      IVCL       IVV  SIGMA_1_1
     0  0.005069  0.974989  0.204629  0.024756  0.012088   0.012943
     1  0.004690  0.958431  0.233231  0.038866  0.029000   0.012516
@@ -263,7 +263,7 @@ def sample_parameters_from_covariance_matrix(
 
     fn = partial(_sample_truncated_joint_normal, sigma)
     samples = _sample_from_function(
-        model, parameter_estimates, fn, force_posdef_samples=force_posdef_samples, n=n, rng=rng
+        model, parameter_estimates, fn, force_posdef_samples=force_posdef_samples, n=n, seed=seed
     )
     return samples
 
@@ -274,7 +274,7 @@ def sample_individual_estimates(
     individual_estimates_covariance: pd.DataFrame,
     parameters: Optional[List[str]] = None,
     samples_per_id: int = 100,
-    rng: Optional[Union[np.random.Generator, int]] = None,
+    seed: Optional[Union[np.random.Generator, int]] = None,
 ):
     """Sample individual estimates given their covariance.
 
@@ -290,7 +290,7 @@ def sample_individual_estimates(
         A list of a subset of individual parameters to sample. Default is None, which means all.
     samples_per_id : int
         Number of samples per individual
-    rng : rng or int
+    seed : rng or int
         Random number generator or seed
 
     Returns
@@ -307,7 +307,7 @@ def sample_individual_estimates(
     >>> rng = create_rng(23)
     >>> ie = results.individual_estimates
     >>> iec = results.individual_estimates_covariance
-    >>> sample_individual_estimates(model, ie, iec, samples_per_id=2, rng=rng)
+    >>> sample_individual_estimates(model, ie, iec, samples_per_id=2, seed=rng)
                   ETA_1     ETA_2
     ID sample
     1  0      -0.127941  0.037273
@@ -331,7 +331,7 @@ def sample_individual_estimates(
     sample_parameters_uniformly : Sample parameter vectors using uniform distribution
 
     """
-    rng = create_rng(rng)
+    rng = create_rng(seed)
     assert rng is not None
     ests = individual_estimates
     covs = individual_estimates_covariance

--- a/src/pharmpy/modeling/results.py
+++ b/src/pharmpy/modeling/results.py
@@ -219,7 +219,7 @@ def calculate_individual_parameter_statistics(
     ],
     parameter_estimates: pd.Series,
     covariance_matrix: Optional[pd.DataFrame] = None,
-    rng: Optional[Union[np.random.Generator, int]] = None,
+    seed: Optional[Union[np.random.Generator, int]] = None,
 ):
     """Calculate statistics for individual parameters
 
@@ -245,7 +245,7 @@ def calculate_individual_parameter_statistics(
         sympy expression or iterable of str or sympy expressions
         Expressions or equations for parameters of interest. If equations are used
         the names of the left hand sides will be used as the names of the parameters.
-    rng : Generator or int
+    seed : Generator or int
         Random number generator or int seed
 
     Returns
@@ -263,14 +263,14 @@ def calculate_individual_parameter_statistics(
     >>> rng = create_rng(23)
     >>> pe = results.parameter_estimates
     >>> cov = results.covariance_matrix
-    >>> calculate_individual_parameter_statistics(model, "K=CL/V", pe, cov, rng=rng)
+    >>> calculate_individual_parameter_statistics(model, "K=CL/V", pe, cov, seed=rng)
                               mean  variance    stderr
     parameter covariates
     K         p5          0.004234  0.000001  0.001138
               median      0.004907  0.000001  0.001247
               p95         0.004907  0.000001  0.001247
     """
-    rng = create_rng(rng)
+    rng = create_rng(seed)
 
     split_exprs = map(
         _split_equation,
@@ -349,7 +349,7 @@ def calculate_individual_parameter_statistics(
             covariance_matrix,
             n=nbatches,
             force_posdef_covmatrix=True,
-            rng=rng,
+            seed=rng,
         )
 
         for _, row in parameters_samples.iterrows():
@@ -403,7 +403,7 @@ def calculate_pk_parameters_statistics(
     model: Model,
     parameter_estimates: pd.Series,
     covariance_matrix: Optional[pd.DataFrame] = None,
-    rng: Optional[Union[np.random.Generator, int]] = None,
+    seed: Optional[Union[np.random.Generator, int]] = None,
 ):
     """Calculate statistics for common pharmacokinetic parameters
 
@@ -419,7 +419,7 @@ def calculate_pk_parameters_statistics(
         Parameter estimates
     covariance_matrix : pd.DataFrame
         Parameter uncertainty covariance matrix
-    rng : Generator or int
+    seed : Generator or int
         Random number generator or seed
 
     Returns
@@ -437,7 +437,7 @@ def calculate_pk_parameters_statistics(
     >>> rng = create_rng(23)
     >>> pe = results.parameter_estimates
     >>> cov = results.covariance_matrix
-    >>> calculate_pk_parameters_statistics(model, pe, cov, rng=rng)
+    >>> calculate_pk_parameters_statistics(model, pe, cov, seed=rng)
                                   mean     variance     stderr
     parameter   covariates
     t_half_elim p5          173.337164  1769.493756  42.843398
@@ -522,7 +522,7 @@ def calculate_pk_parameters_statistics(
         expressions.append(sympy.Eq(sympy.Symbol('k_e'), elimination_rate))
 
     df = calculate_individual_parameter_statistics(
-        model, expressions, parameter_estimates, covariance_matrix, rng=rng
+        model, expressions, parameter_estimates, covariance_matrix, seed=seed
     )
     return df
 

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -2,6 +2,7 @@ import warnings
 from pathlib import Path
 from typing import Callable, List, Literal, Optional, Tuple, Union
 
+from pharmpy.deps import numpy as np
 from pharmpy.deps import pandas as pd
 from pharmpy.deps import sympy
 from pharmpy.model import Model
@@ -67,6 +68,7 @@ def run_amd(
     dv_types: Optional[dict] = None,
     mechanistic_covariates: Optional[List[str]] = None,
     retries_strategy: Literal["final", "all_final", "skip"] = "final",
+    seed: Optional[Union[np.random.Generator, int]] = None,
 ):
     """Run Automatic Model Development (AMD) tool
 
@@ -122,6 +124,8 @@ def run_amd(
     retries_strategy: str
         Weither or not to run retries tool. Valid options are 'skip', 'all_final' or 'final'.
         Default is 'final'.
+    seed : int or rng
+        Random number generator or seed to be used.
 
     Returns
     -------
@@ -370,11 +374,11 @@ def run_amd(
                 f"Unrecognized section {section} in order. Must be one of {default_order}"
             )
         if retries_strategy == 'all_final':
-            func = _subfunc_retires(tool=section, strictness=strictness, path=db.path)
+            func = _subfunc_retires(tool=section, strictness=strictness, seed=seed, path=db.path)
             run_subfuncs[f'{section}_retries'] = func
 
     if retries_strategy == 'final':
-        func = _subfunc_retires(tool="", strictness=strictness, path=db.path)
+        func = _subfunc_retires(tool="", strictness=strictness, seed=seed, path=db.path)
         run_subfuncs['retries'] = func
 
     # Filter data to only contain dvid=1
@@ -543,7 +547,7 @@ def noop_subfunc(_: Model):
     return None
 
 
-def _subfunc_retires(tool, strictness, path):
+def _subfunc_retires(tool, strictness, seed, path):
     def _run_retries(model):
         res = run_tool(
             'retries',
@@ -552,6 +556,7 @@ def _subfunc_retires(tool, strictness, path):
             strictness=strictness,
             scale='UCP',
             prefix_name=tool,
+            seed=seed,
             path=path / f'{tool}_retries',
         )
         assert isinstance(res, Results)

--- a/src/pharmpy/tools/retries/tool.py
+++ b/src/pharmpy/tools/retries/tool.py
@@ -1,12 +1,24 @@
-import random
 import warnings
 from dataclasses import dataclass, replace
-from typing import Optional
+from typing import TYPE_CHECKING, Optional, Union
+
+if TYPE_CHECKING:
+    import numpy as np
+    import pandas as pd
+else:
+    from pharmpy.deps import numpy as np
+    import pandas as pd
 
 from pharmpy.internals.fn.signature import with_same_arguments_as
 from pharmpy.internals.fn.type import with_runtime_arguments_type_check
 from pharmpy.model import Model
-from pharmpy.modeling import calculate_parameters_from_ucp, calculate_ucp_scale, update_inits
+from pharmpy.modeling import (
+    calculate_parameters_from_ucp,
+    calculate_ucp_scale,
+    create_rng,
+    sample_parameters_uniformly,
+    update_inits,
+)
 from pharmpy.tools import summarize_modelfit_results
 from pharmpy.tools.common import ToolResults, create_results
 from pharmpy.tools.modelfit import create_fit_workflow
@@ -26,10 +38,11 @@ def create_workflow(
     model: Optional[Model] = None,
     results: Optional[ModelfitResults] = None,
     number_of_candidates: int = 5,
-    degree: float = 0.1,
+    fraction: float = 0.1,
     strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs >= 0.1)",
     scale: Optional[str] = "UCP",
     prefix_name: Optional[str] = "",  # FIXME : Remove once new database has been implemented
+    seed: Optional[Union[np.random.Generator, int]] = None,
 ):
     """
     Run retries tool.
@@ -42,7 +55,7 @@ def create_workflow(
         Connected ModelfitResults object. The default is None.
     number_of_candidates : int, optional
         Number of retry candidates to run. The default is 5.
-    degree: float
+    fraction: float
         Determines allowed increase/decrease from initial parameter estimate. Default is 0.1 (10%)
     strictness : Optional[str], optional
         Strictness criteria. The default is "minimization_successful or (rounding_errors and sigdigs >= 0.1)".
@@ -50,6 +63,8 @@ def create_workflow(
         Which scale to update the initial values on. Either normal scale or UCP scale.
     prefix_name: Optional[str]
         Prefix the candidate model names with given string.
+    seed: int or rng
+        Random number generator or seed to be used.
 
     Returns
     -------
@@ -69,14 +84,16 @@ def create_workflow(
     wb.add_task(start_task)
 
     candidate_tasks = []
+    seed = create_rng(seed)
     for i in range(1, number_of_candidates + 1):
         new_candidate_task = Task(
             f"Create_candidate_{i}",
             create_random_init_model,
             i,
             scale,
-            degree,
+            fraction,
             prefix_name,
+            seed,
         )
         wb.add_task(new_candidate_task, predecessors=start_task)
         candidate_tasks.append(new_candidate_task)
@@ -98,7 +115,7 @@ def _start(results, model):
         return ModelEntry.create(model=model, modelfit_results=results)
 
 
-def create_random_init_model(context, index, scale, degree, prefix_name, modelentry):
+def create_random_init_model(context, index, scale, fraction, prefix_name, seed, modelentry):
     original_model = modelentry.model
     # Update inits once before running?
 
@@ -109,21 +126,19 @@ def create_random_init_model(context, index, scale, degree, prefix_name, modelen
         name = f'retries_run{index}'
     new_candidate_model = original_model.replace(name=name)
 
+    try_number = 1
     if scale == "normal":
         maximum_tests = 20  # TODO : Convert to argument
+
         for try_number in range(1, maximum_tests + 1):
-            new_parameters = {}
-            for p in original_model.parameters:
-                lower_bound = p.init - p.init * degree
-                if lower_bound < p.lower:
-                    lower_bound = p.lower + 10**-6
-                upper_bound = p.init + p.init * degree
-                if upper_bound > p.upper:
-                    upper_bound = p.upper - 10**-6
-
-                new_init = lower_bound + random.random() * (upper_bound - lower_bound)
-                new_parameters[p.name] = new_init
-
+            new_parameters = sample_parameters_uniformly(
+                new_candidate_model,
+                pd.Series(new_candidate_model.parameters.inits),
+                fraction=fraction,
+                scale=scale,
+                seed=seed,
+            )
+            new_parameters = {p: new_parameters[p][0] for p in new_parameters}
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "error",
@@ -139,46 +154,38 @@ def create_random_init_model(context, index, scale, degree, prefix_name, modelen
                             f"{new_candidate_model.name} could not be determined"
                             f" to be positive semi-definite."
                         )
-
-        new_candidate_model_fit_wf = create_fit_workflow(models=[new_candidate_model])
-        new_candidate_model = call_workflow(
-            new_candidate_model_fit_wf, f'fit_candidate_run{index}', context
-        )
-        new_modelentry = ModelEntry.create(
-            model=new_candidate_model,
-            modelfit_results=new_candidate_model.modelfit_results,
-            parent=original_model,
-        )
-        return Retry(
-            modelentry=new_modelentry,
-            number_of_retries=try_number,
-        )
-
     elif scale == "UCP":
         ucp_scale = calculate_ucp_scale(new_candidate_model)
-        subs_dict = {}
-        for p in new_candidate_model.parameters:
-            subs_dict[p.name] = 0.1 - (0.1 * degree) + random.random() * 2 * degree * 0.1
-        new_parameters = calculate_parameters_from_ucp(new_candidate_model, ucp_scale, subs_dict)
+        new_parameters = sample_parameters_uniformly(
+            new_candidate_model,
+            pd.Series(new_candidate_model.parameters.inits),
+            fraction=fraction,
+            scale=scale,
+            seed=seed,
+        )
+        new_parameters = {p: new_parameters[p][0] for p in new_parameters}
+        new_parameters = calculate_parameters_from_ucp(
+            new_candidate_model, ucp_scale, new_parameters
+        )
 
         new_candidate_model = update_inits(new_candidate_model, new_parameters)
-
-        new_candidate_model_fit_wf = create_fit_workflow(models=[new_candidate_model])
-        new_candidate_model = call_workflow(
-            new_candidate_model_fit_wf, f'fit_candidate_run{index}', context
-        )
-        new_modelentry = ModelEntry.create(
-            model=new_candidate_model,
-            modelfit_results=new_candidate_model.modelfit_results,
-            parent=original_model,
-        )
-        return Retry(
-            modelentry=new_modelentry,
-            number_of_retries=1,
-        )
     else:
         # Should be caught in validate_input()
         raise ValueError(f'Scale ({scale}) is not supported')
+
+    new_candidate_model_fit_wf = create_fit_workflow(models=[new_candidate_model])
+    new_candidate_model = call_workflow(
+        new_candidate_model_fit_wf, f'fit_candidate_run{index}', context
+    )
+    new_modelentry = ModelEntry.create(
+        model=new_candidate_model,
+        modelfit_results=new_candidate_model.modelfit_results,
+        parent=original_model,
+    )
+    return Retry(
+        modelentry=new_modelentry,
+        number_of_retries=try_number,
+    )
 
 
 def task_results(strictness, retries):
@@ -234,7 +241,7 @@ def _modify_summary_tool(summary_tool, retry_runs):
 
 @with_runtime_arguments_type_check
 @with_same_arguments_as(create_workflow)
-def validate_input(model, results, number_of_candidates, degree, strictness, scale, prefix_name):
+def validate_input(model, results, number_of_candidates, fraction, strictness, scale, prefix_name):
     if not isinstance(model, Model):
         raise ValueError(
             f'Invalid `model` type: got `{type(model)}`, must be one of pharmpy Model object.'
@@ -254,8 +261,10 @@ def validate_input(model, results, number_of_candidates, degree, strictness, sca
             f'`number_of_candidates` need to be a positiv integer, not `{number_of_candidates}`'
         )
 
-    if not isinstance(degree, float):
-        raise ValueError(f'Invalid `degree` type: got `{type(degree)}`, must be an number (float).')
+    if not isinstance(fraction, float):
+        raise ValueError(
+            f'Invalid `fraction` type: got `{type(fraction)}`, must be an number (float).'
+        )
 
     # STRICTNESS?
 

--- a/tests/integration/test_retries.py
+++ b/tests/integration/test_retries.py
@@ -14,11 +14,11 @@ from pharmpy.tools import run_retries
 )
 def test_retries(tmp_path, model_count, scale, start_model):
     with chdir(tmp_path):
-        degree = 0.1
+        fraction = 0.1
         number_of_candidates = 5
         res = run_retries(
             number_of_candidates=number_of_candidates,
-            degree=degree,
+            fraction=fraction,
             scale=scale,
             results=start_model.modelfit_results,
             model=start_model,
@@ -29,7 +29,7 @@ def test_retries(tmp_path, model_count, scale, start_model):
         assert len(res.summary_models) == 6
         assert len(res.models) == 6
         for model in res.models:
-            is_within_degree(start_model, model, scale, degree)
+            is_within_fraction(start_model, model, scale, fraction)
         rundir = tmp_path / 'retries_dir1'
         assert rundir.is_dir()
         assert model_count(rundir) == 5  # Not the start model ?
@@ -38,21 +38,21 @@ def test_retries(tmp_path, model_count, scale, start_model):
         assert (rundir / 'metadata.json').exists()
 
 
-def is_within_degree(start_model, candidate_model, scale, degree):
+def is_within_fraction(start_model, candidate_model, scale, fraction):
     allowed_dict = {}
     if scale == "normal":
         for parameter in start_model.parameters:
             allowed_dict[parameter.name] = (
-                parameter.init - parameter.init * degree,
-                parameter.init + parameter.init * degree,
+                parameter.init - parameter.init * fraction,
+                parameter.init + parameter.init * fraction,
             )
     elif scale == "UCP":
         ucp_scale = calculate_ucp_scale(start_model)
         lower = {}
         upper = {}
         for p in start_model.parameters:
-            lower[p.name] = 0.1 - (0.1 * degree)
-            upper[p.name] = 0.1 + (0.1 * degree)
+            lower[p.name] = 0.1 - (0.1 * fraction)
+            upper[p.name] = 0.1 + (0.1 * fraction)
         new_lower_parameters = calculate_parameters_from_ucp(start_model, ucp_scale, lower)
         new_upper_parameters = calculate_parameters_from_ucp(start_model, ucp_scale, upper)
         for p in start_model.parameters:

--- a/tests/modeling/test_parameter_sampling.py
+++ b/tests/modeling/test_parameter_sampling.py
@@ -23,7 +23,7 @@ def test_sample_parameters_uniformly(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
     rng = create_rng(23)
-    df = sample_parameters_uniformly(model, res.parameter_estimates, n=3, rng=rng)
+    df = sample_parameters_uniformly(model, res.parameter_estimates, n=3, seed=rng)
     assert df['PTVCL'][0] == 0.004877674495376137
 
 
@@ -38,7 +38,7 @@ def test_sample_parameter_from_covariance_matrix(load_model_for_test, testdata):
         pe,
         cm,
         n=3,
-        rng=rng,
+        seed=rng,
     )
     correct = pd.DataFrame(
         {
@@ -70,14 +70,14 @@ def test_sample_individual_estimates(load_model_for_test, testdata):
     rng = np.random.default_rng(86)
     ie = res.individual_estimates
     iec = res.individual_estimates_covariance
-    samples = sample_individual_estimates(model, ie, iec, rng=rng)
+    samples = sample_individual_estimates(model, ie, iec, seed=rng)
     assert len(samples) == 59 * 100
     assert list(samples.columns) == ['ETA_1', 'ETA_2']
     assert pytest.approx(samples.iloc[0]['ETA_1'], 1e-5) == 0.21179186940672637
     assert pytest.approx(samples.iloc[0]['ETA_2'], 1e-5) == -0.05771736555248238
 
     restricted = sample_individual_estimates(
-        model, ie, iec, parameters=['ETA_2'], samples_per_id=1, rng=rng
+        model, ie, iec, parameters=['ETA_2'], samples_per_id=1, seed=rng
     )
     assert len(restricted) == 59
     assert restricted.columns == ['ETA_2']

--- a/tests/modeling/test_results.py
+++ b/tests/modeling/test_results.py
@@ -53,7 +53,7 @@ def test_calculate_individual_parameter_statistics(load_model_for_test, testdata
         'CL/V',
         res.parameter_estimates,
         res.covariance_matrix,
-        rng=rng,
+        seed=rng,
     )
 
     assert stats['mean'].iloc[0] == pytest.approx(0.004700589484324183)
@@ -68,7 +68,7 @@ def test_calculate_individual_parameter_statistics(load_model_for_test, testdata
         'CL/V',
         res.parameter_estimates,
         res.covariance_matrix,
-        rng=rng,
+        seed=rng,
     )
     assert stats['mean'].iloc[0] == pytest.approx(0.0049100899539843)
     assert stats['variance'].iloc[0] == pytest.approx(7.391076132098555e-07)
@@ -82,7 +82,7 @@ def test_calculate_individual_parameter_statistics(load_model_for_test, testdata
         'K = CL/V',
         res.parameter_estimates,
         res.covariance_matrix,
-        rng=rng,
+        seed=rng,
     )
     assert stats['mean']['K', 'median'] == pytest.approx(0.004526899290470633)
     assert stats['variance']['K', 'median'] == pytest.approx(2.95125370813005e-06)
@@ -103,7 +103,7 @@ def test_calculate_pk_parameters_statistics(load_model_for_test, testdata):
         model,
         res.parameter_estimates,
         res.covariance_matrix,
-        rng=rng,
+        seed=rng,
     )
     assert df['mean'].loc['t_max', 'median'] == pytest.approx(1.5999856886869577)
     assert df['variance'].loc['t_max', 'median'] == pytest.approx(0.29728565293669557)
@@ -123,7 +123,7 @@ def test_calc_pk_two_comp_bolus(load_model_for_test, testdata):
         model,
         res.parameter_estimates,
         res.covariance_matrix,
-        rng=rng,
+        seed=rng,
     )
     # FIXME: Why doesn't random state handle this difference in stderr?
     df.drop('stderr', inplace=True, axis=1)

--- a/tests/tools/test_frem.py
+++ b/tests/tools/test_frem.py
@@ -75,7 +75,7 @@ def test_bipp_covariance(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
     res = read_modelfit_results(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
     res = calculate_results_using_bipp(
-        model, res, continuous=['APGR', 'WGT'], categorical=[], rng=9532
+        model, res, continuous=['APGR', 'WGT'], categorical=[], seed=9532
     )
     assert res
 
@@ -85,7 +85,7 @@ def test_frem_results_pheno(load_model_for_test, testdata):
     res = read_modelfit_results(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
     rng = np.random.default_rng(39)
     res = calculate_results(
-        model, res, continuous=['APGR', 'WGT'], categorical=[], samples=10, rng=rng
+        model, res, continuous=['APGR', 'WGT'], categorical=[], samples=10, seed=rng
     )
 
     correct = """parameter,covariate,condition,p5,mean,p95
@@ -262,7 +262,7 @@ def test_frem_results_pheno_categorical(load_model_for_test, testdata):
     res = read_modelfit_results(testdata / 'nonmem' / 'frem' / 'pheno_cat' / 'model_4.mod')
     rng = np.random.default_rng(8978)
     res = calculate_results(
-        model, res, continuous=['WGT'], categorical=['APGRX'], samples=10, rng=rng
+        model, res, continuous=['WGT'], categorical=['APGRX'], samples=10, seed=rng
     )
 
     correct = """parameter,covariate,condition,p5,mean,p95


### PR DESCRIPTION
- parameter_sampling can now sample on both normal and UCP scale.
- Retries tool using create_rng instead of random.random
- Added argument "rng" to AMD tool for random sampling (currently only for retries tool)