### PR TITLE
Add total drug and total target to TMDD

### DIFF
--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -341,7 +341,8 @@ def validate_input(
         for key in dv_types.keys():
             if key not in ['drug', 'target', 'complex']:
                 raise ValueError(
-                    f'Invalid dv_types key "{key}". Allowed keys are: "drug", "target" and "complex".'
+                    f'Invalid dv_types key "{key}". Allowed keys are:'
+                    f'"drug", "target", "complex", "drug_tot" and "target_tot".'
                 )
 
 


### PR DESCRIPTION
- Add total drug and total target to TMDD models
- If total drug is dv = 1 then the original dv is overwritten
- Fix bug that required the model to have an IPRED for QSS and Wagner models.