### PR TITLE
Move all_models outside of if statement

### DIFF
--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -729,11 +729,11 @@ def _subfunc_structsearch_tmdd(
 
         final_model = res.final_model
         model_db = res.tool_database.model_database
+        all_models = [model_db.retrieve_model(model) for model in model_db.list_models()]
 
         if not has_mixed_mm_fo_elimination(final_model):
             # Only select models that have mixed MM FO elimination
             # If no model with mixed MM FO then final model from modelsearch will be used
-            all_models = [model_db.retrieve_model(model) for model in model_db.list_models()]
             models_mixed_mm_fo_el = [
                 model.name for model in all_models if has_mixed_mm_fo_elimination(model)
             ]


### PR DESCRIPTION
Move `all_models`outside of the if statement so that it can be used further down as well.