### PR TITLE
Add dv_types to documentation. Add validation for dv_types

### DIFF
--- a/docs/amd.rst
+++ b/docs/amd.rst
@@ -81,6 +81,8 @@ Arguments
 | :ref:`strictness<strictness>`                     | Strictness criteria for model selection.                                                                        |
 |                                                   | Default is "minimization_successful or                                                                          |
 |                                                   | (rounding_errors and sigdigs>= 0.1)"                                                                            |
+|                                                   | If ``strictness`` is set to ``None`` no strictness                                                              |
+|                                                   | criteria are applied                                                                                            |
 +---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 |``mechanistic_covariates``                         | List of covariates to run in a separate prioritezed covsearch run.                                              |
 |                                                   | The effects are extracted from the given search space                                                           |
@@ -88,6 +90,9 @@ Arguments
 | ``retries_strategy``                              | Decide how to use the retries tool. Valid options are 'skip', 'all_final' or 'final'. Default is 'final'        |
 +---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 | ``seed``                                          | A random number generator or seed to use for steps with random sampling.                                        |
++---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
+| ``dv_types``                                      | Dictionary of DV types for multiple DVs (e.g. dv_types = {'target': 2}). Default is None.                       |
+|                                                   | Allowed keys are: 'drug', 'target' and 'complex'. (For TMDD models only)                                        |
 +---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 
 .. _input_amd:

--- a/docs/tmdd.rst
+++ b/docs/tmdd.rst
@@ -24,6 +24,22 @@ The code to initiate structsearch for a TMDD model in Python/R is stated below:
                             results=start_model_results)
 
 
+Run TMDD for multiple DVs:
+
+.. pharmpy-code::
+
+    from pharmpy.modeling import read_model
+    from pharmpy.tools read_modelfit_results, run_structsearch
+
+    start_model = read_model('path/to/model')
+    start_model_results = read_modelfit_results('path/to/model')
+    res = run_structsearch(type='tmdd',
+                            model=start_model,
+                            results=start_model_results,
+                            dv_types = {'drug': 1, 'target':2, 'complex':3})
+
+Note: "drug" can be omitted in ``dv_types``. In this case it will be set to 1.
+
 
 Arguments
 ~~~~~~~~~
@@ -45,6 +61,10 @@ The arguments of the structsearch tool for TMDD models are listed below.
 | ``extra_model``                                 | Extra model for TMDD structsearch                                   |
 +-------------------------------------------------+---------------------------------------------------------------------+
 | ``extra_model_results``                         | ModelfitResults object for the extra model for TMDD structsearch    |
++-------------------------------------------------+---------------------------------------------------------------------+
+| ``dv_types``                                    | Dictionary of DV types for multiple DVs                             |
+|                                                 | (e.g. dv_types = {'target': 2}). Default is None.                   |
+|                                                 | Allowed keys are: 'drug', 'target' and 'complex'.                   |
 +-------------------------------------------------+---------------------------------------------------------------------+
 
 ~~~~~~

--- a/src/pharmpy/modeling/tmdd.py
+++ b/src/pharmpy/modeling/tmdd.py
@@ -52,6 +52,9 @@ def set_tmdd(model: Model, type: str, dv_types: dict = None):
     >>> model = set_tmdd(model, "full")
 
     """
+    if dv_types is not None:
+        _validate_dv_types(dv_types)
+
     type = type.upper()
 
     model = _replace_trivial_redefinitions(model)
@@ -422,3 +425,11 @@ def _create_ksyn():
     ksyn = sympy.Symbol('KSYN')
     ksyn_ass = Assignment(ksyn, sympy.Symbol("R_0") * sympy.Symbol("KDEG"))
     return ksyn, ksyn_ass
+
+
+def _validate_dv_types(dv_types):
+    for key in dv_types.keys():
+        if key not in ['drug', 'target', 'complex']:
+            raise ValueError(
+                f'Invalid dv_types key "{key}". Allowed keys are: "drug", "target" and "complex".'
+            )

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -326,6 +326,7 @@ def validate_input(
     type,
     strictness,
     model,
+    dv_types,
 ):
     if type not in TYPES:
         raise ValueError(f'Invalid `type`: got `{type}`, must be one of {sorted(TYPES)}.')
@@ -335,6 +336,13 @@ def validate_input(
             raise ValueError(
                 'parameter_uncertainty_method not set for model, cannot calculate relative standard errors.'
             )
+
+    if dv_types is not None:
+        for key in dv_types.keys():
+            if key not in ['drug', 'target', 'complex']:
+                raise ValueError(
+                    f'Invalid dv_types key "{key}". Allowed keys are: "drug", "target" and "complex".'
+                )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
- Add `dv_types`to TMDD and AMD documentation
- Add input validation for `dv_types`.
