### PR TITLE
Add modelfit_results to results object

### DIFF
--- a/src/pharmpy/tools/allometry/report.rst
+++ b/src/pharmpy/tools/allometry/report.rst
@@ -15,14 +15,16 @@ Final model
     :hide-code:
 
     from pharmpy.workflows.results import read_results
+    from pharmpy.tools.common import table_final_parameter_estimates
 
     res = read_results('results.json')
+    final_model_parameter_estimates = table_final_parameter_estimates(res.final_model, res.final_results.parameter_estimates_sdcorr, res.final_results.standard_errors_sdcorr)
 
 
 .. jupyter-execute::
    :hide-code:
 
-   res.final_model_parameter_estimates.style.format({
+   final_model_parameter_estimates.style.format({
        'estimates': '{:,.4f}'.format,
        'RSE': '{:,.1%}'.format,
    })

--- a/src/pharmpy/tools/allometry/tool.py
+++ b/src/pharmpy/tools/allometry/tool.py
@@ -185,6 +185,7 @@ def results(start_model_entry, allometry_model_entry):
         summary_individuals_count=sumcount,
         summary_errors=sumerrs,
         final_model=best_model,
+        final_results=allometry_res,
     )
 
 

--- a/src/pharmpy/tools/amd/run.py
+++ b/src/pharmpy/tools/amd/run.py
@@ -42,6 +42,7 @@ from pharmpy.tools.mfl.statement.feature.peripherals import Peripherals
 from pharmpy.tools.mfl.statement.statement import Statement
 from pharmpy.tools.run import summarize_errors_from_entries
 from pharmpy.workflows import ModelEntry, Results, default_context
+from pharmpy.workflows.model_database.local_directory import get_modelfit_results
 from pharmpy.workflows.results import ModelfitResults
 
 from ..run import run_tool
@@ -513,9 +514,9 @@ def run_amd(
                         )
                         run_subfuncs['covsearch'] = func
                 next_model = subresults.final_model
-                # FIXME: This could perhaps be piped
-                model_db = ctx.model_database
-                next_model_entry = model_db.retrieve_model_entry(model)
+                next_model_entry = ModelEntry.create(
+                    model=next_model, modelfit_results=subresults.final_results
+                )
             sum_subtools.append(_create_sum_subtool(tool_name, next_model_entry))
             sum_models.append(subresults.summary_models.reset_index())
             sum_inds_counts.append(subresults.summary_individuals_count.reset_index())
@@ -746,8 +747,11 @@ def _subfunc_structsearch_tmdd(
         )
 
         final_model = res.final_model
-        model_db = res.tool_database.model_database
-        all_models = [model_db.retrieve_model(model) for model in model_db.list_models()]
+        all_models = [
+            subctx1.retrieve_model_entry(model_name).model
+            for model_name in subctx1.list_all_names()
+        ]
+        all_models = retrieve_models(subctx1.path, names=subctx1.list_all_names())
 
         if not has_mixed_mm_fo_elimination(final_model):
             # Only select models that have mixed MM FO elimination
@@ -761,11 +765,15 @@ def _subfunc_structsearch_tmdd(
                 if len(rank_filtered) > 0:
                     rank_filtered = rank_filtered.sort_values(by=['rank'])
                     highest_ranked = rank_filtered.index[0]
-                    final_model = retrieve_models(
-                        ctx.path / 'subcontexts' / 'modelsearch', names=[highest_ranked]
-                    )[0]
+                    final_model = retrieve_models(subctx1.path, names=[highest_ranked])[0]
 
-        final_res = model_db.retrieve_modelfit_results(final_model.name)
+        res_path = (
+            subctx1.path
+            / "models"
+            / final_model.name
+            / ("model" + subctx1.model_database.file_extension)
+        )
+        final_res = get_modelfit_results(final_model, res_path)
 
         extra_model = None
         extra_model_results = None
@@ -789,12 +797,16 @@ def _subfunc_structsearch_tmdd(
             if len(rank_filtered) > 0:
                 rank_filtered = rank_filtered.sort_values(by=['rank'])
                 highest_ranked = rank_filtered.index[0]
-                extra_model = retrieve_models(
-                    ctx.path / 'subcontexts' / 'modelsearch', names=[highest_ranked]
-                )[0]
+                extra_model = retrieve_models(subctx1.path, names=[highest_ranked])[0]
                 if dv_types is not None:
                     extra_model = extra_model.replace(dataset=orig_dataset)
-                extra_model_results = model_db.retrieve_modelfit_results(extra_model.name)
+                res_path = (
+                    subctx1.path
+                    / "models"
+                    / extra_model.name
+                    / ("model" + subctx1.model_database.file_extension)
+                )
+                extra_model_results = get_modelfit_results(extra_model, res_path)
 
         # Replace original dataset if multiple DVs
         if dv_types is not None:
@@ -990,20 +1002,22 @@ def _subfunc_mechanistic_exploratory_covariates(
                     results=modelfit_results,
                     path=subcontext1.path,
                 )
-                model_db = res.tool_database.model_database
-                all_models = [model_db.retrieve_model(model) for model in model_db.list_models()]
                 covsearch_model_number = [
                     re.search(r"(\d*)$").group(1)
-                    for model in all_models
-                    if model.name.startswith('covsearch')
+                    for model_name in subcontext1.list_all_names()
+                    if model_name.startswith('covsearch')
                 ]
                 if covsearch_model_number:
                     index_offset = max(covsearch_model_number)  # Get largest number of run
                 if res.final_model.name != model.name:
                     model = res.final_model
-                    modelfit_results = res.tool_database.model_database.retrieve_modelfit_results(
-                        res.final_model.name
+                    res_path = (
+                        subcontext1.path
+                        / "models"
+                        / model.name
+                        / ("model" + subcontext1.model_database.file_extension)
                     )
+                    modelfit_results = get_modelfit_results(model, res_path)
                     added_covs = ModelFeatures.create_from_mfl_string(
                         get_model_features(model)
                     ).covariate

--- a/src/pharmpy/tools/common.py
+++ b/src/pharmpy/tools/common.py
@@ -55,8 +55,8 @@ class ToolResults(Results):
     summary_individuals_count: Optional[pd.DataFrame] = None
     summary_errors: Optional[pd.DataFrame] = None
     final_model: Optional[Model] = None
+    final_results: Optional[ModelfitResults] = None
     models: Sequence[Model] = ()
-    final_model_parameter_estimates: Optional[pd.DataFrame] = None
     final_model_dv_vs_ipred_plot: Optional[alt.Chart] = None
     final_model_dv_vs_pred_plot: Optional[alt.Chart] = None
     final_model_cwres_vs_idv_plot: Optional[alt.Chart] = None
@@ -153,12 +153,8 @@ def create_results(
         summary_individuals_count=summary_individuals_count,
         summary_errors=summary_errors,
         final_model=best_model,
+        final_results=final_results,
         models=models,
-        final_model_parameter_estimates=table_final_parameter_estimates(
-            best_model,
-            final_results.parameter_estimates_sdcorr,
-            final_results.standard_errors_sdcorr,
-        ),
         final_model_dv_vs_ipred_plot=plots['dv_vs_ipred'],
         final_model_dv_vs_pred_plot=plots['dv_vs_pred'],
         final_model_cwres_vs_idv_plot=plots['cwres_vs_idv'],

--- a/src/pharmpy/tools/covsearch/report.rst
+++ b/src/pharmpy/tools/covsearch/report.rst
@@ -15,21 +15,23 @@ Final model
     :hide-code:
 
     from pharmpy.workflows.results import read_results
+    from pharmpy.tools.common import table_final_parameter_estimates
 
     res = read_results('results.json')
+    final_model_parameter_estimates = table_final_parameter_estimates(res.final_model, res.final_results.parameter_estimates_sdcorr, res.final_results.standard_errors_sdcorr)
 
 Parameter estimates
 
 .. jupyter-execute::
    :hide-code:
 
-   if res.final_model_parameter_estimates['RSE'].any():
-       results = res.final_model_parameter_estimates.style.format({
+   if final_model_parameter_estimates['RSE'].any():
+       results = final_model_parameter_estimates.style.format({
            'estimates': '{:,.4f}'.format,
            'RSE': '{:,.1%}'.format,
        })
    else:
-       results = res.final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
+       results = final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
            'estimates': '{:,.4f}'.format,
        })
 

--- a/src/pharmpy/tools/iivsearch/report.rst
+++ b/src/pharmpy/tools/iivsearch/report.rst
@@ -15,21 +15,27 @@ Final model
     :hide-code:
 
     from pharmpy.workflows.results import read_results
+    from pharmpy.tools.common import table_final_parameter_estimates
 
     res = read_results('results.json')
+    final_model_parameter_estimates = table_final_parameter_estimates(
+            res.final_model,
+            res.final_results.parameter_estimates_sdcorr,
+            res.final_results.standard_errors_sdcorr
+            )
 
 Parameter estimates
 
 .. jupyter-execute::
    :hide-code:
 
-   if res.final_model_parameter_estimates['RSE'].any():
-       results = res.final_model_parameter_estimates.style.format({
+   if final_model_parameter_estimates['RSE'].any():
+       results = final_model_parameter_estimates.style.format({
            'estimates': '{:,.4f}'.format,
            'RSE': '{:,.1%}'.format,
        })
    else:
-       results = res.final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
+       results = final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
            'estimates': '{:,.4f}'.format,
        })
 

--- a/src/pharmpy/tools/iivsearch/tool.py
+++ b/src/pharmpy/tools/iivsearch/tool.py
@@ -23,7 +23,6 @@ from pharmpy.tools.common import (
     create_plots,
     create_results,
     table_final_eta_shrinkage,
-    table_final_parameter_estimates,
     update_initial_estimates,
 )
 from pharmpy.tools.iivsearch.algorithms import _get_fixed_etas, _remove_sublist
@@ -259,8 +258,9 @@ def start(
 
         final_model = res.final_model
         if final_model.name != input_model_entry.model.name:
-            # FIXME: This should be piped instead
-            final_model_entry = context.retrieve_model_entry(final_model.name)
+            final_model_entry = ModelEntry.create(
+                model=final_model, modelfit_results=res.final_results
+            )
         else:
             final_res = input_model_entry.modelfit_results
             final_model_entry = ModelEntry.create(model=final_model, modelfit_results=final_res)
@@ -310,11 +310,7 @@ def start(
         summary_individuals_count=_concat_summaries(sum_inds_count, keys),
         summary_errors=_concat_summaries(sum_errs, keys),
         final_model=final_final_model,
-        final_model_parameter_estimates=table_final_parameter_estimates(
-            final_final_model,
-            final_results.parameter_estimates_sdcorr,
-            final_results.standard_errors_sdcorr,
-        ),
+        final_results=final_results,
         final_model_dv_vs_ipred_plot=plots['dv_vs_ipred'],
         final_model_dv_vs_pred_plot=plots['dv_vs_pred'],
         final_model_cwres_vs_idv_plot=plots['cwres_vs_idv'],

--- a/src/pharmpy/tools/iovsearch/report.rst
+++ b/src/pharmpy/tools/iovsearch/report.rst
@@ -15,21 +15,27 @@ Final model
     :hide-code:
 
     from pharmpy.workflows.results import read_results
+    from pharmpy.tools.common import table_final_parameter_estimates
 
     res = read_results('results.json')
+    final_model_parameter_estimates = table_final_parameter_estimates(
+            res.final_model,
+            res.final_results.parameter_estimates_sdcorr,
+            res.final_results.standard_errors_sdcorr
+            )
 
 Parameter estimates
 
 .. jupyter-execute::
    :hide-code:
 
-   if res.final_model_parameter_estimates['RSE'].any():
-       results = res.final_model_parameter_estimates.style.format({
+   if final_model_parameter_estimates['RSE'].any():
+       results = final_model_parameter_estimates.style.format({
            'estimates': '{:,.4f}'.format,
            'RSE': '{:,.1%}'.format,
        })
    else:
-       results = res.final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
+       results = final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
            'estimates': '{:,.4f}'.format,
        })
 

--- a/src/pharmpy/tools/modelsearch/report.rst
+++ b/src/pharmpy/tools/modelsearch/report.rst
@@ -15,8 +15,14 @@ Final model
     :hide-code:
 
     from pharmpy.workflows.results import read_results
+    from pharmpy.tools.common import table_final_parameter_estimates
 
     res = read_results('results.json')
+    final_model_parameter_estimates = table_final_parameter_estimates(
+            res.final_model,
+            res.final_results.parameter_estimates_sdcorr,
+            res.final_results.standard_errors_sdcorr
+            )
 
 
 Parameter estimates
@@ -24,13 +30,13 @@ Parameter estimates
 .. jupyter-execute::
    :hide-code:
 
-   if res.final_model_parameter_estimates['RSE'].any():
-       results = res.final_model_parameter_estimates.style.format({
+   if final_model_parameter_estimates['RSE'].any():
+       results = final_model_parameter_estimates.style.format({
            'estimates': '{:,.4f}'.format,
            'RSE': '{:,.1%}'.format,
        })
    else:
-       results = res.final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
+       results = final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
            'estimates': '{:,.4f}'.format,
        })
 

--- a/src/pharmpy/tools/retries/report.rst
+++ b/src/pharmpy/tools/retries/report.rst
@@ -15,21 +15,27 @@ Final model
     :hide-code:
 
     from pharmpy.workflows.results import read_results
+    from pharmpy.tools.common import table_final_parameter_estimates
 
     res = read_results('results.json')
+    final_model_parameter_estimates = table_final_parameter_estimates(
+            res.final_model,
+            res.final_results.parameter_estimates_sdcorr,
+            res.final_results.standard_errors_sdcorr
+            )
 
 Parameter estimates
 
 .. jupyter-execute::
    :hide-code:
 
-   if res.final_model_parameter_estimates['RSE'].any():
-       results = res.final_model_parameter_estimates.style.format({
+   if final_model_parameter_estimates['RSE'].any():
+       results = final_model_parameter_estimates.style.format({
            'estimates': '{:,.4f}'.format,
            'RSE': '{:,.1%}'.format,
        })
    else:
-       results = res.final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
+       results = final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
            'estimates': '{:,.4f}'.format,
        })
 

--- a/src/pharmpy/tools/ruvsearch/report.rst
+++ b/src/pharmpy/tools/ruvsearch/report.rst
@@ -15,21 +15,27 @@ Final model
     :hide-code:
 
     from pharmpy.workflows.results import read_results
+    from pharmpy.tools.common import table_final_parameter_estimates
 
     res = read_results('results.json')
+    final_model_parameter_estimates = table_final_parameter_estimates(
+            res.final_model,
+            res.final_results.parameter_estimates_sdcorr,
+            res.final_results.standard_errors_sdcorr
+            )
 
 Parameter estimates
 
 .. jupyter-execute::
    :hide-code:
 
-   if res.final_model_parameter_estimates['RSE'].any():
-       results = res.final_model_parameter_estimates.style.format({
+   if final_model_parameter_estimates['RSE'].any():
+       results = final_model_parameter_estimates.style.format({
            'estimates': '{:,.4f}'.format,
            'RSE': '{:,.1%}'.format,
        })
    else:
-       results = res.final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
+       results = final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
            'estimates': '{:,.4f}'.format,
        })
 

--- a/src/pharmpy/tools/ruvsearch/tool.py
+++ b/src/pharmpy/tools/ruvsearch/tool.py
@@ -36,7 +36,6 @@ from pharmpy.tools.common import (
     create_plots,
     summarize_tool,
     table_final_eta_shrinkage,
-    table_final_parameter_estimates,
     update_initial_estimates,
 )
 from pharmpy.tools.modelfit import create_fit_workflow
@@ -245,14 +244,10 @@ def start(context, input_model, input_res, groups, p_value, skip, max_iter, dv, 
         summary_individuals=sumind,
         summary_individuals_count=sumcount,
         final_model=model_entry.model,
+        final_results=model_entry.modelfit_results,
         summary_models=summf,
         summary_tool=summary_tool,
         summary_errors=summary_errors,
-        final_model_parameter_estimates=table_final_parameter_estimates(
-            model_entry.model,
-            model_entry.modelfit_results.parameter_estimates_sdcorr,
-            model_entry.modelfit_results.standard_errors_sdcorr,
-        ),
         final_model_dv_vs_ipred_plot=plots['dv_vs_ipred'],
         final_model_dv_vs_pred_plot=plots['dv_vs_pred'],
         final_model_cwres_vs_idv_plot=plots['cwres_vs_idv'],

--- a/src/pharmpy/tools/structsearch/report.rst
+++ b/src/pharmpy/tools/structsearch/report.rst
@@ -15,21 +15,27 @@ Final model
     :hide-code:
 
     from pharmpy.workflows.results import read_results
+    from pharmpy.tools.common import table_final_parameter_estimates
 
     res = read_results('results.json')
+    final_model_parameter_estimates = table_final_parameter_estimates(
+            res.final_model,
+            res.final_results.parameter_estimates_sdcorr,
+            res.final_results.standard_errors_sdcorr
+            )
 
 Parameter estimates
 
 .. jupyter-execute::
    :hide-code:
 
-   if res.final_model_parameter_estimates['RSE'].any():
-       results = res.final_model_parameter_estimates.style.format({
+   if final_model_parameter_estimates['RSE'].any():
+       results = final_model_parameter_estimates.style.format({
            'estimates': '{:,.4f}'.format,
            'RSE': '{:,.1%}'.format,
        })
    else:
-       results = res.final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
+       results = final_model_parameter_estimates['estimates'].to_frame(name='estimates').style.format({
            'estimates': '{:,.4f}'.format,
        })
 


### PR DESCRIPTION
- add `modelfit_results` to `results` object so that `modelfit_results` can be piped instead of parsed.
- remove `final_model_parameter_estimates` from `results`
- Fix model database/context issues in AMD