### PR TITLE
Remove TMDD models that have less than two dvs

### DIFF
--- a/src/pharmpy/tools/structsearch/tmdd.py
+++ b/src/pharmpy/tools/structsearch/tmdd.py
@@ -75,14 +75,50 @@ def create_remaining_models(model, ests, num_peripherals_qss, dv_types):
     if num_peripherals_qss < num_peripherals_model:
         model = remove_peripheral_compartment(model)
 
-    models = (
-        create_full_models(model, ests, dv_types)
-        + create_cr_models(model, ests, dv_types)
-        + create_ib_models(model, ests, dv_types)
-        + create_crib_models(model, ests, dv_types)
-        + create_wagner_model(model, ests, dv_types)
-        + create_mmapp_model(model, ests, dv_types)
-    )
+    if dv_types is None:
+        models = (
+            create_full_models(model, ests, dv_types)
+            + create_cr_models(model, ests, dv_types)
+            + create_ib_models(model, ests, dv_types)
+            + create_crib_models(model, ests, dv_types)
+            + create_wagner_model(model, ests, dv_types)
+            + create_mmapp_model(model, ests, dv_types)
+        )
+    else:
+        if len(dv_types) < 2:
+            raise ValueError('`dv_types` must contain more than 1 dv type')
+        else:
+            if (
+                ('drug' in dv_types or 'drug_tot' in dv_types)
+                and ('target' in dv_types or 'target_tot' in dv_types)
+                and 'complex' not in dv_types
+            ):
+                models = (
+                    create_full_models(model, ests, dv_types)
+                    + create_ib_models(model, ests, dv_types)
+                    + create_mmapp_model(model, ests, dv_types)
+                )
+            elif (
+                ('drug' in dv_types or 'drug_tot' in dv_types)
+                and 'complex' in dv_types
+                and not ('target' in dv_types or 'target_tot' in dv_types)
+            ):
+                models = (
+                    create_full_models(model, ests, dv_types)
+                    + create_cr_models(model, ests, dv_types)
+                    + create_ib_models(model, ests, dv_types)
+                    + create_crib_models(model, ests, dv_types)
+                    + create_wagner_model(model, ests, dv_types)
+                )
+            else:
+                models = (
+                    create_full_models(model, ests, dv_types)
+                    + create_cr_models(model, ests, dv_types)
+                    + create_ib_models(model, ests, dv_types)
+                    + create_crib_models(model, ests, dv_types)
+                    + create_wagner_model(model, ests, dv_types)
+                    + create_mmapp_model(model, ests, dv_types)
+                )
     return models
 
 

--- a/src/pharmpy/tools/structsearch/tool.py
+++ b/src/pharmpy/tools/structsearch/tool.py
@@ -352,6 +352,8 @@ def validate_input(
         if dv_types is not None:
             if not len(dv_types.values()) == len(set(dv_types.values())):
                 raise ValueError('Values must be unique.')
+            if len(dv_types) == 1:
+                raise ValueError('`dv_types` must contain more than 1 dv type')
             for key, value in dv_types.items():
                 if key not in ['drug', 'drug_tot'] and value == 1:
                     raise ValueError('Only drug can have DVID = 1. Please choose another DVID.')

--- a/tests/tools/test_structsearch.py
+++ b/tests/tools/test_structsearch.py
@@ -87,6 +87,17 @@ def test_create_remaining_models(load_example_model_for_test):
     model = load_example_model_for_test("pheno")
     models = create_remaining_models(model, ests, 2, None)
     assert len(models) == 12
+    models = create_remaining_models(model, ests, 2, dv_types={'drug': 1, 'complex': 2})
+    assert len(models) == 11
+    models = create_remaining_models(model, ests, 2, dv_types={'drug': 1, 'target': 2})
+    assert len(models) == 7
+    models = create_remaining_models(
+        model, ests, 2, dv_types={'drug': 1, 'target': 2, 'target_tot': 3}
+    )
+    assert len(models) == 7
+    with pytest.raises(ValueError, match='`dv_types` must contain more than 1 dv type'):
+        models = create_remaining_models(model, ests, 2, dv_types={'drug': 1})
+        assert len(models) == 7
 
 
 def test_create_remaining_models_multiple_dvs(load_example_model_for_test):


### PR DESCRIPTION
Remove TMDD models with fewer than 2 dvs from structsearch because there is no DV filtering for single dvs