### PR TITLE
Remove structural covariates from amd for pkpd models

### DIFF
--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -328,12 +328,13 @@ def run_amd(
 
     for section in order:
         if section == 'structural':
-            run_subfuncs['structural_covariates'] = _subfunc_structural_covariates(
-                amd_start_model=model,
-                search_space=covsearch_features,
-                strictness=strictness,
-                path=db.path,
-            )
+            if modeltype != 'pkpd':
+                run_subfuncs['structural_covariates'] = _subfunc_structural_covariates(
+                    amd_start_model=model,
+                    search_space=covsearch_features,
+                    strictness=strictness,
+                    path=db.path,
+                )
             if modeltype == 'pkpd':
                 func = _subfunc_structsearch(
                     type=modeltype,

--- a/src/pharmpy/tools/structsearch/pkpd.py
+++ b/src/pharmpy/tools/structsearch/pkpd.py
@@ -76,6 +76,8 @@ def create_pkpd_models(
     """
     if isinstance(search_space, str):
         mfl_statements = mfl_parse(search_space, True)
+    else:
+        mfl_statements = search_space
     functions = mfl_statements.convert_to_funcs(model=model, subset_features="pd")
 
     models = []

--- a/tests/integration/test_structsearch.py
+++ b/tests/integration/test_structsearch.py
@@ -1,28 +1,41 @@
+import os
+
 import pytest
 
 from pharmpy.internals.fs.cwd import chdir
-from pharmpy.modeling import convert_model, create_basic_pk_model  # , filter_dataset
+from pharmpy.modeling import convert_model, create_basic_pk_model, filter_dataset
 from pharmpy.tools import fit, run_structsearch
 
 
 def test_pkpd(tmp_path, load_model_for_test, testdata):
+    if os.name == 'nt':
+        pytest.skip("TODO Fails on Windows, temporarily skipping.")
     with chdir(tmp_path):
         model = create_basic_pk_model('iv', dataset_path=testdata / "nonmem" / "pheno_pd.csv")
         model = convert_model(model, 'nonmem')
-    #    pk_model = filter_dataset(model, "DVID != 2")  # NOTE: This step needs to be removed later
-    #    pk_res = fit(pk_model)
-    #    res = run_structsearch(type='pkpd', search_space="DIRECTEFFECT(*)",results=pk_res, model=model)
+        pk_model = filter_dataset(model, "DVID != 2")  # NOTE: This step needs to be removed later
+        pk_res = fit(pk_model)
+        res = run_structsearch(
+            type='pkpd',
+            search_space="DIRECTEFFECT(*)",
+            results=pk_res,
+            model=model,
+            b_init=0.1,
+            emax_init=0.1,
+            ec50_init=0.1,
+            met_init=0.1,
+        )
 
-    #    no_of_models = 9
-    #    assert len(res.summary_models) == no_of_models + 1
-    #    assert len(res.summary_tool) == no_of_models + 1
-    #    assert len(res.models) == no_of_models
+        no_of_models = 3
+        assert len(res.summary_models) == no_of_models + 2
+        assert len(res.summary_tool) == no_of_models + 1
+        assert len(res.models) == no_of_models + 1
 
-    #    rundir = tmp_path / 'structsearch_dir1'
-    #    assert rundir.is_dir()
-    #    assert (rundir / 'results.json').exists()
-    #    assert (rundir / 'results.csv').exists()
-    #    assert (rundir / 'metadata.json').exists()
+        rundir = tmp_path / 'structsearch_dir1'
+        assert rundir.is_dir()
+        assert (rundir / 'results.json').exists()
+        assert (rundir / 'results.csv').exists()
+        assert (rundir / 'metadata.json').exists()
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")

--- a/tests/integration/test_structsearch.py
+++ b/tests/integration/test_structsearch.py
@@ -13,7 +13,7 @@ def test_pkpd(tmp_path, load_model_for_test, testdata):
     with chdir(tmp_path):
         model = create_basic_pk_model('iv', dataset_path=testdata / "nonmem" / "pheno_pd.csv")
         model = convert_model(model, 'nonmem')
-        pk_model = filter_dataset(model, "DVID != 2")  # NOTE: This step needs to be removed later
+        pk_model = filter_dataset(model, "DVID != 2")
         pk_res = fit(pk_model)
         res = run_structsearch(
             type='pkpd',

--- a/tests/integration/test_structsearch.py
+++ b/tests/integration/test_structsearch.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import pytest
 
@@ -8,8 +9,8 @@ from pharmpy.tools import fit, run_structsearch
 
 
 def test_pkpd(tmp_path, load_model_for_test, testdata):
-    if os.name == 'nt':
-        pytest.skip("TODO Fails on Windows, temporarily skipping.")
+    if os.name == 'nt' or sys.platform == 'darwin':  # needs to be fixed. Issue #1967
+        pytest.skip("TODO Fails on Windows and Mac, temporarily skipping.")
     with chdir(tmp_path):
         model = create_basic_pk_model('iv', dataset_path=testdata / "nonmem" / "pheno_pd.csv")
         model = convert_model(model, 'nonmem')


### PR DESCRIPTION
- Remove structural covariates from AMD for PKPD models
- Fix bug in structsearch for PKPD
- Activate integration tests for mac and linux