### PR TITLE
Simplify covariate extraction and allow param/covariate combination in AMD

### DIFF
--- a/docs/amd.rst
+++ b/docs/amd.rst
@@ -85,8 +85,9 @@ Arguments
 |                                                   | If ``strictness`` is set to ``None`` no strictness                                                              |
 |                                                   | criteria are applied                                                                                            |
 +---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
-| ``mechanistic_covariates``                        | List of covariates to run in a separate prioritezed covsearch run.                                              |
-|                                                   | The effects are extracted from the given search space                                                           |
+| ``mechanistic_covariates``                        | List of covariates or covariate/parameter combinations to run in a separate prioritized covsearch run. Allowed  |
+|                                                   | elements in the list are strings of covariates or tuples with one covariate and parameter each, e.g ["AGE",     |
+|                                                   | ("WGT", "CL")]. The associated effects are extracted from the given search space.                               |
 +---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 | ``retries_strategy``                              | Decide how to use the retries tool. Valid options are 'skip', 'all_final' or 'final'. Default is 'all_final'    |
 +---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
@@ -549,7 +550,7 @@ For an entire AMD run, it is possible to get a maximum of three covsearch runs, 
 |                     | be tested once more at the start of the next covsearch run.                             |
 +---------------------+-----------------------------------------------------------------------------------------+
 | Mechanistic         | If any mechanistic covariates have been given as input to the AMD tool, the specified   |
-|                     | covariate effects for these covariates is run in a separate initial covsearch run When  |
+|                     | covariate effects for these covariates is run in a separate initial covsearch run when  |
 |                     | adding covariates.                                                                      |
 +---------------------+-----------------------------------------------------------------------------------------+
 | Exploratory         | The remaining covariates are tested after all mechanistic covariates have been tested.  |

--- a/src/pharmpy/modeling/__init__.py
+++ b/src/pharmpy/modeling/__init__.py
@@ -22,7 +22,7 @@ from .common import (
 from .compartments import get_bioavailability, get_lag_times
 from .covariate_effect import (
     add_covariate_effect,
-    get_covariates,
+    get_covariate_effects,
     has_covariate_effect,
     remove_covariate_effect,
 )
@@ -310,7 +310,7 @@ __all__ = [
     'get_cmt',
     'get_concentration_parameters_from_data',
     'get_config_path',
-    'get_covariates',
+    'get_covariate_effects',
     'get_covariate_baselines',
     'get_doses',
     'get_doseid',

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -9,6 +9,7 @@ from pharmpy.internals.fn.type import check_list, with_runtime_arguments_type_ch
 from pharmpy.model import Model
 from pharmpy.modeling import (
     add_parameter_uncertainty_step,
+    get_pk_parameters,
     has_mixed_mm_fo_elimination,
     plot_abs_cwres_vs_ipred,
     plot_cwres_vs_idv,
@@ -77,7 +78,7 @@ def run_amd(
     resume: bool = False,
     strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs>=0.1)",
     dv_types: Optional[dict[Literal[DV_TYPES], int]] = None,
-    mechanistic_covariates: Optional[List[str]] = None,
+    mechanistic_covariates: Optional[List[Union[str, tuple]]] = None,
     retries_strategy: Literal["final", "all_final", "skip"] = "all_final",
     seed: Optional[Union[np.random.Generator, int]] = None,
     parameter_uncertainty_method: Optional[Literal['SANDWICH', 'SMAT', 'RMAT', 'EFIM']] = None,
@@ -132,8 +133,9 @@ def run_amd(
     dv_types : dict or None
         Dictionary of DV types for TMDD models with multiple DVs.
     mechanistic_covariates : list
-        List of covariates to run in a separate proioritized covsearch run. The effects are extracted
-        from the search space for covsearch
+        List of covariates or tuple of covariate and parameter combination to run in a
+        separate proioritized covsearch run. For instance ["WT", ("CRCL", "CL")].
+        The effects are extracted from the search space for covsearch.
     retries_strategy: str
         Weither or not to run retries tool. Valid options are 'skip', 'all_final' or 'final'.
         Default is 'final'.
@@ -819,8 +821,6 @@ def _subfunc_structural_covariates(
     path,
 ) -> SubFunc:
     def _run_structural_covariates(model, modelfit_results):
-        from pharmpy.modeling import get_pk_parameters
-
         allowed_parameters = allowed_parameters = set(get_pk_parameters(model)).union(
             str(statement.symbol) for statement in model.statements.before_odes
         )
@@ -913,55 +913,24 @@ def _subfunc_mechanistic_exploratory_covariates(
             return None
 
         if mechanistic_covariates:
-            # Extract them and all forced
-            mfl = ModelFeatures.create_from_mfl_statement_list(search_space)
-            mfl_covariates = mfl.expand(model).covariate
-            filtered_searchspace = []
-            mechanistic_searchspace = []
-            structural_searchspace = []
-            for cov_statement in mfl_covariates:
-                if not cov_statement.optional.option:
-                    # Not optional -> Add to all search spaces (was added in structural run)
-                    structural_searchspace.append(cov_statement)
-                    mechanistic_searchspace.append(cov_statement)
-                    filtered_searchspace.append(cov_statement)
-                else:
-                    current_cov = []
-                    for cov in cov_statement.covariate:
-                        if cov in mechanistic_covariates:
-                            current_cov.append(cov)
-                    if current_cov:
-                        mechanistic_cov = Covariate(
-                            cov_statement.parameter,
-                            tuple(current_cov),
-                            cov_statement.fp,
-                            cov_statement.op,
-                            cov_statement.optional,
-                        )
-                        mechanistic_searchspace.append(mechanistic_cov)
-                        if filtered_cov_set := tuple(
-                            set(cov_statement.covariate) - set(current_cov)
-                        ):
-                            filtered_cov = Covariate(
-                                cov_statement.parameter,
-                                filtered_cov_set,
-                                cov_statement.fp,
-                                cov_statement.op,
-                                cov_statement.optional,
-                            )
-                            filtered_searchspace.append(filtered_cov)
-                    else:
-                        filtered_searchspace.append(cov_statement)
+            mechanistic_searchspace, filtered_searchspace = _mechanistic_cov_extraction(
+                search_space, model, mechanistic_covariates
+            )
 
+            # FIXME : Move to validation
             if not mechanistic_searchspace:
                 warnings.warn(
                     'No covariate effect for given mechanistic covariates found.'
                     ' Skipping mechanistic COVsearch.'
                 )
             else:
+                mechanistic_searchspace = ModelFeatures.create_from_mfl_statement_list(
+                    mechanistic_searchspace
+                )
+
                 res = run_tool(
                     'covsearch',
-                    mfl_stringify(mechanistic_searchspace),
+                    mechanistic_searchspace,
                     model=model,
                     strictness=strictness,
                     results=modelfit_results,
@@ -970,6 +939,7 @@ def _subfunc_mechanistic_exploratory_covariates(
                 index_offset = int(
                     res.summary_tool.iloc[-1].name[-1][13:]
                 )  # Get largest number of run
+                # FIXME : CHECK IF NAME IS CORRECT AS WELL
                 if res.final_model.name != model.name:
                     model = res.final_model
                     modelfit_results = res.tool_database.model_database.retrieve_modelfit_results(
@@ -982,11 +952,11 @@ def _subfunc_mechanistic_exploratory_covariates(
                         added_covs
                     )  # Avoid removing added cov in exploratory
         else:
-            filtered_searchspace = search_space
+            filtered_searchspace = mfl_stringify(search_space)
 
         res = run_tool(
             'covsearch',
-            mfl_stringify(filtered_searchspace),
+            filtered_searchspace,
             model=model,
             strictness=strictness,
             results=modelfit_results,
@@ -997,6 +967,47 @@ def _subfunc_mechanistic_exploratory_covariates(
         return res
 
     return _run_mechanistic_exploratory_covariates
+
+
+def _mechanistic_cov_extraction(search_space, model, mechanistic_covariates):
+    mechanistic_covariates = [c if isinstance(c, str) else set(c) for c in mechanistic_covariates]
+    # Extract them and all forced
+    mfl = ModelFeatures.create_from_mfl_statement_list(search_space)
+    mfl_covariates = mfl.expand(model).covariate
+    mechanistic_searchspace = []
+    for cov_statement in mfl_covariates:
+        if not cov_statement.optional.option:
+            # Not optional -> Add search space (was added in structural run)
+            mechanistic_searchspace.append(cov_statement)
+        else:
+            current_cov = []
+            current_param = []
+            for cov in cov_statement.covariate:
+                if cov in mechanistic_covariates:
+                    current_cov.append(cov)
+                    current_param.append(cov_statement.parameter)
+                else:
+                    for param in cov_statement.parameter:
+                        if {cov, param} in mechanistic_covariates:
+                            current_cov.append(cov)
+                            current_param.append([param])
+            for cc, cp in zip(current_cov, current_param):
+                mechanistic_cov = Covariate(
+                    tuple(cp),
+                    (cc,),
+                    cov_statement.fp,
+                    cov_statement.op,
+                    cov_statement.optional,
+                )
+                mechanistic_searchspace.append(mechanistic_cov)
+    if mechanistic_searchspace:
+        mechanistic_searchspace = ModelFeatures.create_from_mfl_statement_list(
+            mechanistic_searchspace
+        )
+        filtered_searchspace = mfl - mechanistic_searchspace
+    else:
+        filtered_searchspace = mfl
+    return mechanistic_searchspace, filtered_searchspace
 
 
 def _subfunc_allometry(amd_start_model: Model, allometric_variable, path) -> SubFunc:
@@ -1056,7 +1067,7 @@ def validate_input(
     resume: bool = False,
     strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs>=0.1)",
     dv_types: Optional[dict[Literal[DV_TYPES], int]] = None,
-    mechanistic_covariates: Optional[List[str]] = None,
+    mechanistic_covariates: Optional[List[Union[str, tuple]]] = None,
     retries_strategy: Literal["final", "all_final", "skip"] = "all_final",
     seed: Optional[Union[np.random.Generator, int]] = None,
     parameter_uncertainty_method: Optional[Literal['SANDWICH', 'SMAT', 'RMAT', 'EFIM']] = None,
@@ -1118,6 +1129,50 @@ def validate_input(
         validate_allometric_variable(model, allometric_variable)
 
     # COVSEARCH
+    if mechanistic_covariates:
+        allowed_covariates = get_covariates_allowed_in_covariate_effect(model)
+        allowed_parameters = allowed_parameters = set(get_pk_parameters(model)).union(
+            str(statement.symbol) for statement in model.statements.before_odes
+        )
+        for c in mechanistic_covariates:
+            if isinstance(c, str):
+                if c not in allowed_covariates:
+                    raise ValueError(
+                        f'Invalid mechanistic covariate: {c}.'
+                        f' Must be in {sorted(allowed_covariates)}'
+                    )
+            else:
+                if len(c) != 2:
+                    raise ValueError(
+                        f'Invalid argument in `mechanistic_covariate`: {c}.'
+                        f' Tuples need to be given with one parameter and one covariate.'
+                    )
+                cov_found = False
+                par_found = False
+                for a in c:
+                    if a in allowed_covariates:
+                        if cov_found:
+                            raise ValueError(
+                                f'`mechanistic_covariates` contain invalid argument: got `{c}`,'
+                                f' which contain two covariates.'
+                                f' Tuples need to be given with one parameter and one covariate.'
+                            )
+                        cov_found = True
+                    elif a in allowed_parameters:
+                        if par_found:
+                            raise ValueError(
+                                f'`mechanistic_covariates` contain invalid argument: got `{c}`,'
+                                f' which contain two parameters.'
+                                f' Tuples need to be given with one parameter and one covariate.'
+                            )
+                        par_found = True
+                    else:
+                        raise ValueError(
+                            f'`mechanistic_covariates` contain invalid argument: got `{c}`,'
+                            f' which contain {a}.'
+                            f' Tuples need to be given with one parameter and one covariate.'
+                        )
+
     if search_space is not None:
         covsearch_features = tuple(
             filter(

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 from pathlib import Path
 from typing import Callable, List, Literal, Optional, Tuple, Union
@@ -936,10 +937,15 @@ def _subfunc_mechanistic_exploratory_covariates(
                     results=modelfit_results,
                     path=path / 'covsearch_mechanistic',
                 )
-                index_offset = int(
-                    res.summary_tool.iloc[-1].name[-1][13:]
-                )  # Get largest number of run
-                # FIXME : CHECK IF NAME IS CORRECT AS WELL
+                model_db = res.tool_database.model_database
+                all_models = [model_db.retrieve_model(model) for model in model_db.list_models()]
+                covsearch_model_number = [
+                    re.search(r"(\d*)$").group(1)
+                    for model in all_models
+                    if model.name.startswith('covsearch')
+                ]
+                if covsearch_model_number:
+                    index_offset = max(covsearch_model_number)  # Get largest number of run
                 if res.final_model.name != model.name:
                     model = res.final_model
                     modelfit_results = res.tool_database.model_database.retrieve_modelfit_results(

--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -18,6 +18,7 @@ from pharmpy.tools.common import create_results, update_initial_estimates
 from pharmpy.tools.mfl.feature.covariate import EffectLiteral, all_covariate_effects
 from pharmpy.tools.mfl.feature.covariate import features as covariate_features
 from pharmpy.tools.mfl.feature.covariate import parse_spec, spec
+from pharmpy.tools.mfl.helpers import all_funcs
 from pharmpy.tools.mfl.parse import parse as mfl_parse
 from pharmpy.tools.mfl.statement.feature.covariate import Covariate
 from pharmpy.tools.mfl.statement.feature.symbols import Wildcard
@@ -242,18 +243,20 @@ def filter_search_space_and_model(search_space, model):
                 description.append(f'({cov_effect[0]}-{cov_effect[1]}-{cov_effect[2]})')
         filtered_model = filtered_model.replace(description=';'.join(description))
 
-    ss_funcs = ss_mfl.convert_to_funcs(["covariate"])
+    all_forced_cov = tuple([c for c in ss_mfl.covariate if not c.optional.option])
+    all_forced = all_funcs(Model(), all_forced_cov)
+    added_comb = set(k[1:3] for k in all_forced.keys())
 
-    remove_funcs = {k: v for k, v in ss_funcs.items() if k[-1] == "REMOVE"}
-    optional_funcs = {}
-    for key in remove_funcs.keys():
-        add_key = key[:-1] + ("ADD",)
-        optional_funcs[add_key] = ss_funcs[add_key]
-    mandatory_funcs = {
-        k: v
-        for k, v in ss_funcs.items()
-        if k[-1] != "REMOVE" and k[:-1] + ("REMOVE",) not in ss_funcs.keys()
-    }
+    ss_cov = ss_mfl - model_mfl
+    forced_add_cov = tuple([c for c in ss_cov.covariate if not c.optional.option])
+    mandatory_funcs = all_funcs(Model(), forced_add_cov)
+
+    optional_cov_list = tuple(c for c in ss_cov.covariate if c.optional.option)
+    optional_cov = ModelFeatures.create(covariate=optional_cov_list)
+    optional_funcs = optional_cov.convert_to_funcs()
+    optional_funcs = {k: v for k, v in optional_funcs.items() if not k[1:3] in added_comb}
+    optional_remove = {k: v for k, v in optional_funcs.items() if k[-1] == "REMOVE"}
+    optional_add = {k: v for k, v in optional_funcs.items() if k[-1] == "ADD"}
 
     def func_description(effect_funcs, model=None, add=True):
         d = []
@@ -270,9 +273,9 @@ def filter_search_space_and_model(search_space, model):
         return d
 
     # Remove all optional covariates
-    if len(remove_funcs) != 0:
-        potential_extension = func_description(remove_funcs, filtered_model, add=True)
-        for _, optional_func in remove_funcs.items():
+    if len(optional_remove) != 0:
+        potential_extension = func_description(optional_remove, filtered_model, add=True)
+        for _, optional_func in optional_remove.items():
             filtered_model = optional_func(filtered_model)
         if len(potential_extension) != 0:
             if not description:
@@ -291,13 +294,13 @@ def filter_search_space_and_model(search_space, model):
                 filtered_model = mandatory_func(filtered_model)
 
     # Filter unneccessary keys from fuctions
-    optional_funcs = {k[1:-1]: v for k, v in optional_funcs.items()}
+    optional_add = {k[1:-1]: v for k, v in optional_add.items()}
 
     if len(description) > 1:
         filtered_model = filtered_model.replace(description=';'.join(description))
-        return (optional_funcs, filtered_model)
+        return (optional_add, filtered_model)
     else:
-        return (optional_funcs, model)
+        return (optional_add, model)
 
 
 def task_greedy_forward_search(

--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -1,7 +1,7 @@
 from collections import Counter, defaultdict
 from dataclasses import astuple, dataclass, replace
 from itertools import count
-from typing import Any, Callable, Iterable, List, Literal, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Iterable, List, Literal, Optional, Tuple, Union
 
 from pharmpy.deps import numpy as np
 from pharmpy.deps import pandas as pd
@@ -15,7 +15,7 @@ from pharmpy.modeling.lrt import p_value as lrt_p_value
 from pharmpy.modeling.lrt import test as lrt_test
 from pharmpy.tools import is_strictness_fulfilled, summarize_modelfit_results
 from pharmpy.tools.common import create_results, update_initial_estimates
-from pharmpy.tools.mfl.feature.covariate import EffectLiteral, InputSpec, all_covariate_effects
+from pharmpy.tools.mfl.feature.covariate import EffectLiteral, all_covariate_effects
 from pharmpy.tools.mfl.feature.covariate import features as covariate_features
 from pharmpy.tools.mfl.feature.covariate import parse_spec, spec
 from pharmpy.tools.mfl.parse import parse as mfl_parse
@@ -99,7 +99,7 @@ ALGORITHMS = ('scm-forward', 'scm-forward-then-backward')
 
 
 def create_workflow(
-    effects: Union[str, Sequence[InputSpec]],
+    search_space: Union[str, ModelFeatures],
     p_forward: float = 0.01,
     p_backward: float = 0.001,
     max_steps: int = -1,
@@ -113,7 +113,7 @@ def create_workflow(
 
     Parameters
     ----------
-    effects : str
+    search_space : str
         MFL of covariate effects to try
     p_forward : float
         The p-value to use in the likelihood ratio test for forward steps
@@ -144,15 +144,15 @@ def create_workflow(
     >>> from pharmpy.tools import run_covsearch, load_example_modelfit_results
     >>> model = load_example_model("pheno")
     >>> results = load_example_modelfit_results("pheno")
-    >>> effects = 'COVARIATE([CL, V], [AGE, WT], EXP)'
-    >>> res = run_covsearch(effects, model=model, results=results)      # doctest: +SKIP
+    >>> search_space = 'COVARIATE([CL, V], [AGE, WT], EXP)'
+    >>> res = run_covsearch(search_space, model=model, results=results)      # doctest: +SKIP
     """
 
     wb = WorkflowBuilder(name=NAME_WF)
 
     # FIXME : Handle when model is None
     start_task = Task("create_modelentry", _start, model, results)
-    init_task = Task("init", _init_search_state, effects)
+    init_task = Task("init", _init_search_state, search_space)
     wb.add_task(init_task, predecessors=start_task)
 
     forward_search_task = Task(
@@ -197,9 +197,9 @@ def _start(model, results):
     return ModelEntry.create(model=model, parent=None, modelfit_results=results)
 
 
-def _init_search_state(context, effects: str, modelentry: ModelEntry) -> SearchState:
+def _init_search_state(context, search_space: str, modelentry: ModelEntry) -> SearchState:
     model = modelentry.model
-    effect_funcs, filtered_model = filter_search_space_and_model(effects, model)
+    effect_funcs, filtered_model = filter_search_space_and_model(search_space, model)
     if filtered_model != model:
         filtered_modelentry = ModelEntry.create(model=filtered_model)
         filtered_fit_wf = create_fit_workflow(modelentries=[filtered_modelentry])
@@ -210,11 +210,11 @@ def _init_search_state(context, effects: str, modelentry: ModelEntry) -> SearchS
     return (effect_funcs, SearchState(modelentry, filtered_modelentry, candidate, [candidate]))
 
 
-def filter_search_space_and_model(effects, model):
+def filter_search_space_and_model(search_space, model):
     filtered_model = model.replace(name="filtered_input_model", parent_model="filtered_input_model")
-    ss_mfl = ModelFeatures.create_from_mfl_string(effects).expand(
-        filtered_model
-    )  # Expand to remove LET/REF
+    if isinstance(search_space, str):
+        search_space = ModelFeatures.create_from_mfl_string(search_space)
+    ss_mfl = search_space.expand(filtered_model)  # Expand to remove LET/REF
     model_mfl = ModelFeatures.create_from_mfl_string(get_model_features(filtered_model))
 
     # Remove all covariates not part of the search space
@@ -759,7 +759,7 @@ def _make_df_steps_row(
 @with_runtime_arguments_type_check
 @with_same_arguments_as(create_workflow)
 def validate_input(
-    effects, p_forward, p_backward, algorithm, model, strictness, naming_index_offset
+    search_space, p_forward, p_backward, algorithm, model, strictness, naming_index_offset
 ):
     if not 0 < p_forward <= 1:
         raise ValueError(
@@ -772,10 +772,17 @@ def validate_input(
         )
 
     if model is not None:
-        try:
-            statements = mfl_parse(effects)
-        except:  # noqa E722
-            raise ValueError(f'Invalid `effects`, could not be parsed: `{effects}`')
+        if isinstance(search_space, str):
+            try:
+                statements = mfl_parse(search_space)
+            except:  # noqa E722
+                raise ValueError(f'Invalid `search_space`, could not be parsed: `{search_space}`')
+        else:
+            if not search_space.covariate:
+                raise ValueError(
+                    f'Invalid `search_space`, no covariate effect could be found in: `{search_space}`'
+                )
+            statements = search_space.covariate
 
         bad_statements = list(
             filter(
@@ -783,16 +790,15 @@ def validate_input(
                 statements,
             )
         )
-
         if bad_statements:
             raise ValueError(
-                f'Invalid `effects`: found unknown statement of type {type(bad_statements[0]).__name__}.'
+                f'Invalid `search_space`: found unknown statement of type {type(bad_statements[0]).__name__}.'
             )
 
         for s in statements:
             if isinstance(s, Covariate) and isinstance(s.fp, Wildcard) and not s.optional.option:
                 raise ValueError(
-                    f'Invalid `effects` due to non-optional covariate'
+                    f'Invalid `search_space` due to non-optional covariate'
                     f' defined with WILDCARD as effect in {s}'
                     f' Only single effect allowed for mandatory covariates'
                 )
@@ -813,26 +819,26 @@ def validate_input(
         for effect in candidate_effects:
             if effect.covariate not in allowed_covariates:
                 raise ValueError(
-                    f'Invalid `effects` because of invalid covariate found in'
-                    f' effects: got `{effect.covariate}`,'
+                    f'Invalid `search_space` because of invalid covariate found in'
+                    f' search_space: got `{effect.covariate}`,'
                     f' must be in {sorted(allowed_covariates)}.'
                 )
             if effect.parameter not in allowed_parameters:
                 raise ValueError(
-                    f'Invalid `effects` because of invalid parameter found in'
-                    f' effects: got `{effect.parameter}`,'
+                    f'Invalid `search_space` because of invalid parameter found in'
+                    f' search_space: got `{effect.parameter}`,'
                     f' must be in {sorted(allowed_parameters)}.'
                 )
             if effect.fp not in allowed_covariate_effects:
                 raise ValueError(
-                    f'Invalid `effects` because of invalid effect function found in'
-                    f' effects: got `{effect.fp}`,'
+                    f'Invalid `search_space` because of invalid effect function found in'
+                    f' search_space: got `{effect.fp}`,'
                     f' must be in {sorted(allowed_covariate_effects)}.'
                 )
             if effect.operation not in allowed_ops:
                 raise ValueError(
-                    f'Invalid `effects` because of invalid effect operation found in'
-                    f' effects: got `{effect.operation}`,'
+                    f'Invalid `search_space` because of invalid effect operation found in'
+                    f' search_space: got `{effect.operation}`,'
                     f' must be in {sorted(allowed_ops)}.'
                 )
     if strictness is not None and "rse" in strictness.lower():

--- a/src/pharmpy/tools/mfl/parse.py
+++ b/src/pharmpy/tools/mfl/parse.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from lark import Lark
 
 from pharmpy.model import Model
-from pharmpy.modeling.covariate_effect import get_covariates
+from pharmpy.modeling.covariate_effect import get_covariate_effects
 from pharmpy.modeling.odes import (
     get_number_of_peripheral_compartments,
     get_number_of_transit_compartments,
@@ -88,10 +88,6 @@ def validate_mfl_list(mfl_statement_list):
                             f" multiple statements. Please force only once"
                         )
                     mandatory_cov.update(product(s.parameter, s.covariate))
-    if error := [op for op in optional_cov if op in mandatory_cov]:
-        raise ValueError(
-            f"The covariate effect(s) {error} : are defined as both mandatory and optional"
-        )
 
 
 class ModelFeatures:
@@ -291,6 +287,30 @@ class ModelFeatures:
                 f"Covariate effect(s) {error} is forced by multiple reference statements."
                 f" Please redefine the search space."
             )
+
+        # Overwrite optional covariates if forced
+        if covariate:
+            covariate_combinations = set()
+            for cov in covariate:
+                covariate_combinations.update(
+                    set(
+                        product(
+                            cov.parameter, cov.covariate, cov.eval().fp, (cov.op,), (cov.optional,)
+                        )
+                    )
+                )
+            for combination in covariate_combinations.copy():
+                if not combination[4].option:
+                    opposite = combination[:-1] + (Option(True),)
+                    covariate_combinations.discard(opposite)
+
+            covariate_combinations = [tuple({x} for x in e) for e in covariate_combinations]
+            covariate_combinations = _reduce_covariate(covariate_combinations)
+            covariate = tuple()
+            for param, cov, fp, op, opt in covariate_combinations:
+                covariate += (
+                    Covariate(tuple(param), tuple(cov), tuple(fp), list(op)[0], list(opt)[0]),
+                )
 
         return ModelFeatures.create(
             absorption=self.absorption.eval,
@@ -621,27 +641,9 @@ class ModelFeatures:
         else:
             return tuple()
 
-        def _reduce(s, n):
-            clean_s = []
-            checked_keys = []
-            for i in s:
-                key = i[:n] + i[n + 1 :]
-                if key in checked_keys:
-                    pass
-                else:
-                    checked_keys.append(key)
-                    attr_set = set()
-                    for e in s:
-                        if key == e[:n] + e[n + 1 :]:
-                            attr_set.update(e[n])
-                    clean_s.append(i[:n] + (attr_set,) + i[n + 1 :])
-            return clean_s
-
         # Convert all elements to SETS before using reduce
         res = [tuple({x} for x in e) for e in res]
-        res = _reduce(res, 2)
-        res = _reduce(res, 1)
-        res = _reduce(res, 0)
+        res = _reduce_covariate(res)
         cov_res = []
         for param, cov, fp, op, opt in res:
             cov_res.append(
@@ -709,6 +711,67 @@ class ModelFeatures:
             )
 
         return lhs
+
+
+def _add_helper(s1, s2, value_name, join_name):
+    s1_join_name_dict = defaultdict(list)
+    for s in s1:
+        s = s.eval
+        attribute_names = getattr(s, join_name)
+        attribute_values = getattr(s, value_name)
+        for a in attribute_names:
+            s1_join_name_dict[a].extend(attribute_values)
+    s2_join_name_dict = defaultdict(list)
+    for s in s2:
+        s = s.eval
+        attribute_names = getattr(s, join_name)
+        attribute_values = getattr(s, value_name)
+        for a in attribute_names:
+            s2_join_name_dict[a].extend(attribute_values)
+    s1_unique = {
+        k: tuple(set(s1_join_name_dict[k]) - set(s2_join_name_dict[k]))
+        for k in s1_join_name_dict.keys()
+    }
+    s2_unique = {
+        k: tuple(set(s2_join_name_dict[k]) - set(s1_join_name_dict[k]))
+        for k in s2_join_name_dict.keys()
+    }
+    s2_unique = {k: v for k, v in s2_unique.items() if v}
+    s12_joined = {
+        k: tuple(set(s1_join_name_dict[k]).intersection(set(s2_join_name_dict[k])))
+        for k in s1_join_name_dict.keys()
+    }
+    s12_joined = {k: v for k, v in s12_joined.items() if v}
+
+    def remove_empty(d):
+        return {k: v for k, v in d.items() if v}
+
+    return (remove_empty(s1_unique), remove_empty(s2_unique), remove_empty(s12_joined))
+
+
+def _reduce_covariate(c):
+    c = _reduce(c, 2)
+    c = _reduce(c, 1)
+    c = _reduce(c, 0)
+    return c
+
+
+def _reduce(s, n):
+    """Reduce list of tuples of sets based on the n:th element in each tuple"""
+    clean_s = []
+    checked_keys = []
+    for i in s:
+        key = i[:n] + i[n + 1 :]
+        if key in checked_keys:
+            pass
+        else:
+            checked_keys.append(key)
+            attr_set = set()
+            for e in s:
+                if key == e[:n] + e[n + 1 :]:
+                    attr_set.update(e[n])
+            clean_s.append(i[:n] + (attr_set,) + i[n + 1 :])
+    return clean_s
 
 
 def get_model_features(model: Model, supress_warnings: bool = False) -> str:
@@ -780,7 +843,7 @@ def get_model_features(model: Model, supress_warnings: bool = False) -> str:
     peripherals = get_number_of_peripheral_compartments(model)
 
     # COVARIATES
-    covariates = get_covariates(model)
+    covariates = get_covariate_effects(model)
 
     if absorption:
         absorption = f'ABSORPTION({absorption})'

--- a/src/pharmpy/tools/mfl/statement/feature/covariate.py
+++ b/src/pharmpy/tools/mfl/statement/feature/covariate.py
@@ -45,10 +45,10 @@ class Covariate(ModelFeature):
 
         if self.fp == EffectFunctionWildcard:
             fp = (
-                'lin',
-                'piece_lin',
-                'exp',
-                'pow',
+                'LIN',
+                'PIECE_LIN',
+                'EXP',
+                'POW',
             )
         else:
             fp = self.fp

--- a/tests/tools/test_amd.py
+++ b/tests/tools/test_amd.py
@@ -8,7 +8,8 @@ import pytest
 from pharmpy.internals.fs.cwd import chdir
 from pharmpy.model import Model
 from pharmpy.tools import read_modelfit_results, run_amd
-from pharmpy.tools.amd.run import validate_input
+from pharmpy.tools.amd.run import _mechanistic_cov_extraction, validate_input
+from pharmpy.tools.mfl.parse import parse as mfl_parse
 from pharmpy.workflows import default_tool_database
 
 
@@ -181,6 +182,118 @@ def test_ignore_datainfo_fallback(tmp_path, testdata):
         )
 
     assert len(to_be_skipped) == 3
+
+
+@pytest.mark.parametrize(
+    'mechanistic_covariates, error',
+    [
+        (
+            ["WT", ("CLCR", "CL")],
+            'PASS',
+        ),
+        (
+            ["WT", "CLCR"],
+            'PASS',
+        ),
+        (
+            [("CLCR", "CL")],
+            'PASS',
+        ),
+        (
+            [("CL", "CLCR")],
+            'PASS',
+        ),
+        (
+            ["NOT_A_COVARIATE", ("CLCR", "CL")],
+            'Invalid mechanistic covariate:',
+        ),
+        (
+            ["WT", ("CL", "CL")],
+            '`mechanistic_covariates` contain invalid argument',
+        ),
+        (
+            ["CLCR", ("WT", "WT")],
+            '`mechanistic_covariates` contain invalid argument',
+        ),
+        (
+            ["CLCR", ("WT", "NOT_A_COVARIATE")],
+            '`mechanistic_covariates` contain invalid argument',
+        ),
+        (
+            ["CLCR", ("WT",)],
+            'Invalid argument in `mechanistic_covariate`:',
+        ),
+    ],
+)
+@pytest.mark.filterwarnings(
+    'ignore::UserWarning',
+)
+def test_mechanistic_covariate_option(tmp_path, testdata, mechanistic_covariates, error):
+    with chdir(tmp_path):
+        db, model = _load_model(testdata, with_datainfo=True)
+
+        if error != "PASS":
+            with pytest.raises(
+                ValueError,
+                match=error,
+            ):
+                validate_input(
+                    model,
+                    results=model.modelfit_results,
+                    modeltype='basic_pk',
+                    administration='oral',
+                    retries_strategy="skip",
+                    mechanistic_covariates=mechanistic_covariates,
+                    path=db.path,
+                    resume=True,
+                )
+        else:
+            # Should not raise any errors
+            validate_input(
+                model,
+                results=model.modelfit_results,
+                modeltype='basic_pk',
+                administration='oral',
+                retries_strategy="skip",
+                mechanistic_covariates=mechanistic_covariates,
+                path=db.path,
+                resume=True,
+            )
+
+
+@pytest.mark.parametrize(
+    'mechanistic_covariates, expected_mechanistic_ss, expected_filtered_ss',
+    [
+        (["WT", ("CLCR", "CL")], 'COVARIATE?(CL, [WT,CLCR], POW)', ''),
+        (["WT", "CLCR"], 'COVARIATE?(CL, [WT,CLCR], POW)', ''),
+        ([("CLCR", "CL")], 'COVARIATE?(CL, CLCR, POW)', 'COVARIATE?(CL, WT, POW)'),
+        ([("CL", "CLCR")], 'COVARIATE?(CL, CLCR, POW)', 'COVARIATE?(CL, WT, POW)'),
+        (
+            ["WT"],
+            'COVARIATE?(CL, WT, POW)',
+            'COVARIATE?(CL, CLCR, POW)',
+        ),
+    ],
+)
+@pytest.mark.filterwarnings(
+    'ignore::UserWarning',
+)
+def test_mechanistic_covariate_extraction(
+    tmp_path, testdata, mechanistic_covariates, expected_mechanistic_ss, expected_filtered_ss
+):
+    with chdir(tmp_path):
+        db, model = _load_model(testdata, with_datainfo=True)
+
+        search_space = mfl_parse('COVARIATE?(CL, [WT,CLCR], POW)')
+        mechanistic_ss, filtered_ss = _mechanistic_cov_extraction(
+            search_space, model, mechanistic_covariates
+        )
+
+        assert mechanistic_ss == mfl_parse(expected_mechanistic_ss, True)
+        if expected_filtered_ss:
+            assert filtered_ss == mfl_parse(expected_filtered_ss, True)
+        else:
+            assert not filtered_ss.covariate
 
 
 def _load_model(testdata: Path, with_datainfo: bool = False):

--- a/tests/tools/test_amd.py
+++ b/tests/tools/test_amd.py
@@ -230,7 +230,7 @@ def test_ignore_datainfo_fallback(tmp_path, testdata):
 )
 def test_mechanistic_covariate_option(tmp_path, testdata, mechanistic_covariates, error):
     with chdir(tmp_path):
-        db, model = _load_model(testdata, with_datainfo=True)
+        db, model, res = _load_model(testdata, with_datainfo=True)
 
         if error != "PASS":
             with pytest.raises(
@@ -239,7 +239,7 @@ def test_mechanistic_covariate_option(tmp_path, testdata, mechanistic_covariates
             ):
                 validate_input(
                     model,
-                    results=model.modelfit_results,
+                    results=res,
                     modeltype='basic_pk',
                     administration='oral',
                     retries_strategy="skip",
@@ -251,7 +251,7 @@ def test_mechanistic_covariate_option(tmp_path, testdata, mechanistic_covariates
             # Should not raise any errors
             validate_input(
                 model,
-                results=model.modelfit_results,
+                results=res,
                 modeltype='basic_pk',
                 administration='oral',
                 retries_strategy="skip",
@@ -282,7 +282,7 @@ def test_mechanistic_covariate_extraction(
     tmp_path, testdata, mechanistic_covariates, expected_mechanistic_ss, expected_filtered_ss
 ):
     with chdir(tmp_path):
-        db, model = _load_model(testdata, with_datainfo=True)
+        db, model, res = _load_model(testdata, with_datainfo=True)
 
         search_space = mfl_parse('COVARIATE?(CL, [WT,CLCR], POW)')
         mechanistic_ss, filtered_ss = _mechanistic_cov_extraction(

--- a/tests/tools/test_covsearch.py
+++ b/tests/tools/test_covsearch.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pharmpy.modeling import add_covariate_effect, get_covariates, remove_covariate_effect
+from pharmpy.modeling import add_covariate_effect, get_covariate_effects, remove_covariate_effect
 from pharmpy.tools.covsearch.tool import (
     create_workflow,
     filter_search_space_and_model,
@@ -147,21 +147,21 @@ def test_validate_input_raises(
 def test_covariate_filtering(load_model_for_test, testdata):
     search_space = 'COVARIATE(@IIV, @CONTINUOUS, lin);COVARIATE?(@IIV, @CATEGORICAL, CAT)'
     model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-    orig_cov = get_covariates(model)
+    orig_cov = get_covariate_effects(model)
     assert len(orig_cov) == 3
 
     eff, filtered_model = filter_search_space_and_model(search_space, model)
     assert len(eff) == 2
     expected_cov_eff = set((('CL', 'APGR', 'cat', '*'), ('V', 'APGR', 'cat', '*')))
     assert set(eff.keys()) == expected_cov_eff
-    assert len(get_covariates(filtered_model)) == 2
+    assert len(get_covariate_effects(filtered_model)) == 2
 
-    for cov_effect in get_covariates(model):
+    for cov_effect in get_covariate_effects(model):
         model = remove_covariate_effect(model, cov_effect[0], cov_effect[1].name)
 
     model = add_covariate_effect(model, 'CL', 'WGT', 'pow', '*')
-    assert len(get_covariates(model)) == 1
+    assert len(get_covariate_effects(model)) == 1
     search_space = 'COVARIATE([CL, V],WGT,pow,*)'
     eff, filtered_model = filter_search_space_and_model(search_space, model)
-    assert len(get_covariates(filtered_model)) == 2
+    assert len(get_covariate_effects(filtered_model)) == 2
     assert len(eff) == 0

--- a/tests/tools/test_covsearch.py
+++ b/tests/tools/test_covsearch.py
@@ -79,47 +79,42 @@ def test_validate_input_with_model(load_model_for_test, testdata, model_path):
             ValueError,
             'Invalid `algorithm`',
         ),
-        (('nonmem', 'pheno.mod'), dict(effects=1), TypeError, 'Invalid `effects`'),
+        (('nonmem', 'pheno.mod'), dict(search_space=1), TypeError, 'Invalid `search_space`'),
         (
             ('nonmem', 'pheno.mod'),
-            dict(effects=MINIMAL_INVALID_MFL_STRING),
+            dict(search_space=MINIMAL_INVALID_MFL_STRING),
             ValueError,
-            'Invalid `effects`',
+            'Invalid `search_space`',
         ),
         (
             ('nonmem', 'pheno.mod'),
-            dict(effects='LAGTIME()'),
+            dict(search_space='LAGTIME(ON)'),
             ValueError,
-            'Invalid `effects`',
+            'Invalid `search_space`',
         ),
         (
             ('nonmem', 'pheno.mod'),
-            dict(effects='COVARIATE([CL, VC], WGT, EXP)'),
+            dict(search_space='COVARIATE([CL, VC], WGT, EXP)'),
             ValueError,
-            'Invalid `effects` because of invalid parameter',
+            'Invalid `search_space` because of invalid parameter',
         ),
         (
             ('nonmem', 'pheno.mod'),
-            dict(effects='COVARIATE([CL, V], SEX, EXP)'),
+            dict(search_space='COVARIATE([CL, V], SEX, EXP)'),
             ValueError,
-            'Invalid `effects` because of invalid covariate',
+            'Invalid `search_space` because of invalid covariate',
         ),
         (
             ('nonmem', 'pheno.mod'),
-            dict(effects='COVARIATE([CL, V], WGT, [EXP, ABC])'),
+            dict(search_space='COVARIATE([CL, V], WGT, [EXP, ABC])'),
             ValueError,
-            'Invalid `effects` because of invalid effect function',
+            'Invalid `search_space` because of invalid effect function',
         ),
         (
             ('nonmem', 'pheno.mod'),
-            dict(
-                effects=(
-                    ('CL', 'WGT', 'exp', '*'),
-                    ('V', 'WGT', 'exp', '-'),
-                )
-            ),
+            dict(search_space='COVARIATE(CL, WGT, exp, -)'),
             ValueError,
-            'Invalid `effects`',
+            'Invalid `search_space`',
         ),
         (
             None,
@@ -140,7 +135,7 @@ def test_validate_input_raises(
     model = load_model_for_test(testdata.joinpath(*model_path)) if model_path else None
 
     harmless_arguments = dict(
-        effects=MINIMAL_VALID_MFL_STRING,
+        search_space=MINIMAL_VALID_MFL_STRING,
     )
 
     kwargs = {**harmless_arguments, 'model': model, **arguments}
@@ -150,12 +145,12 @@ def test_validate_input_raises(
 
 
 def test_covariate_filtering(load_model_for_test, testdata):
-    effects = 'COVARIATE(@IIV, @CONTINUOUS, lin);COVARIATE?(@IIV, @CATEGORICAL, CAT)'
+    search_space = 'COVARIATE(@IIV, @CONTINUOUS, lin);COVARIATE?(@IIV, @CATEGORICAL, CAT)'
     model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
     orig_cov = get_covariates(model)
     assert len(orig_cov) == 3
 
-    eff, filtered_model = filter_search_space_and_model(effects, model)
+    eff, filtered_model = filter_search_space_and_model(search_space, model)
     assert len(eff) == 2
     expected_cov_eff = set((('CL', 'APGR', 'cat', '*'), ('V', 'APGR', 'cat', '*')))
     assert set(eff.keys()) == expected_cov_eff
@@ -166,7 +161,7 @@ def test_covariate_filtering(load_model_for_test, testdata):
 
     model = add_covariate_effect(model, 'CL', 'WGT', 'pow', '*')
     assert len(get_covariates(model)) == 1
-    effects = 'COVARIATE([CL, V],WGT,pow,*)'
-    eff, filtered_model = filter_search_space_and_model(effects, model)
+    search_space = 'COVARIATE([CL, V],WGT,pow,*)'
+    eff, filtered_model = filter_search_space_and_model(search_space, model)
     assert len(get_covariates(filtered_model)) == 2
     assert len(eff) == 0

--- a/tests/tools/test_mfl.py
+++ b/tests/tools/test_mfl.py
@@ -622,7 +622,7 @@ def test_stringify(statements: Tuple[Statement, ...], expected: str):
 def test_get_model_features(load_model_for_test, pheno_path):
     model = load_model_for_test(pheno_path)
     assert (
-        'ABSORPTION(INST);ELIMINATION(FO);COVARIATE([CL, V],WGT,custom,*);COVARIATE([V],APGR,custom,*)'
+        'ABSORPTION(INST);ELIMINATION(FO);COVARIATE([CL, V],WGT,CUSTOM,*);COVARIATE([V],APGR,CUSTOM,*)'
         == get_model_features(model)
     )
 

--- a/tests/tools/test_mfl.py
+++ b/tests/tools/test_mfl.py
@@ -642,7 +642,9 @@ def test_ModelFeatures_eq(load_model_for_test, pheno_path):
     model = load_model_for_test(pheno_path)
     model_string = get_model_features(model)
     model_mfl = ModelFeatures.create_from_mfl_string(model_string)
-    assert ModelFeatures() == model_mfl
+    mfl = ModelFeatures()
+    mfl = mfl.replace(covariate=model_mfl.covariate)
+    assert mfl == model_mfl
 
 
 def test_ModelFeatures_add(load_model_for_test, pheno_path):
@@ -665,7 +667,8 @@ def test_ModelFeatures_add(load_model_for_test, pheno_path):
         peripherals=Peripherals(counts=(0, 1)),
         lagtime=LagTime(modes=(Name(name='OFF'),)),
         covariate=(
-            Covariate(parameter=('CL', 'V'), covariate=('APGR', 'WGT'), fp=('CUSTOM',), op=('*',)),
+            Covariate(parameter=('CL', 'V'), covariate=('WGT',), fp=('CUSTOM',), op=('*')),
+            Covariate(parameter=('V',), covariate=('APGR',), fp=('CUSTOM',), op=('*')),
         ),
     )
 
@@ -682,10 +685,9 @@ def test_ModelFeatures_add(load_model_for_test, pheno_path):
 
     m2 = m2.expand(model)
     m3 = m1 + m2
-
     assert set(m3.covariate[0].parameter) == {'CL', 'V'}
     assert set(m3.covariate[0].covariate) == {'WGT'}
-    assert set(m3.covariate[0].fp) == {'lin', 'piece_lin', 'exp', 'pow'}
+    assert set(m3.covariate[0].fp) == {'LIN', 'PIECE_LIN', 'EXP', 'POW'}
     assert set(m3.covariate[0].op) == {'*'}
 
 
@@ -725,7 +727,8 @@ def test_ModelFeatures_sub(load_model_for_test, pheno_path):
         peripherals=Peripherals(counts=(0,)),
         lagtime=LagTime(modes=(Name(name='OFF'),)),
         covariate=(
-            Covariate(parameter=('CL', 'V'), covariate=('APGR', 'WGT'), fp=('CUSTOM',), op=('*',)),
+            Covariate(parameter=('CL', 'V'), covariate=('WGT',), fp=('CUSTOM',), op=('*')),
+            Covariate(parameter=('V',), covariate=('APGR',), fp=('CUSTOM',), op=('*')),
         ),
     )
 
@@ -739,14 +742,14 @@ def test_ModelFeatures_sub(load_model_for_test, pheno_path):
         ValueError,
         match=r'Cannot be performed with reference value. Try using .expand\(model\) first.',
     ):
-        m1 + m2
+        m1 - m2
 
     m2 = m2.expand(model)
     m3 = m1 - m2
 
     assert set(m3.covariate[0].parameter) == {'V'}
     assert set(m3.covariate[0].covariate) == {'WGT'}
-    assert set(m3.covariate[0].fp) == {'lin', 'piece_lin', 'exp', 'pow'}
+    assert set(m3.covariate[0].fp) == {'LIN', 'PIECE_LIN', 'EXP', 'POW'}
     assert set(m3.covariate[0].op) == {'*'}
 
 
@@ -754,18 +757,19 @@ def test_least_number_of_transformations(load_model_for_test, pheno_path):
     model = load_model_for_test(pheno_path)
     model_string = get_model_features(model)
     model_mfl = ModelFeatures.create_from_mfl_string(model_string)
-    ss = "ABSORPTION([FO,ZO]);ELIMINATION(ZO);PERIPHERALS(1)"
+    ss = "ABSORPTION([FO,ZO]);ELIMINATION(ZO);PERIPHERALS(1);TRANSITS(1)"
     ss_mfl = parse(ss, mfl_class=True)
 
     lnt = model_mfl.least_number_of_transformations(ss_mfl, model)
     assert ('ABSORPTION', 'FO') in lnt
     assert ('ELIMINATION', 'ZO') in lnt
     assert ('PERIPHERALS', 1) in lnt
+    assert ('TRANSITS', 1, 'DEPOT') in lnt
     assert ('COVARIATE', 'CL', 'WGT', 'custom', '*', 'REMOVE') in lnt
     assert ('COVARIATE', 'V', 'WGT', 'custom', '*', 'REMOVE') in lnt
     assert ('COVARIATE', 'V', 'APGR', 'custom', '*', 'REMOVE') in lnt
 
-    assert len(lnt) == 6
+    assert len(lnt) == 7
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes crashing AMD integration test
Simplifies covariate effect extraction
Allows for param/covariate combinations (as tuples) for structural covariate effects in AMD