### PR TITLE
Use literals in typehints

### DIFF
--- a/src/pharmpy/modeling/blq.py
+++ b/src/pharmpy/modeling/blq.py
@@ -1,10 +1,11 @@
 """
 :meta private:
 """
-from typing import Optional
+from typing import Literal, Optional
 
 from pharmpy.deps import sympy
 from pharmpy.internals.expr.funcs import PHI
+from pharmpy.internals.fn.type import check_list
 from pharmpy.model import Assignment, EstimationSteps, JointNormalDistribution, Model
 
 from .data import remove_loq_data, set_lloq_data
@@ -13,7 +14,11 @@ from .expressions import _simplify_expression_from_parameters, create_symbol
 SUPPORTED_METHODS = frozenset(['m1', 'm3', 'm4', 'm5', 'm6', 'm7'])
 
 
-def transform_blq(model: Model, method: str = 'm4', lloq: Optional[float] = None):
+def transform_blq(
+    model: Model,
+    method: Literal['m1', 'm3', 'm4', 'm5', 'm6', 'm7'] = 'm4',
+    lloq: Optional[float] = None,
+):
     """Transform for BLQ data
 
     Transform a given model, methods available are m1, m3, m4, m5, m6 and m7 [1]_.
@@ -120,10 +125,7 @@ def transform_blq(model: Model, method: str = 'm4', lloq: Optional[float] = None
 
     """
     method = method.lower()
-    if method not in SUPPORTED_METHODS:
-        raise ValueError(
-            f'Invalid `method`: got `{method}`,' f' must be one of {sorted(SUPPORTED_METHODS)}.'
-        )
+    check_list("method", method, SUPPORTED_METHODS)
 
     blq_col, lloq_col = _get_blq_and_lloq_columns(model)
     indicator, indicator_type, level, level_type = _which_indicator_and_level(

--- a/src/pharmpy/modeling/parameter_variability.py
+++ b/src/pharmpy/modeling/parameter_variability.py
@@ -8,7 +8,7 @@ from collections import Counter, defaultdict
 from functools import reduce
 from itertools import chain, combinations
 from operator import add, mul
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
 from pharmpy.deps import numpy as np
 from pharmpy.deps import pandas as pd
@@ -168,7 +168,7 @@ def add_iov(
     occ: str,
     list_of_parameters: Optional[Union[List[str], str]] = None,
     eta_names: Optional[Union[List[str], str]] = None,
-    distribution: str = 'disjoint',
+    distribution: Literal[tuple(ADD_IOV_DISTRIBUTION)] = 'disjoint',
 ):
     """Adds IOVs to :class:`pharmpy.model`.
 
@@ -186,7 +186,7 @@ def add_iov(
     eta_names : str, list
         Custom names of new etas. Must be equal to the number of input etas times the number of
         categories for occasion.
-    distribution : str
+    distribution : {'disjoint', 'joint', 'explicit', 'same-as-iiv'}
         The distribution that should be used for the new etas. Options are
         'disjoint' for disjoint normal distributions, 'joint' for joint normal
         distribution, 'explicit' for an explicit mix of joint and disjoint

--- a/src/pharmpy/modeling/pd.py
+++ b/src/pharmpy/modeling/pd.py
@@ -1,6 +1,8 @@
 """
 :meta private:
 """
+from typing import Literal
+
 from pharmpy.deps import sympy
 from pharmpy.model import (
     Assignment,
@@ -16,8 +18,10 @@ from pharmpy.modeling import get_central_volume_and_clearance, set_initial_condi
 from .error import set_proportional_error_model
 from .odes import add_individual_parameter, set_initial_estimates
 
+PD_TYPES = ('linear', 'emax', 'sigmoid', 'step', 'loglin')
 
-def add_effect_compartment(model: Model, expr: str):
+
+def add_effect_compartment(model: Model, expr: Literal[PD_TYPES]):
     r"""Add an effect compartment.
 
     Implemented PD models are:
@@ -50,8 +54,8 @@ def add_effect_compartment(model: Model, expr: str):
     ----------
     model : Model
         Pharmpy model
-    expr : str
-        Name of the PD effect function. Valid names are: linear, emax, sigmoid, step and loglin
+    expr : {'linear', 'emax', 'sigmoid', 'step', 'loglin'}
+        Name of the PD effect function.
 
     Return
     ------
@@ -94,7 +98,7 @@ def add_effect_compartment(model: Model, expr: str):
     return model
 
 
-def set_direct_effect(model: Model, expr: str):
+def set_direct_effect(model: Model, expr: Literal[PD_TYPES]):
     r"""Add an effect to a model.
 
     Implemented PD models are:
@@ -127,8 +131,8 @@ def set_direct_effect(model: Model, expr: str):
     ----------
     model : Model
         Pharmpy model
-    expr : str
-        Name of PD effect function. Valid names are: linear, emax, sigmoid, step and loglin
+    expr : {'linear', 'emax', 'sigmoid', 'step', 'loglin'}
+        Name of PD effect function.
 
     Return
     ------
@@ -203,7 +207,7 @@ def _add_effect(model: Model, expr: str, conc):
 
 def add_indirect_effect(
     model: Model,
-    expr: str,
+    expr: Literal['linear', 'emax', 'sigmoid', 'step'],
     prod: bool = True,
 ):
     r"""Add indirect (turnover) effect
@@ -242,8 +246,8 @@ def add_indirect_effect(
         Pharmpy model
     prod : bool
         Production (True) (default) or degradation (False)
-    expr : str
-        Name of PD effect function. Valid names are: linear, emax, sigmoid and step
+    expr : {'linear', 'emax', 'sigmoid', 'step'}
+        Name of PD effect function.
 
     Return
     ------

--- a/src/pharmpy/modeling/tmdd.py
+++ b/src/pharmpy/modeling/tmdd.py
@@ -1,7 +1,7 @@
 """
 :meta private:
 """
-from typing import Optional
+from typing import Literal, Optional
 
 from pharmpy.deps import sympy
 from pharmpy.model import (
@@ -19,8 +19,13 @@ from .expressions import _replace_trivial_redefinitions
 from .odes import add_individual_parameter, set_first_order_elimination, set_initial_condition
 from .parameter_variability import add_iiv
 
+TMDD_TYPE = ('full', 'ib', 'cr', 'crib', 'qss', 'wagner', 'mmapp')
+DV_TYPES = ('drug', 'drug_tot', 'target', 'target_tot', 'complex')
 
-def set_tmdd(model: Model, type: str, dv_types: Optional[dict[str, int]] = None):
+
+def set_tmdd(
+    model: Model, type: Literal[TMDD_TYPE], dv_types: Optional[dict[Literal[DV_TYPES], int]] = None
+):
     """Sets target mediated drug disposition
 
     Implemented target mediated drug disposition (TMDD) models are:

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -17,6 +17,7 @@ from pharmpy.modeling.blq import has_blq_transformation, transform_blq
 from pharmpy.modeling.common import convert_model, filter_dataset
 from pharmpy.modeling.covariate_effect import get_covariates_allowed_in_covariate_effect
 from pharmpy.modeling.parameter_variability import get_occasion_levels
+from pharmpy.modeling.tmdd import DV_TYPES
 from pharmpy.reporting import generate_report
 from pharmpy.tools import retrieve_models, summarize_errors, write_results
 from pharmpy.tools.allometry.tool import validate_allometric_variable
@@ -66,7 +67,7 @@ def run_amd(
     path: Optional[Union[str, Path]] = None,
     resume: bool = False,
     strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs>=0.1)",
-    dv_types: Optional[dict[str, int]] = None,
+    dv_types: Optional[dict[Literal[DV_TYPES], int]] = None,
     mechanistic_covariates: Optional[List[str]] = None,
     retries_strategy: Literal["final", "all_final", "skip"] = "final",
     seed: Optional[Union[np.random.Generator, int]] = None,

--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -1,7 +1,7 @@
 from collections import Counter, defaultdict
 from dataclasses import astuple, dataclass, replace
 from itertools import count
-from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Iterable, List, Literal, Optional, Sequence, Tuple, Union
 
 from pharmpy.deps import numpy as np
 from pharmpy.deps import pandas as pd
@@ -95,7 +95,7 @@ class SearchState:
     all_candidates_so_far: List[Candidate]
 
 
-ALGORITHMS = frozenset(['scm-forward', 'scm-forward-then-backward'])
+ALGORITHMS = ('scm-forward', 'scm-forward-then-backward')
 
 
 def create_workflow(
@@ -103,7 +103,7 @@ def create_workflow(
     p_forward: float = 0.01,
     p_backward: float = 0.001,
     max_steps: int = -1,
-    algorithm: str = 'scm-forward-then-backward',
+    algorithm: Literal[ALGORITHMS] = 'scm-forward-then-backward',
     results: Optional[ModelfitResults] = None,
     model: Optional[Model] = None,
     strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs>=0.1)",
@@ -121,7 +121,7 @@ def create_workflow(
         The p-value to use in the likelihood ratio test for backward steps
     max_steps : int
         The maximum number of search steps to make
-    algorithm : str
+    algorithm : {'scm-forward', 'scm-forward-then-backward'}
         The search algorithm to use. Currently, 'scm-forward' and
         'scm-forward-then-backward' are supported.
     results : ModelfitResults
@@ -755,11 +755,6 @@ def _make_df_steps_row(
 def validate_input(
     effects, p_forward, p_backward, algorithm, model, strictness, naming_index_offset
 ):
-    if algorithm not in ALGORITHMS:
-        raise ValueError(
-            f'Invalid `algorithm`: got `{algorithm}`, must be one of {sorted(ALGORITHMS)}.'
-        )
-
     if not 0 < p_forward <= 1:
         raise ValueError(
             f'Invalid `p_forward`: got `{p_forward}`, must be a float in range (0, 1].'

--- a/src/pharmpy/tools/estmethod/tool.py
+++ b/src/pharmpy/tools/estmethod/tool.py
@@ -1,7 +1,7 @@
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Any, List, Literal, Optional, Union
 
 import pharmpy.tools.estmethod.algorithms as algorithms
 from pharmpy.deps import numpy as np
@@ -24,10 +24,12 @@ ALGORITHMS = frozenset(['exhaustive', 'exhaustive_with_update', 'exhaustive_only
 
 
 def create_workflow(
-    algorithm: str,
-    methods: Optional[Union[List[str], str]] = None,
-    solvers: Optional[Union[List[str], str]] = None,
-    parameter_uncertainty_methods: Optional[Union[List[str], str]] = None,
+    algorithm: Literal[tuple(ALGORITHMS)],
+    methods: Optional[Union[List[Literal[METHODS]], Literal['all']]] = None,
+    solvers: Optional[Union[List[Literal[SOLVERS]], Literal[SOLVERS]]] = None,
+    parameter_uncertainty_methods: Optional[
+        Union[List[Literal[PARAMETER_UNCERTAINTY_METHODS]], Literal[PARAMETER_UNCERTAINTY_METHODS]]
+    ] = None,
     results: Optional[ModelfitResults] = None,
     model: Optional[Model] = None,
 ):
@@ -37,13 +39,13 @@ def create_workflow(
     ----------
     algorithm : str
          The algorithm to use (can be 'exhaustive', 'exhaustive_with_update' or 'exhaustive_only_eval')
-    methods : list or None
+    methods : list of {'FOCE', 'FO', 'IMP', 'IMPMAP', 'ITS', 'SAEM', 'LAPLACE', 'BAYES'}, None or 'all'
          List of estimation methods to test.
          Can be specified as 'all', a list of estimation methods, or None (to not test any estimation method)
-    solvers : list, str or None
+    solvers : str or list of {'CVODES', 'DGEAR', 'DVERK', 'IDA', 'LSODA', 'LSODI'} or None
          List of solver to test. Can be specified as 'all', a list of solvers, or None (to
          not test any solver)
-    parameter_uncertainty_methods : list, str or None
+    parameter_uncertainty_methods : str or list of {'SANDWICH', 'CPG', 'OFIM'} or None
          List of parameter uncertainty methods to test.
          Can be specified as 'all', a list of uncertainty methods, or None (to not evaluate any uncertainty)
     results : ModelfitResults
@@ -62,7 +64,7 @@ def create_workflow(
     >>> from pharmpy.tools import run_estmethod, load_example_modelfit_results
     >>> model = load_example_model("pheno")
     >>> results = load_example_modelfit_results("pheno")
-    >>> methods = ['imp', 'saem']
+    >>> methods = ['IMP', 'SAEM']
     >>> parameter_uncertainty_methods = None
     >>> run_estmethod( # doctest: +SKIP
     >>>     'reduced', methods=methods, solvers='all', # doctest: +SKIP
@@ -190,11 +192,6 @@ def validate_input(algorithm, methods, solvers, parameter_uncertainty_methods, m
     if solvers is not None and has_linear_odes(model):
         raise ValueError(
             'Invalid input `model`: testing non-linear solvers on linear system is not supported'
-        )
-
-    if algorithm not in ALGORITHMS:
-        raise ValueError(
-            f'Invalid `algorithm`: got `{algorithm}`, must be one of {sorted(ALGORITHMS)}.'
         )
 
     if methods is None and solvers is None and parameter_uncertainty_methods is None:

--- a/src/pharmpy/tools/iivsearch/tool.py
+++ b/src/pharmpy/tools/iivsearch/tool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass, replace
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
 import pharmpy.tools.iivsearch.algorithms as algorithms
 from pharmpy.deps import pandas as pd
@@ -30,9 +30,9 @@ IIV_ALGORITHMS = frozenset(('brute_force', 'brute_force_no_of_etas', 'brute_forc
 
 
 def create_workflow(
-    algorithm: str,
-    iiv_strategy: str = 'no_add',
-    rank_type: str = 'mbic',
+    algorithm: Literal[tuple(IIV_ALGORITHMS)],
+    iiv_strategy: Literal[tuple(IIV_STRATEGIES)] = 'no_add',
+    rank_type: Literal[tuple(RANK_TYPES)] = 'mbic',
     cutoff: Optional[Union[float, int]] = None,
     results: Optional[ModelfitResults] = None,
     model: Optional[Model] = None,
@@ -43,13 +43,12 @@ def create_workflow(
 
     Parameters
     ----------
-    algorithm : str
-        Which algorithm to run (brute_force, brute_force_no_of_etas, brute_force_block_structure)
-    iiv_strategy : str
-        If/how IIV should be added to start model. Possible strategies are 'no_add', 'add_diagonal',
-        or 'fullblock'. Default is 'no_add'
-    rank_type : str
-        Which ranking type should be used (OFV, AIC, BIC, mBIC). Default is BIC
+    algorithm : {'brute_force', 'brute_force_no_of_etas', 'brute_force_block_structure'}
+        Which algorithm to run.
+    iiv_strategy : {'no_add', 'add_diagonal', 'fullblock', 'pd_add_diagonal', 'pd_fullblock'}
+        If/how IIV should be added to start model. Default is 'no_add'.
+    rank_type : {'ofv', 'lrt', 'aic', 'bic', 'mbic'}
+        Which ranking type should be used. Default is mBIC.
     cutoff : float
         Cutoff for which value of the ranking function that is considered significant. Default
         is None (all models will be ranked)
@@ -326,22 +325,6 @@ def validate_input(
     keep,
     strictness,
 ):
-    if algorithm not in IIV_ALGORITHMS:
-        raise ValueError(
-            f'Invalid `algorithm`: got `{algorithm}`, must be one of {sorted(IIV_ALGORITHMS)}.'
-        )
-
-    if rank_type not in RANK_TYPES:
-        raise ValueError(
-            f'Invalid `rank_type`: got `{rank_type}`, must be one of {sorted(RANK_TYPES)}.'
-        )
-
-    if iiv_strategy not in IIV_STRATEGIES:
-        raise ValueError(
-            f'Invalid `iiv_strategy`: got `{iiv_strategy}`,'
-            f' must be one of {sorted(IIV_STRATEGIES)}.'
-        )
-
     if keep:
         for parameter in keep:
             try:

--- a/src/pharmpy/tools/iovsearch/tool.py
+++ b/src/pharmpy/tools/iovsearch/tool.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Callable, Iterable, List, Optional, Tuple, TypeVar, Union
+from typing import Callable, Iterable, List, Literal, Optional, Tuple, TypeVar, Union
 
 import pharmpy.tools.iivsearch.algorithms
 from pharmpy.deps import pandas as pd
@@ -32,9 +32,9 @@ T = TypeVar('T')
 def create_workflow(
     column: str = 'OCC',
     list_of_parameters: Optional[List[str]] = None,
-    rank_type: str = 'mbic',
+    rank_type: Literal[tuple(RANK_TYPES)] = 'mbic',
     cutoff: Optional[Union[float, int]] = None,
-    distribution: str = 'same-as-iiv',
+    distribution: Literal[tuple(ADD_IOV_DISTRIBUTION)] = 'same-as-iiv',
     results: Optional[ModelfitResults] = None,
     model: Optional[Model] = None,
     strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs>=0.1)",
@@ -47,12 +47,12 @@ def create_workflow(
         Name of column in dataset to use as occasion column (default is 'OCC')
     list_of_parameters : None or list
         List of parameters to test IOV on, if none all parameters with IIV will be tested (default)
-    rank_type : str
-        Which ranking type should be used (OFV, AIC, BIC). Default is BIC
+    rank_type : {'ofv', 'lrt', 'aic', 'bic', 'mbic'}
+        Which ranking type should be used. Default is mBIC.
     cutoff : None or float
         Cutoff for which value of the ranking type that is considered significant. Default
         is None (all models will be ranked)
-    distribution : str
+    distribution : {'disjoint', 'joint', 'explicit', 'same-as-iiv'}
         Which distribution added IOVs should have (default is same-as-iiv)
     results : ModelfitResults
         Results for model
@@ -347,17 +347,6 @@ def validate_input(
     distribution,
     strictness,
 ):
-    if rank_type not in RANK_TYPES:
-        raise ValueError(
-            f'Invalid `rank_type`: got `{rank_type}`, must be one of {sorted(RANK_TYPES)}.'
-        )
-
-    if distribution not in ADD_IOV_DISTRIBUTION:
-        raise ValueError(
-            f'Invalid `distribution`: got `{distribution}`,'
-            f' must be one of {sorted(ADD_IOV_DISTRIBUTION)}.'
-        )
-
     if model is not None:
         if column not in model.datainfo.names:
             raise ValueError(

--- a/src/pharmpy/tools/modelsearch/tool.py
+++ b/src/pharmpy/tools/modelsearch/tool.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import pharmpy.tools.modelsearch.algorithms as algorithms
 from pharmpy.internals.fn.signature import with_same_arguments_as
-from pharmpy.internals.fn.type import check_list, with_runtime_arguments_type_check
+from pharmpy.internals.fn.type import with_runtime_arguments_type_check
 from pharmpy.model import Model
 from pharmpy.modeling import update_inits
 from pharmpy.tools import get_model_features, summarize_modelfit_results
@@ -19,9 +19,9 @@ from ..mfl.parse import parse as mfl_parse
 
 def create_workflow(
     search_space: Union[str, ModelFeatures],
-    algorithm: str,
-    iiv_strategy: str = 'absorption_delay',
-    rank_type: str = 'mbic',
+    algorithm: Literal[tuple(algorithms.ALGORITHMS)],
+    iiv_strategy: Literal[tuple(algorithms.IIV_STRATEGIES)] = 'absorption_delay',
+    rank_type: Literal[tuple(RANK_TYPES)] = 'mbic',
     cutoff: Optional[Union[float, int]] = None,
     results: Optional[ModelfitResults] = None,
     model: Optional[Model] = None,
@@ -33,13 +33,12 @@ def create_workflow(
     ----------
     search_space : str, ModelFeatures
         Search space to test. Either as a string or a ModelFeatures object.
-    algorithm : str
-        Algorithm to use (e.g. exhaustive)
-    iiv_strategy : str
-        If/how IIV should be added to candidate models. Possible strategies are 'no_add',
-        'add_diagonal', 'fullblock', or 'absorption_delay'. Default is 'absorption_delay'
-    rank_type : str
-        Which ranking type should be used (OFV, AIC, BIC, mBIC). Default is BIC
+    algorithm : {'exhaustive', 'exhaustive_stepwise', 'reduced_stepwise'}
+        Algorithm to use.
+    iiv_strategy : {'no_add', 'add_diagonal', 'fullblock', 'absorption_delay'}
+        If/how IIV should be added to candidate models. Default is 'absorption_delay'.
+    rank_type : {'ofv', 'lrt', 'aic', 'bic', 'mbic'}
+        Which ranking type should be used. Default is mBIC.
     cutoff : float
         Cutoff for which value of the ranking function that is considered significant. Default
         is None (all models will be ranked)
@@ -300,10 +299,6 @@ def validate_input(
     model,
     strictness,
 ):
-    check_list("algorithm", algorithm, algorithms.ALGORITHMS)
-    check_list("rank_type", rank_type, RANK_TYPES)
-    check_list("iiv_strategy", iiv_strategy, algorithms.IIV_STRATEGIES)
-
     try:
         statements = mfl_parse(search_space)
     except:  # noqa E722

--- a/src/pharmpy/tools/retries/tool.py
+++ b/src/pharmpy/tools/retries/tool.py
@@ -1,6 +1,6 @@
 import warnings
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 if TYPE_CHECKING:
     import numpy as np
@@ -41,7 +41,7 @@ def create_workflow(
     fraction: float = 0.1,
     use_initial_estimates: bool = False,
     strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs >= 0.1)",
-    scale: Optional[str] = "UCP",
+    scale: Optional[Literal[tuple(SCALES)]] = "UCP",
     prefix_name: Optional[str] = "",  # FIXME : Remove once new database has been implemented
     seed: Optional[Union[np.random.Generator, int]] = None,
 ):
@@ -62,7 +62,7 @@ def create_workflow(
         Use initial parameter estimates instead of final estimates of input model when creating candidate models.
     strictness : Optional[str], optional
         Strictness criteria. The default is "minimization_successful or (rounding_errors and sigdigs >= 0.1)".
-    scale : Optional[str]
+    scale : {'normal', 'UCP'}
         Which scale to update the initial values on. Either normal scale or UCP scale.
     prefix_name: Optional[str]
         Prefix the candidate model names with given string.

--- a/src/pharmpy/tools/ruvsearch/tool.py
+++ b/src/pharmpy/tools/ruvsearch/tool.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pharmpy.deps import pandas as pd
 from pharmpy.deps import sympy
@@ -52,7 +52,7 @@ def create_workflow(
     results: Optional[ModelfitResults] = None,
     groups: int = 4,
     p_value: float = 0.001,
-    skip: Optional[List[str]] = None,
+    skip: Optional[List[Literal[tuple(SKIP)]]] = None,
     max_iter: int = 3,
     dv: Optional[int] = None,
     strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs>=0.1)",
@@ -69,7 +69,7 @@ def create_workflow(
         The number of bins to use for the time varying models
     p_value : float
         The p-value to use for the likelihood ratio test
-    skip : list
+    skip : list of {'IIV_on_RUV', 'power', 'combined', 'time_varying'}
         A list of models to not attempt.
     max_iter :  int
         Number of iterations to run (1, 2, or 3). For models with BLQ only one iteration is supported.
@@ -534,9 +534,6 @@ def validate_input(model, results, groups, p_value, skip, max_iter, dv, strictne
 
     if not 0 < p_value <= 1:
         raise ValueError(f'Invalid `p_value`: got `{p_value}`, must be a float in range (0, 1].')
-
-    if skip is not None and not set(skip).issubset(SKIP):
-        raise ValueError(f'Invalid `skip`: got `{skip}`, must be None/NULL or a subset of {SKIP}.')
 
     if max_iter < 1 or max_iter > 3:
         raise ValueError(f'Invalid `max_iter`: got `{max_iter}`, must be int in range [1, 3].')

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from pharmpy.deps import numpy as np
 from pharmpy.deps import pandas as pd
 from pharmpy.internals.fn.signature import with_same_arguments_as
 from pharmpy.internals.fn.type import with_runtime_arguments_type_check
 from pharmpy.model import Model
+from pharmpy.modeling.tmdd import DV_TYPES
 from pharmpy.tools import summarize_modelfit_results
 from pharmpy.tools.common import ToolResults, create_results, update_initial_estimates
 from pharmpy.tools.modelfit import create_fit_workflow
@@ -22,7 +23,7 @@ TYPES = frozenset(('pkpd', 'drug_metabolite', 'tmdd'))
 
 
 def create_workflow(
-    type: str,
+    type: Literal[tuple(TYPES)],
     search_space: Optional[str] = None,
     b_init: Optional[Union[int, float]] = None,
     emax_init: Optional[Union[int, float]] = None,
@@ -33,7 +34,7 @@ def create_workflow(
     extra_model: Optional[Model] = None,
     strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs >= 0.1)",
     extra_model_results: Optional[ModelfitResults] = None,
-    dv_types: Optional[dict[str, int]] = None,
+    dv_types: Optional[dict[Literal[DV_TYPES], int]] = None,
 ):
     """Run the structsearch tool. For more details, see :ref:`structsearch`.
 
@@ -335,9 +336,6 @@ def validate_input(
     extra_model,
     extra_model_results,
 ):
-    if type not in TYPES:
-        raise ValueError(f'Invalid `type`: got `{type}`, must be one of {sorted(TYPES)}.')
-
     if strictness is not None and "rse" in strictness.lower():
         if model.estimation_steps[-1].parameter_uncertainty_method is None:
             raise ValueError(
@@ -348,11 +346,6 @@ def validate_input(
         if not len(dv_types.values()) == len(set(dv_types.values())):
             raise ValueError('Values must be unique.')
         for key, value in dv_types.items():
-            if key not in ['drug', 'target', 'complex', 'drug_tot', 'target_tot']:
-                raise ValueError(
-                    f'Invalid dv_types key "{key}". Allowed keys are:'
-                    f' "drug", "target", "complex", "drug_tot" and "target_tot".'
-                )
             if key not in ['drug', 'drug_tot'] and value == 1:
                 raise ValueError('Only drug can have DVID = 1. Please choose another DVID.')
 

--- a/tests/tools/test_covsearch.py
+++ b/tests/tools/test_covsearch.py
@@ -72,7 +72,7 @@ def test_validate_input_with_model(load_model_for_test, testdata, model_path):
             TypeError,
             'Invalid `max_steps`',
         ),
-        (None, dict(algorithm=()), TypeError, 'Invalid `algorithm`'),
+        (None, dict(algorithm=()), ValueError, 'Invalid `algorithm`'),
         (
             None,
             dict(algorithm='scm-backward'),

--- a/tests/tools/test_estmethod.py
+++ b/tests/tools/test_estmethod.py
@@ -117,7 +117,7 @@ def test_create_candidate_model(
     ),
     [
         (
-            dict(algorithm='x'),
+            dict(algorithm='x', methods='all'),
             ValueError,
             'Invalid `algorithm`',
         ),
@@ -127,7 +127,7 @@ def test_create_candidate_model(
             'Invalid search space options',
         ),
         (
-            dict(algorithm='exhaustive', solvers=['lsoda']),
+            dict(algorithm='exhaustive', solvers=['LSODA']),
             ValueError,
             'Invalid input `model`',
         ),
@@ -136,5 +136,5 @@ def test_create_candidate_model(
 def test_validate_input(load_model_for_test, pheno_path, args, exception, match):
     model = load_model_for_test(pheno_path)
     kwargs = {**args, 'model': model}
-    with pytest.raises(ValueError, match=match):
+    with pytest.raises(exception, match=match):
         validate_input(**kwargs)

--- a/tests/tools/test_iivsearch.py
+++ b/tests/tools/test_iivsearch.py
@@ -222,11 +222,11 @@ def test_validate_input_with_model(load_model_for_test, testdata):
 @pytest.mark.parametrize(
     ('model_path', 'arguments', 'exception', 'match'),
     [
-        (None, dict(algorithm=1), TypeError, 'Invalid `algorithm`'),
+        (None, dict(algorithm=1), ValueError, 'Invalid `algorithm`'),
         (None, dict(algorithm='brute_force_no_of_eta'), ValueError, 'Invalid `algorithm`'),
-        (None, dict(rank_type=1), TypeError, 'Invalid `rank_type`'),
+        (None, dict(rank_type=1), ValueError, 'Invalid `rank_type`'),
         (None, dict(rank_type='bi'), ValueError, 'Invalid `rank_type`'),
-        (None, dict(iiv_strategy=['no_add']), TypeError, 'Invalid `iiv_strategy`'),
+        (None, dict(iiv_strategy=['no_add']), ValueError, 'Invalid `iiv_strategy`'),
         (None, dict(iiv_strategy='diagonal'), ValueError, 'Invalid `iiv_strategy`'),
         (None, dict(cutoff='1'), TypeError, 'Invalid `cutoff`'),
         (

--- a/tests/tools/test_iovsearch.py
+++ b/tests/tools/test_iovsearch.py
@@ -70,10 +70,10 @@ def test_validate_input_with_model_and_list_of_parameters(load_model_for_test, t
     [
         (None, dict(column=1), TypeError, 'Invalid `column`'),
         (None, dict(list_of_parameters='CL'), TypeError, 'Invalid `list_of_parameters`'),
-        (None, dict(rank_type=1), TypeError, 'Invalid `rank_type`'),
+        (None, dict(rank_type=1), ValueError, 'Invalid `rank_type`'),
         (None, dict(rank_type='bi'), ValueError, 'Invalid `rank_type`'),
         (None, dict(cutoff='1'), TypeError, 'Invalid `cutoff`'),
-        (None, dict(distribution=['same-as-iiv']), TypeError, 'Invalid `distribution`'),
+        (None, dict(distribution=['same-as-iiv']), ValueError, 'Invalid `distribution`'),
         (None, dict(distribution='same'), ValueError, 'Invalid `distribution`'),
         (
             ('nonmem', 'pheno.mod'),

--- a/tests/tools/test_modelsearch.py
+++ b/tests/tools/test_modelsearch.py
@@ -311,7 +311,7 @@ def test_validate_input_with_model(load_model_for_test, testdata):
         (
             None,
             dict(algorithm=1),
-            TypeError,
+            ValueError,
             'Invalid `algorithm`',
         ),
         (
@@ -323,7 +323,7 @@ def test_validate_input_with_model(load_model_for_test, testdata):
         (
             None,
             dict(iiv_strategy=1),
-            TypeError,
+            ValueError,
             'Invalid `iiv_strategy`',
         ),
         (
@@ -335,7 +335,7 @@ def test_validate_input_with_model(load_model_for_test, testdata):
         (
             None,
             dict(rank_type=1),
-            TypeError,
+            ValueError,
             'Invalid `rank_type`',
         ),
         (

--- a/tests/tools/test_ruvsearch.py
+++ b/tests/tools/test_ruvsearch.py
@@ -153,7 +153,7 @@ def test_create_dataset(load_model_for_test, testdata, tmp_path):
         (
             None,
             dict(skip=['IIV_on_RUV', 'power', 'time']),
-            ValueError,
+            TypeError,
             'Invalid `skip`',
         ),
         (
@@ -178,6 +178,8 @@ def test_validate_input_raises(
 
     with pytest.raises(exception, match=match):
         validate_input(**kwargs)
+
+    validate_input(None, skip=['IIV_on_RUV', 'power'])
 
 
 def test_validate_input_raises_modelfit_results(load_model_for_test, testdata):

--- a/tests/tools/test_structsearch.py
+++ b/tests/tools/test_structsearch.py
@@ -173,9 +173,9 @@ def test_create_workflow_drug_metabolite(load_model_for_test, testdata):
             'Invalid arguments "b_init", "emax_init", "ec50_init" and "met_init" for TMDD models.',
         ),
         (
-            dict(type='tmdd', dv_types={'dru': 1}),
+            dict(type='a'),
             ValueError,
-            'Invalid dv_types key "dru". Allowed keys are: "drug", "target", "complex", "drug_tot" and "target_tot".',
+            'Invalid `type`',
         ),
         (
             dict(type='tmdd', search_space='ABSORPTION'),


### PR DESCRIPTION
- Implementation of `Literal` in type hints for all subtools, transform_blq, pkpd and tmdd.
- Additional error message for type `Literal` so that the error message looks nicer (as in `check_list`). Is that needed? This does not work if type is `Optional[Literal]`.
- Now arguments of type `Literal` are checked in internals/fn/type.py and do not need extra validation functions.

Possible issues:
- With Literals the arguments are case sensitive. Is that a problem?
- In structsearch the types are checked before the functions in `validate_input`. E.g. `dv_types` is checked before validating that `dv_types` is even a valid argument (e.g. for type `pkpd`). But if type is `pkpd` then validation of `dv_types` is unnecessary. 