### PR TITLE
Restructure derivative handling

### DIFF
--- a/src/pharmpy/model/external/nonmem/parsing.py
+++ b/src/pharmpy/model/external/nonmem/parsing.py
@@ -370,8 +370,8 @@ def parse_execution_steps(control_stream, random_variables) -> ExecutionSteps:
     solver, tol, atol = parse_solver(control_stream)
 
     # Read eta and epsilon derivatives
-    etaderiv_names = None
-    epsilonderivs_names = None
+    etaderiv_names = []
+    epsilonderivs_names = []
     table_records = control_stream.get_records('TABLE')
     predictions = ()
     residuals = ()
@@ -397,11 +397,13 @@ def parse_execution_steps(control_stream, random_variables) -> ExecutionSteps:
         etaderivs = table.eta_derivatives
         if etaderivs:
             etas = random_variables.etas
-            etaderiv_names = [etas.names[i - 1] for i in etaderivs]
+            etaderiv_names = [(Expr.symbol(etas.names[i - 1]),) for i in etaderivs]
         epsderivs = table.epsilon_derivatives
         if epsderivs:
             epsilons = random_variables.epsilons
-            epsilonderivs_names = [epsilons.names[i - 1] for i in epsderivs]
+            epsilonderivs_names = [(Expr.symbol(epsilons.names[i - 1]),) for i in epsderivs]
+
+    derivatives = tuple(etaderiv_names + epsilonderivs_names)
 
     for record in records:
         value = record.get_option('METHOD')
@@ -493,8 +495,7 @@ def parse_execution_steps(control_stream, random_variables) -> ExecutionSteps:
                 solver=solver,
                 solver_rtol=tol,
                 solver_atol=atol,
-                eta_derivatives=etaderiv_names,
-                epsilon_derivatives=epsilonderivs_names,
+                derivatives=derivatives,
                 predictions=predictions,
                 residuals=residuals,
             )

--- a/src/pharmpy/workflows/results.py
+++ b/src/pharmpy/workflows/results.py
@@ -399,6 +399,8 @@ class ModelfitResults(Results):
         Table of various residuals
     predictions: pd.DataFrame
         Table of various predictions
+    derivaitves: pd.DataFrame
+        Table of various derivatives
     estimation_runtime : float
         Runtime for one estimation step
     runtime_total : float
@@ -446,6 +448,7 @@ class ModelfitResults(Results):
     individual_estimates_covariance: Optional[pd.DataFrame] = None
     residuals: Optional[pd.DataFrame] = None
     predictions: Optional[pd.DataFrame] = None
+    derivatives: Optional[pd.DataFrame] = None
     runtime_total: Optional[float] = None
     termination_cause: Optional[str] = None
     termination_cause_iterations: Optional[pd.Series] = None

--- a/tests/nonmem/test_nonmem_model.py
+++ b/tests/nonmem/test_nonmem_model.py
@@ -988,8 +988,9 @@ def test_parse_derivatives(load_model_for_test, testdata):
     model = load_model_for_test(
         testdata / "nonmem" / "linearize" / "linearize_dir1" / "scm_dir1" / "derivatives.mod"
     )
-    assert model.execution_steps[0].eta_derivatives == ('ETA_1', 'ETA_2')
-    assert model.execution_steps[0].epsilon_derivatives == ('EPS_1',)
+    # NOTE : Order of derivatives is cannonicalized
+    d = tuple(tuple(map(Expr.symbol, p)) for p in (('EPS_1',), ('ETA_1',), ('ETA_2',)))
+    assert model.execution_steps[0].derivatives == d
 
 
 def test_no_etas_in_model(pheno):
@@ -1262,7 +1263,6 @@ def test_zo(load_model_for_test, pheno_path):
     model = load_model_for_test(pheno_path)
     model = set_zero_order_input(model, "CENTRAL", 10)
     des = model.internals.control_stream.get_records("DES")[0]
-    print(des)
     assert str(des) == "$DES\nDADT(1) = -A(1)*CL/V + 10\n"
 
 

--- a/tests/workflows/test_hashing.py
+++ b/tests/workflows/test_hashing.py
@@ -5,7 +5,7 @@ from pharmpy.workflows.hashing import DatasetHash, ModelHash
 def test_hash(load_example_model_for_test):
     model = load_example_model_for_test("pheno")
     h = ModelHash(model)
-    assert str(h) == "Q1IeIf2PVAiya2ghqLshv7JSRZD-CG_Q2T_FMPvD6Zk"
+    assert str(h) == "Ov1wUMumvRAxL0WKygUhXacZ2pnRKmbr-mNpGRUuaBI"
     d = DatasetHash(model.dataset)
     assert str(d) == h.dataset_hash
 


### PR DESCRIPTION
Single .derivative attribute instead of splitting ETA/EPS in EstimationStep. Derivatives are always with respect to the prediction.
Derivatives are stored as a tuple of tuples where each tuple represent one derivative. Each element within the tuples are required to be a symbol of type pharmpy.basic.Expr.