### PR TITLE
Fix problem with central compartment being Response compartment

### DIFF
--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -1051,7 +1051,7 @@ class CompartmentalSystem(Statement):
             # E.g. TMDD models have more than one output
             # FIXME: Relying heavily on compartment naming for drug metabolite
             central = list(self._g.predecessors(output))[-1]
-            if central.name in ["METABOLITE", "EFFECT", "COMPLEX"]:
+            if central.name in ["METABOLITE", "EFFECT", "COMPLEX", "RESPONSE"]:
                 central = self.find_compartment("CENTRAL")
                 if central is None:
                     raise ValueError('Cannot find central compartment')

--- a/tests/modeling/test_pd.py
+++ b/tests/modeling/test_pd.py
@@ -158,3 +158,10 @@ def test_pd_michaelis_menten(load_model_for_test, testdata):
     michaelis_menten = set_michaelis_menten_elimination(model)
     pkpd_mm = add_effect_compartment(michaelis_menten, 'linear')
     assert pkpd.statements.find_assignment('E') == pkpd_mm.statements.find_assignment('E')
+
+
+def test_find_central_comp(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / "nonmem" / "pheno_pd.mod")
+    pkpd = add_indirect_effect(model, 'linear', True)
+    central = pkpd.statements.ode_system.central_compartment
+    assert central.name == 'CENTRAL'


### PR DESCRIPTION
When using `central_compartment` for an indirect effect model the response compartment was returned instead of the central compartment. 