### PR TITLE
Add model entry in tool summaries

### DIFF
--- a/src/pharmpy/tools/allometry/tool.py
+++ b/src/pharmpy/tools/allometry/tool.py
@@ -184,7 +184,7 @@ def results(start_model_entry, allometry_model_entry):
     summod = summarize_modelfit_results([start_res, allometry_res])
     summod['step'] = [0, 1]
     summods = summod.reset_index().set_index(['step', 'model'])
-    suminds = summarize_individuals([start_model, allometry_model])
+    suminds = summarize_individuals([start_model, allometry_model], [start_res, allometry_res])
     sumcount = summarize_individuals_count_table(df=suminds)
     sumerrs = summarize_errors([start_res, allometry_res])
 

--- a/src/pharmpy/tools/common.py
+++ b/src/pharmpy/tools/common.py
@@ -79,6 +79,7 @@ def create_results(
         delta_name = f'd{rank_type}'
     summary_individuals, summary_individuals_count = summarize_tool_individuals(
         [base_model] + res_models,
+        [base_model.modelfit_results] + [model.modelfit_results for model in res_models],
         summary_tool['description'],
         summary_tool[delta_name],
     )
@@ -195,8 +196,8 @@ def summarize_tool(
     return df_sorted
 
 
-def summarize_tool_individuals(models, description_col, rank_type_col):
-    summary_individuals = summarize_individuals(models)
+def summarize_tool_individuals(models, models_res, description_col, rank_type_col):
+    summary_individuals = summarize_individuals(models, models_res)
     summary_individuals = summary_individuals.join(description_col, how='inner')
     col_to_move = summary_individuals.pop('description')
     summary_individuals.insert(0, 'description', col_to_move)

--- a/src/pharmpy/tools/common.py
+++ b/src/pharmpy/tools/common.py
@@ -22,11 +22,7 @@ DataFrame = Any  # NOTE: Should be pd.DataFrame but we want lazy loading
 RANK_TYPES = frozenset(('ofv', 'lrt', 'aic', 'bic', 'mbic'))
 
 
-def update_initial_estimates(model, modelfit_results=None):
-    # FIXME: Remove once modelfit_results have been removed from Model object
-    if modelfit_results is None:
-        modelfit_results = model.modelfit_results
-
+def update_initial_estimates(model, modelfit_results):
     if modelfit_results is None:
         return model
     if not modelfit_results.minimization_successful:

--- a/src/pharmpy/tools/common.py
+++ b/src/pharmpy/tools/common.py
@@ -125,13 +125,6 @@ def create_results(
     return res
 
 
-def _model_entry_to_model(model_entry):
-    parent_name = model_entry.parent.name if model_entry.parent else model_entry.model.name
-    return model_entry.model.replace(
-        modelfit_results=model_entry.modelfit_results, parent_model=parent_name
-    )
-
-
 def summarize_tool(
     model_entries,
     start_model_entry,

--- a/src/pharmpy/tools/common.py
+++ b/src/pharmpy/tools/common.py
@@ -142,6 +142,9 @@ def summarize_tool(
         start_model = _model_entry_to_model(start_model)
         models = [_model_entry_to_model(model_entry) for model_entry in models]
 
+    start_model_res = start_model.modelfit_results
+    models_res = [model.modelfit_results for model in models]
+
     if rank_type == 'mbic':
         rank_type = 'bic'
         if len(models) > 0:
@@ -158,7 +161,9 @@ def summarize_tool(
 
     df_rank = rank_models(
         start_model,
+        start_model_res,
         models,
+        models_res,
         strictness=strictness,
         rank_type=rank_type,
         cutoff=cutoff,

--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -14,7 +14,7 @@ from pharmpy.modeling.lrt import best_of_many as lrt_best_of_many
 from pharmpy.modeling.lrt import p_value as lrt_p_value
 from pharmpy.modeling.lrt import test as lrt_test
 from pharmpy.tools import is_strictness_fulfilled, summarize_modelfit_results
-from pharmpy.tools.common import _model_entry_to_model, create_results, update_initial_estimates
+from pharmpy.tools.common import create_results, update_initial_estimates
 from pharmpy.tools.mfl.feature.covariate import EffectLiteral, InputSpec, all_covariate_effects
 from pharmpy.tools.mfl.feature.covariate import features as covariate_features
 from pharmpy.tools.mfl.feature.covariate import parse_spec, spec
@@ -652,8 +652,7 @@ def _make_df_steps(best_modelentry: ModelEntry, candidates: List[Candidate]):
     ]
     index_offset = 0
     if not any(
-        children_count[c.modelentry.model.name] >= 1
-        or _model_entry_to_model(c.modelentry) is best_model
+        children_count[c.modelentry.model.name] >= 1 or c.modelentry.model is best_model
         for c in largest_forward_candidates
     ):
         index_offset = 1

--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -501,7 +501,9 @@ def task_add_covariate_effect(
     name = f'covsearch_run{effect_index}'
     description = _create_description(effect[0], candidate.steps)
     model_with_added_effect = model.replace(name=name, description=description)
-    model_with_added_effect = update_initial_estimates(model_with_added_effect)
+    model_with_added_effect = update_initial_estimates(
+        model_with_added_effect, modelentry.modelfit_results
+    )
     func = effect[1]
     model_with_added_effect = func(model_with_added_effect, allow_nested=True)
     return ModelEntry.create(

--- a/src/pharmpy/tools/ruvsearch/tool.py
+++ b/src/pharmpy/tools/ruvsearch/tool.py
@@ -229,7 +229,7 @@ def start(context, input_model, input_res, groups, p_value, skip, max_iter, dv, 
     selected_models = [_model_entry_to_model(model_entry) for model_entry in selected_model_entries]
     model_results = [model_entry.modelfit_results for model_entry in selected_model_entries]
 
-    sumind = summarize_individuals(selected_models)
+    sumind = summarize_individuals(selected_models, model_results)
     sumcount = summarize_individuals_count_table(df=sumind)
     sum_models = summarize_modelfit_results(model_results)
     sum_models['step'] = list(range(len(sum_models)))

--- a/src/pharmpy/tools/ruvsearch/tool.py
+++ b/src/pharmpy/tools/ruvsearch/tool.py
@@ -37,7 +37,7 @@ from pharmpy.tools import (
     summarize_individuals_count_table,
     summarize_modelfit_results,
 )
-from pharmpy.tools.common import _model_entry_to_model, summarize_tool, update_initial_estimates
+from pharmpy.tools.common import summarize_tool, update_initial_estimates
 from pharmpy.tools.modelfit import create_fit_workflow
 from pharmpy.workflows import ModelEntry, Task, Workflow, WorkflowBuilder, call_workflow
 from pharmpy.workflows.results import ModelfitResults
@@ -225,8 +225,7 @@ def start(context, input_model, input_res, groups, p_value, skip, max_iter, dv, 
     if delta_ofv < cutoff:
         model_entry = input_model_entry
 
-    # FIXME: Remove once modelfit_results have been removed from Model object
-    selected_models = [_model_entry_to_model(model_entry) for model_entry in selected_model_entries]
+    selected_models = [model_entry.model for model_entry in selected_model_entries]
     model_results = [model_entry.modelfit_results for model_entry in selected_model_entries]
 
     sumind = summarize_individuals(selected_models, model_results)

--- a/tests/integration/test_iivsearch.py
+++ b/tests/integration/test_iivsearch.py
@@ -74,8 +74,6 @@ def test_no_of_etas(tmp_path, model_count, start_modelres):
         res_models = [model for model in retrieve_models(res) if model.name != 'input_model']
         assert len(res_models) == no_of_candidate_models
 
-        # assert res.models[-1].modelfit_results
-
         assert res.summary_tool.loc[1, 'mox2']['description'] == '[CL]+[VC]+[MAT]'
         assert start_modelres[0].random_variables.iiv.names == ['ETA_1', 'ETA_2', 'ETA_3']
 
@@ -169,7 +167,6 @@ def test_no_of_etas_iiv_strategies(tmp_path, model_count, start_modelres, iiv_st
 
         res_models = [model for model in retrieve_models(res) if model.name != 'input_model']
         assert len(res_models) == no_of_candidate_models + 1
-        # assert res.models[-1].modelfit_results
 
         if iiv_strategy == 'fullblock':
             base_model = [model for model in res_models if model.name == 'base_model'].pop()

--- a/tests/integration/test_modelsearch.py
+++ b/tests/integration/test_modelsearch.py
@@ -1,6 +1,5 @@
 import shutil
 
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -22,8 +21,7 @@ def test_exhaustive(tmp_path, model_count, start_modelres):
         assert len(res.summary_tool) == 4
         assert len(res.summary_models) == 4
         assert len(res.models) == 4
-        assert all(model.modelfit_results for model in res.models)
-        assert not all(np.isnan(model.modelfit_results.ofv) for model in res.models)
+
         rundir = tmp_path / 'modelsearch_dir1'
         assert rundir.is_dir()
         assert model_count(rundir) == 3
@@ -72,7 +70,6 @@ def test_exhaustive_stepwise_basic(
         assert len(res.summary_tool) == no_of_models + 1
         assert len(res.summary_models) == no_of_models + 1
         assert len(res.models) == no_of_models + 1
-        assert res.models[-1].modelfit_results
 
         assert res.models[0].parent_model == 'mox2'
         assert res.models[-1].parent_model == last_model_parent_name
@@ -140,7 +137,6 @@ def test_exhaustive_stepwise_iiv_strategies(
             - len(start_modelres[0].random_variables.etas.names)
             == no_of_added_etas
         )
-        assert model_last.modelfit_results
 
         rundir = tmp_path / 'modelsearch_dir1'
         assert rundir.is_dir()

--- a/tests/tools/test_summarize_individuals.py
+++ b/tests/tools/test_summarize_individuals.py
@@ -49,37 +49,29 @@ tflite_condition = (
 def test_tflite_not_installed(pheno_path, monkeypatch):
     model = read_model(pheno_path)
     results = read_modelfit_results(pheno_path)
-    # FIXME
-    model = model.replace(modelfit_results=results)
 
-    df = summarize_individuals([model])
+    df = summarize_individuals([model], [results])
     assert not df['predicted_dofv'].isnull().any().any()
 
     with pytest.warns(UserWarning, match='tflite is not installed'):
         monkeypatch.setitem(sys.modules, 'tflite_runtime', None)
-        df = summarize_individuals([model])
+        df = summarize_individuals([model], [results])
         assert df['predicted_dofv'].isnull().all().all()
 
 
 def test_dofv_parent_model_is_none(pheno_path):
-    candidate_model = read_model(pheno_path)
-    res = dofv(None, candidate_model)
+    res = read_modelfit_results(pheno_path)
+    res = dofv(None, res)
     assert np.isnan(res)
 
 
 def test_dofv_modelfit_results_is_none(pheno_path):
-    parent_model = read_model(pheno_path)
-    res = read_modelfit_results(pheno_path)
-    parent_model = parent_model.replace(modelfit_results=res)
-    candidate_model = parent_model.replace(modelfit_results=None)
-    res = dofv(parent_model, candidate_model)
+    parent_res = read_modelfit_results(pheno_path)
+    res = dofv(parent_res, None)
     assert res.isna().all()
 
 
 def test_dofv_individual_ofv_is_none(pheno_path):
-    parent_model = read_model(pheno_path)
-    res = read_modelfit_results(pheno_path)
-    parent_model = parent_model.replace(modelfit_results=res)
-    candidate_model = parent_model.replace(modelfit_results=ModelfitResults())
-    res = dofv(parent_model, candidate_model)
+    parent_res = read_modelfit_results(pheno_path)
+    res = dofv(parent_res, ModelfitResults())
     assert res.isna().all()


### PR DESCRIPTION
Remove workarounds in `tools/common.py` that attaches `ModelfitResults` to `Model`, various fixes where `ModelEntry` was not used.