### PR TITLE
Default keep=["CL"] in IIVSearch

### DIFF
--- a/docs/iivsearch.rst
+++ b/docs/iivsearch.rst
@@ -72,6 +72,9 @@ Optional
 | ``cutoff``                                    | :ref:`Cutoff<ranking_iivsearch>` for the ranking function, exclude |
 |                                               | models that are below cutoff (default is none)                     |
 +-----------------------------------------------+--------------------------------------------------------------------+
+| ``keep``                                      | List of IIVs to keep, either by parameter name or ETA name.        |
+|                                               | Default is ["CL"]                                                  |
++-----------------------------------------------+--------------------------------------------------------------------+
 | ``strictness``                                | :ref:`strictness<strictness>` criteria for model selection.        |
 |                                               | Default is "minimization_successful or                             |
 |                                               | (rounding_errors and sigdigs>= 0.1)"                               |

--- a/src/pharmpy/tools/iivsearch/tool.py
+++ b/src/pharmpy/tools/iivsearch/tool.py
@@ -49,7 +49,7 @@ def create_workflow(
     cutoff: Optional[Union[float, int]] = None,
     results: Optional[ModelfitResults] = None,
     model: Optional[Model] = None,
-    keep: Optional[List[str]] = None,
+    keep: Optional[List[str]] = ["CL"],
     strictness: Optional[str] = "minimization_successful or (rounding_errors and sigdigs>=0.1)",
     correlation_algorithm: Optional[Literal[tuple(IIV_CORRELATION_ALGORITHMS)]] = None,
 ):
@@ -71,7 +71,7 @@ def create_workflow(
     model : Model
         Pharmpy model
     keep :  List[str]
-        List of IIVs to keep
+        List of IIVs to keep. Default is ["CL"]
     strictness : str or None
         Strictness criteria
     correlation_algorithm: {'top_down_exhaustive', 'skip'} or None
@@ -423,12 +423,12 @@ def post_process(
 def validate_input(
     algorithm, iiv_strategy, rank_type, model, keep, strictness, correlation_algorithm
 ):
-    if keep:
+    if keep and model:
         for parameter in keep:
             try:
                 has_random_effect(model, parameter, "iiv")
             except KeyError:
-                raise ValueError(f"Parameter {parameter} has no iiv.")
+                warnings.warn(f"Parameter {keep} has no iiv and is ignored")
 
     if strictness is not None and "rse" in strictness.lower():
         if model.estimation_steps[-1].parameter_uncertainty_method is None:

--- a/tests/integration/test_iivsearch.py
+++ b/tests/integration/test_iivsearch.py
@@ -82,6 +82,7 @@ def test_no_of_etas(
             algorithm,
             results=start_modelres[1],
             model=start_modelres[0],
+            keep=[],
             correlation_algorithm=correlation_algorithm,
         )
 
@@ -119,7 +120,7 @@ def test_no_of_etas(
 )
 def test_brute_force(tmp_path, model_count, start_modelres, algorithm, no_of_candidate_models):
     with chdir(tmp_path):
-        res = run_iivsearch(algorithm, results=start_modelres[1], model=start_modelres[0])
+        res = run_iivsearch(algorithm, keep=[], results=start_modelres[1], model=start_modelres[0])
 
         assert len(res.summary_tool) == no_of_candidate_models + 2
         assert len(res.summary_models) == no_of_candidate_models + 1
@@ -196,6 +197,7 @@ def test_no_of_etas_iiv_strategies(
             iiv_strategy=iiv_strategy,
             results=start_res,
             model=start_model,
+            keep=[],
             correlation_algorithm=correlation_algorithm,
         )
 

--- a/tests/tools/test_iivsearch.py
+++ b/tests/tools/test_iivsearch.py
@@ -252,3 +252,27 @@ def test_validate_input_raises(
 
     with pytest.raises(exception, match=match):
         validate_input(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ('model_path', 'arguments', 'warning', 'match'),
+    [(["nonmem", "pheno.mod"], dict(keep=["NONEXISTENT"]), UserWarning, 'Parameter')],
+)
+def test_validate_input_warn(
+    load_model_for_test,
+    testdata,
+    model_path,
+    arguments,
+    warning,
+    match,
+):
+    model = load_model_for_test(testdata.joinpath(*model_path)) if model_path else None
+
+    harmless_arguments = dict(
+        algorithm='top_down_exhaustive',
+    )
+
+    kwargs = {**harmless_arguments, 'model': model, **arguments}
+
+    with pytest.warns(warning, match=match):
+        validate_input(**kwargs)


### PR DESCRIPTION
Should fix #2776.
Warns the user if parameters are given in the "keep" argument that are not found in the model (this includes the default value of "CL")
