### PR TITLE
Add info to dv_types for TMDD

### DIFF
--- a/docs/amd_tmdd.rst
+++ b/docs/amd_tmdd.rst
@@ -68,7 +68,7 @@ Optional
 | ``dv_types``                                      | Dictionary of DV types for multiple DVs (e.g. dv_types = {'target': 2}).                                        |
 |                                                   | Allowed keys are: 'drug', 'target', 'complex', 'drug_tot' and 'target_tot'. (For TMDD models only)              |
 |                                                   | For more information see :ref:`here<dv_types>`.                                                                 |
-|                                                   | Default is None                                                                                                 |
+|                                                   | Default is None which means that all observations are treated as drug observations.                             |
 +---------------------------------------------------+-----------------------------------------------------------------------------------------------------------------+
 
 .. note::

--- a/docs/tmdd.rst
+++ b/docs/tmdd.rst
@@ -59,9 +59,11 @@ Optional
 |                                                 | Optional if ``extra_model`` is not specified.                       |
 +-------------------------------------------------+---------------------------------------------------------------------+
 | ``dv_types``                                    | Dictionary of :ref:`DV types<dv_types>` for multiple DVs            |
-|                                                 | (e.g. dv_types = {'target': 2}). Default is None.                   |
+|                                                 | (e.g. dv_types = {'target': 2}).                                    |
 |                                                 | Allowed keys are: 'drug', 'target', 'complex', 'drug_tot' and       |
 |                                                 | 'target_tot'. Optional.                                             |
+|                                                 | Default is None which means that all observations are treated as    |
+|                                                 | drug observations.                                                  |
 +-------------------------------------------------+---------------------------------------------------------------------+
 
 ~~~~~~

--- a/src/pharmpy/modeling/tmdd.py
+++ b/src/pharmpy/modeling/tmdd.py
@@ -48,6 +48,7 @@ def set_tmdd(
         Type of TMDD model
     dv_types: dict
         Dictionary of DV types for TMDD models with multiple DVs (e.g. dv_types = {'drug' : 1, 'target': 2}).
+        Default is None which means that all observations are treated as drug observations.
         For dv = 1 the only allowed keys are 'drug' and 'drug_tot'. If no DV for drug is specified then (free) drug
         will have dv = 1.
 


### PR DESCRIPTION
Make it clear that all observations are treated as drug if `dv_types`is set to `None`.