### PR TITLE
Remove unused function in structsearch

### DIFF
--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -316,10 +316,6 @@ def bundle_results(*args):
     return args
 
 
-def _results(model):
-    return model.modelfit_results
-
-
 @with_runtime_arguments_type_check
 @with_same_arguments_as(create_workflow)
 def validate_input(


### PR DESCRIPTION
Remove unused function `_results`