### PR TITLE
Correct extraction of redundant K-rate individual parameters

### DIFF
--- a/src/pharmpy/modeling/expressions.py
+++ b/src/pharmpy/modeling/expressions.py
@@ -768,7 +768,6 @@ def get_individual_parameters(
 
     """
     # FIXME: Support multiple DVs
-
     model = make_declarative(model)
     model = _replace_trivial_redefinitions(model)
     statements = model.statements
@@ -801,7 +800,6 @@ def get_individual_parameters(
         ind = statements.find_assignment_index(y)
         gsub = _subgraph_of(full_graph, ind)
         gsub = _cut_partial_odes(model, gsub, ind)
-
         candidates = set(gsub.nodes).intersection(all_candidates)
 
         parameter_indices = _find_individual_parameters(gsub, candidates)
@@ -976,8 +974,11 @@ def _replace_trivial_redefinitions(model):
             s.expression in all_assigned_symbols or 1 / s.expression in all_assigned_symbols
         ):
             d[s.symbol] = s.expression
+            if s.expression in d.keys():
+                d[s.symbol] = d[s.expression]
         else:
             keep.append(s)
+
     new = Statements(tuple(keep)).subs(d)
     return model.replace(statements=new)
 

--- a/tests/modeling/test_expressions.py
+++ b/tests/modeling/test_expressions.py
@@ -41,6 +41,8 @@ from pharmpy.modeling import (
     mu_reference_model,
     read_model_from_string,
     set_direct_effect,
+    set_first_order_absorption,
+    set_transit_compartments,
     simplify_expression,
     solve_ode_system,
 )
@@ -494,6 +496,14 @@ def test_get_pd_parameters_indirect(
 def test_get_individual_parameters(load_model_for_test, testdata, model_path, level, expected):
     model = load_model_for_test(testdata / model_path)
     assert set(get_individual_parameters(model, level)) == set(expected)
+
+
+def test_get_individual_parameters_redundant_assign(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    model = set_first_order_absorption(model)
+    model = set_transit_compartments(model, 3)
+
+    assert set(get_individual_parameters(model)) == {'CL', 'MAT', 'MDT', 'V'}
 
 
 basic_pk_model = create_basic_pk_model()


### PR DESCRIPTION
A model being created with first order absorption as well as a number of transit compartments will have somewhat redundant k-rate parameters. The following example would create such a model

```
model = load_example_model("pheno")
model = set_first_order_absorption(model)
model = set_transit_compartments(model, 3)
```

The assignments in question would be the following

```
MAT = POP_MAT
KA = 1/MAT
K45 = KA
```

And through this, MAT was previously not caught as an individual parameter.