### PR TITLE
Adaptive scope reduction and max eval option for covsearch

### DIFF
--- a/docs/covsearch.rst
+++ b/docs/covsearch.rst
@@ -82,6 +82,9 @@ Optional
 | ``algorithm``                               | The search :ref:`algorithm<algorithm_covsearch>` to use               |
 |                                             | (default is `'scm-forward-then-backward'`)                            |
 +---------------------------------------------+-----------------------------------------------------------------------+
+| ``max_eval``                                | Limit the number of function evaluations to 3.1 times that of the     |
+|                                             | base model. Default is False.                                         |
++---------------------------------------------+-----------------------------------------------------------------------+
 | ``strictness``                              | :ref:`Strictness<strictness>` criteria for model selection.           |
 |                                             | Default is "minimization_successful or                                |
 |                                             | (rounding_errors and sigdigs>= 0.1)"                                  |

--- a/docs/covsearch.rst
+++ b/docs/covsearch.rst
@@ -85,6 +85,11 @@ Optional
 | ``max_eval``                                | Limit the number of function evaluations to 3.1 times that of the     |
 |                                             | base model. Default is False.                                         |
 +---------------------------------------------+-----------------------------------------------------------------------+
+| ``adaptive_scope_reduction``                | Stash all non-significant parameter-covariate effects at each step in |
+|                                             | the forward search for later evaluation. As soon as all significant   |
+|                                             | effects have been tested the stashed effects gets evaluated in a      |
+|                                             | normal forward approach. Default is False                             |
++---------------------------------------------+-----------------------------------------------------------------------+
 | ``strictness``                              | :ref:`Strictness<strictness>` criteria for model selection.           |
 |                                             | Default is "minimization_successful or                                |
 |                                             | (rounding_errors and sigdigs>= 0.1)"                                  |
@@ -253,6 +258,16 @@ To skip the backward steps use search algorithm `'scm-forward'`.
             s4 -> s9
         }
 
+Adaptive scope reduction
+------------------------
+
+The adaptive scope reduction option integrates part of the SCM+ procedure within the covsearch tool. This option will
+modify the forward search such that only significant effects will be transferred to the next step. Insignificant effects 
+are stored away. The number of possible steps in this search is dependent on the ``max_steps`` argument. With the resulting
+model from this search as input, a regular 'scm-forward' procedure is applied, using only the previously insignificant effects.
+The number of possible steps in this procedure is also determined by the ``max_steps`` argument.
+
+If 'scm-forward-then-backward' is used, a subsequent backward search will follow.
 
 ~~~~~~~
 Results

--- a/tests/integration/test_covsearch.py
+++ b/tests/integration/test_covsearch.py
@@ -17,4 +17,20 @@ def test_default_str(tmp_path, model_count, start_modelres):
         )
 
         rundir = tmp_path / 'covsearch1'
-        assert model_count(rundir) >= 9
+        assert model_count(rundir) == 39
+
+
+def test_adaptive_scope_reduction(tmp_path, model_count, start_modelres):
+    with chdir(tmp_path):
+        run_tool(
+            'covsearch',
+            'LET(CONTINUOUS, [AGE, WT]); LET(CATEGORICAL, SEX)\n'
+            'COVARIATE?([CL, MAT, VC], @CONTINUOUS, exp, *)\n'
+            'COVARIATE?([CL, MAT, VC], @CATEGORICAL, cat, *)',
+            results=start_modelres[1],
+            model=start_modelres[0],
+            adaptive_scope_reduction=True,
+        )
+
+        rundir = tmp_path / 'covsearch1'
+        assert model_count(rundir) == 33

--- a/tests/tools/test_covsearch.py
+++ b/tests/tools/test_covsearch.py
@@ -1,14 +1,23 @@
+from dataclasses import replace
+
 import pytest
 
 from pharmpy.modeling import add_covariate_effect, get_covariate_effects, remove_covariate_effect
 from pharmpy.tools import read_modelfit_results
 from pharmpy.tools.covsearch.tool import (
+    AdaptiveStep,
+    AddEffect,
+    Candidate,
+    ForwardStep,
+    SearchState,
+    _greedy_search,
     _start,
     create_workflow,
     filter_search_space_and_model,
+    task_add_covariate_effect,
     validate_input,
 )
-from pharmpy.workflows import Workflow
+from pharmpy.workflows import ModelEntry, Workflow
 
 MINIMAL_INVALID_MFL_STRING = ''
 MINIMAL_VALID_MFL_STRING = 'LET(x, 0)'
@@ -181,3 +190,110 @@ def test_max_eval(load_model_for_test, testdata):
     assert max_eval_model_entry.model.execution_steps[0].maximum_evaluations == round(
         3.1 * modelres.function_evaluations_iterations.loc[1]
     )
+
+
+def _mock_fit(effect, parent, adaptive_step):
+    if effect[0][0] == "CL":
+        if effect[0][1] == "WGT" and effect[0][2] == "pow":
+            ofv = parent.modelentry.modelfit_results.ofv + 100 * -2
+        else:
+            if not adaptive_step:
+                if (
+                    len(parent.steps) != 0
+                    and effect[0][0] == "CL"
+                    and effect[0][1] == "APGR"
+                    and effect[0][2] == "pow"
+                ):
+                    ofv = parent.modelentry.modelfit_results.ofv + 100 * -2
+                else:
+                    ofv = parent.modelentry.modelfit_results.ofv + 100 * -1
+            else:
+                if len(parent.steps) != 0:
+                    ofv = parent.modelentry.modelfit_results.ofv + 100
+                else:
+                    ofv = parent.modelentry.modelfit_results.ofv + 100 * -1
+    else:
+        ofv = parent.modelentry.modelfit_results.ofv + 100
+
+    return ofv
+
+
+@pytest.mark.parametrize(('adaptive_step',), ((True,), (False,)))
+def test_adaptive_scope_reduction(load_model_for_test, testdata, adaptive_step):
+    p_value = 0.01
+    search_space = "COVARIATE?([CL,V],[WGT,APGR],[exp,lin,pow])"
+
+    # Mock version of handle_effects() within covsearch
+    def _mock_handle_effects(
+        step: int,
+        parent: Candidate,
+        candidate_effect_funcs: dict,
+        index_offset: int,
+    ):
+        new_candidate_modelentries = []
+        for i, effect in enumerate(candidate_effect_funcs.items(), 1):
+            candidate_model_entry = task_add_covariate_effect(
+                parent.modelentry,
+                parent,
+                effect,
+                index_offset + i,
+            )
+
+            # Fake new ofv value of model
+            ofv = _mock_fit(effect, parent, adaptive_step)
+            new_modelfit = replace(parent.modelentry.modelfit_results, ofv=ofv)
+
+            candidate_model_entry = ModelEntry.create(
+                model=candidate_model_entry.model,
+                modelfit_results=new_modelfit,
+                parent=candidate_model_entry.parent,
+            )
+            new_candidate_modelentries.append(candidate_model_entry)
+        return [
+            Candidate(modelentry, parent.steps + (ForwardStep(p_value, AddEffect(*effect)),))
+            for modelentry, effect in zip(new_candidate_modelentries, candidate_effect_funcs.keys())
+        ]
+
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    modelres = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+
+    candidate_effect_funcs, start = filter_search_space_and_model(search_space, model)
+    start = _start(start, modelres, False)
+    candidate = Candidate(start, ())
+    state = SearchState(start, start, candidate, [candidate])
+
+    res = _greedy_search(
+        state,
+        _mock_handle_effects,
+        candidate_effect_funcs,
+        p_value,
+        6,
+        "minimization_successful or (rounding_errors and sigdigs>=0.1)",
+        True,
+    )
+
+    best_candidate = res.all_candidates_so_far[0]
+    for c in res.all_candidates_so_far:
+        if c.modelentry.modelfit_results.ofv < best_candidate.modelentry.modelfit_results.ofv:
+            best_candidate = c
+
+    for c in res.all_candidates_so_far:
+        print(c.modelentry.modelfit_results.ofv, c.steps)
+        if len(c.steps) == 1:
+            assert (
+                best_candidate.modelentry.modelfit_results.ofv <= c.modelentry.modelfit_results.ofv
+            )
+        elif len(c.steps) == 2:
+            assert best_candidate.steps[0] == c.steps[0]
+        elif len(c.steps) == 3 and adaptive_step:
+            assert isinstance(c.steps[-2], AdaptiveStep)
+        elif len(c.steps) == 3 and not adaptive_step:
+            assert c.steps[-1].effect.parameter == "V"
+            assert (
+                c.modelentry.modelfit_results.ofv > best_candidate.modelentry.modelfit_results.ofv
+            )
+        elif len(c.steps) == 4:
+            assert c.steps[-1].effect.parameter == "V"
+            assert (
+                c.modelentry.modelfit_results.ofv > best_candidate.modelentry.modelfit_results.ofv
+            )

--- a/tests/tools/test_covsearch.py
+++ b/tests/tools/test_covsearch.py
@@ -1,7 +1,9 @@
 import pytest
 
 from pharmpy.modeling import add_covariate_effect, get_covariate_effects, remove_covariate_effect
+from pharmpy.tools import read_modelfit_results
 from pharmpy.tools.covsearch.tool import (
+    _start,
     create_workflow,
     filter_search_space_and_model,
     validate_input,
@@ -165,3 +167,17 @@ def test_covariate_filtering(load_model_for_test, testdata):
     eff, filtered_model = filter_search_space_and_model(search_space, model)
     assert len(get_covariate_effects(filtered_model)) == 2
     assert len(eff) == 0
+
+
+def test_max_eval(load_model_for_test, testdata):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
+    modelres = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+
+    no_max_eval_model_entry = _start(model, modelres, max_eval=False)
+    assert no_max_eval_model_entry.model == model
+
+    max_eval_model_entry = _start(model, modelres, max_eval=True)
+    assert max_eval_model_entry.model != model
+    assert max_eval_model_entry.model.execution_steps[0].maximum_evaluations == round(
+        3.1 * modelres.function_evaluations_iterations.loc[1]
+    )


### PR DESCRIPTION
Possibility of setting the adaptive scope reduction (from scm+) and max eval when running covsearch.
Should implement #2881 as well as #2880