### PR TITLE
Substitute fixed parameter symbols when calculating new UCP parameters

### DIFF
--- a/src/pharmpy/modeling/estimation.py
+++ b/src/pharmpy/modeling/estimation.py
@@ -126,8 +126,16 @@ def calculate_parameters_from_ucp(
     --------
     calculate_ucp_scale : Calculate the scale for conversion from ucps
     """
+    fixed_parameters_dict = model.parameters.fixed.inits
+    for p in model.parameters.names:
+        if p not in fixed_parameters_dict and p not in ucps:
+            raise ValueError(f'Parameter "{p}" is neither fixed nor given in ucps.')
+        if p in fixed_parameters_dict and p in ucps:
+            raise ValueError(f'Parameter "{p}" cannot both be fixed and given in ucps.')
+
     omega_symbolic = model.random_variables.etas.covariance_matrix
     omega = omega_symbolic.subs(dict(ucps))
+    omega = omega.subs(fixed_parameters_dict)
     omega = omega.to_numpy()
     descaled_omega = _descale_matrix(omega, scale.omega)
     omega_dict = {}
@@ -137,6 +145,7 @@ def calculate_parameters_from_ucp(
 
     sigma_symbolic = model.random_variables.epsilons.covariance_matrix
     sigma = sigma_symbolic.subs(dict(ucps))
+    sigma = sigma.subs(fixed_parameters_dict)
     sigma = sigma.to_numpy()
     descaled_sigma = _descale_matrix(sigma, scale.sigma)
     sigma_dict = {}

--- a/tests/modeling/test_estimation.py
+++ b/tests/modeling/test_estimation.py
@@ -1,0 +1,49 @@
+import pytest
+
+from pharmpy.modeling import (
+    calculate_parameters_from_ucp,
+    calculate_ucp_scale,
+    fix_parameters,
+    get_omegas,
+    get_sigmas,
+    get_thetas,
+)
+
+
+def test_calculate_ucp_scale(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
+
+    ucp = calculate_ucp_scale(model)
+
+    assert len(get_thetas(model)) == len(ucp.theta)
+    for res, expected in zip(ucp.theta, [19.27717888, 13.90639125, 13.82933276]):
+        assert abs(res - expected) <= 10**-4
+
+    assert len(get_omegas(model)) == len(ucp.omega)
+    for res, expected in zip(ucp.omega.flatten(), [0.15921694, 0.0, 0.0, 0.15964163]):
+        assert abs(res - expected) <= 10**-4
+
+    assert len(get_sigmas(model)) == len(ucp.sigma)
+    for res, expected in zip(ucp.sigma.flatten(), [0.10411923]):
+        assert abs(res - expected) <= 10**-4
+
+
+def test_calculate_parameters_from_ucp(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
+
+    ucp_scale = calculate_ucp_scale(model)
+
+    new_param = calculate_parameters_from_ucp(model, ucp_scale, model.parameters.inits)
+    assert len(new_param) == 6
+
+    model = fix_parameters(model, model.parameters.names)
+    with pytest.raises(
+        ValueError, match='Parameter "PTVCL" cannot both be fixed and given in ucps'
+    ):
+        calculate_parameters_from_ucp(model, ucp_scale, model.parameters.inits)
+
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
+    new_parameters = model.parameters.inits
+    new_parameters.pop("PTVCL")
+    with pytest.raises(ValueError, match='Parameter "PTVCL" is neither fixed nor given in ucps.'):
+        calculate_parameters_from_ucp(model, ucp_scale, new_parameters)


### PR DESCRIPTION
Should fix #2904