### PR TITLE
Allow multiple arguments when defining derivative in Expr

### DIFF
--- a/src/pharmpy/basic/expr.py
+++ b/src/pharmpy/basic/expr.py
@@ -239,8 +239,8 @@ class Expr:
         return cls(x)
 
     @classmethod
-    def derivative(cls, f, x) -> Expr:
-        dfdx = symengine.Derivative(f, x)
+    def derivative(cls, f, *x) -> Expr:
+        dfdx = symengine.Derivative(f, *x)
         return cls(dfdx)
 
     @classmethod


### PR DESCRIPTION
For defining derivatives of second order and above