### PR TITLE
Disallow unsupported covariate effect types in MFL parsing

### DIFF
--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -15,7 +15,7 @@ from pharmpy.modeling.lrt import p_value as lrt_p_value
 from pharmpy.modeling.lrt import test as lrt_test
 from pharmpy.tools import is_strictness_fulfilled
 from pharmpy.tools.common import create_results, update_initial_estimates
-from pharmpy.tools.mfl.feature.covariate import EffectLiteral, all_covariate_effects
+from pharmpy.tools.mfl.feature.covariate import EffectLiteral
 from pharmpy.tools.mfl.feature.covariate import features as covariate_features
 from pharmpy.tools.mfl.feature.covariate import parse_spec, spec
 from pharmpy.tools.mfl.helpers import all_funcs
@@ -815,7 +815,7 @@ def validate_input(
         allowed_parameters = set(get_pk_parameters(model)).union(
             str(statement.symbol) for statement in model.statements.before_odes
         )
-        allowed_covariate_effects = set(all_covariate_effects)
+
         allowed_ops = set(['*', '+'])
 
         for effect in candidate_effects:
@@ -831,11 +831,10 @@ def validate_input(
                     f' search_space: got `{effect.parameter}`,'
                     f' must be in {sorted(allowed_parameters)}.'
                 )
-            if effect.fp not in allowed_covariate_effects:
+            if effect.fp == "custom":
                 raise ValueError(
                     f'Invalid `search_space` because of invalid effect function found in'
-                    f' search_space: got `{effect.fp}`,'
-                    f' must be in {sorted(allowed_covariate_effects)}.'
+                    f' search_space: `{effect.fp}` is not a supported type.'
                 )
             if effect.operation not in allowed_ops:
                 raise ValueError(

--- a/src/pharmpy/tools/mfl/grammar.py
+++ b/src/pharmpy/tools/mfl/grammar.py
@@ -34,7 +34,7 @@ elimination: "ELIMINATION"i "(" (_elimination_option) ")"
 peripherals: "PERIPHERALS"i "(" (_counts) ["," _peripheral_comp] ")"
 transits: "TRANSITS"i "(" _counts ["," _depot_option] ")"
 lagtime: "LAGTIME"i "(" (_lagtime_option) ")"
-covariate: "COVARIATE"i [optional_cov] "(" parameter_option "," covariate_option "," fp_option ["," op_option] ")"
+covariate: "COVARIATE"i [optional_cov] "(" parameter_option "," covariate_option "," (_fp_options) ["," op_option] ")"
 
 direct_effect: "DIRECTEFFECT"i "(" (_pdtype_option) ")"
 effect_comp: "EFFECTCOMP"i "(" (_pdtype_option) ")"
@@ -84,13 +84,15 @@ LAGTIME_MODE: "ON"i | "OFF"i
 
 parameter_option: values | ref | parameter_wildcard
 covariate_option: values | ref | covariate_wildcard
-fp_option: values | fp_wildcard
+_fp_options: fp_option | fp_wildcard
 !op_option: "+" | "*"
 optional_cov: OPTIONAL
 
 ref: "@" VARIABLE_NAME
 parameter_wildcard: WILDCARD
 covariate_wildcard: WILDCARD
+fp_option: FP_OP  | "[" [FP_OP ("," FP_OP)*] "]"
+FP_OP: "LIN"i | "CAT"i | "CAT2"i | "PIECE_LIN"i | "EXP"i | "POW"i | "CUSTOM"i
 fp_wildcard: WILDCARD
 
 WILDCARD: "*"

--- a/src/pharmpy/tools/mfl/statement/feature/covariate.py
+++ b/src/pharmpy/tools/mfl/statement/feature/covariate.py
@@ -110,7 +110,8 @@ class CovariateInterpreter(Interpreter):
         return self.option(tree)
 
     def fp_option(self, tree):
-        return self.option(tree)
+        children = self.visit_children(tree)
+        return list((child.value.upper()) for child in children)
 
     def optional_cov(self, tree):
         children = self.visit_children(tree)

--- a/tests/tools/test_covsearch.py
+++ b/tests/tools/test_covsearch.py
@@ -106,7 +106,7 @@ def test_validate_input_with_model(load_model_for_test, testdata, model_path):
         ),
         (
             ('nonmem', 'pheno.mod'),
-            dict(search_space='COVARIATE([CL, V], WGT, [EXP, ABC])'),
+            dict(search_space='COVARIATE([CL, V], WGT, [EXP, CUSTOM])'),
             ValueError,
             'Invalid `search_space` because of invalid effect function',
         ),

--- a/tests/tools/test_mfl.py
+++ b/tests/tools/test_mfl.py
@@ -566,16 +566,13 @@ def test_funcs_ivoral(source, expected):
 @pytest.mark.parametrize(
     ('code'),
     (
-        [
-            ('ABSORPTION(ILLEGAL)'),
-            ('ELIMINATION(ALSOILLEGAL)'),
-            ('LAGTIME(0)'),
-            ('TRANSITS(*)'),
-        ],
-        [
-            ('COVARIATE([V], WGT, *, +)'),
-            ('COVARIATE?(V, WGT, *, +)'),
-        ],
+        ('ABSORPTION(ILLEGAL)'),
+        ('ELIMINATION(ALSOILLEGAL)'),
+        ('LAGTIME(0)'),
+        ('TRANSITS(*)'),
+        ('COVARIATE([V], WGT, *, +)'),
+        ('COVARIATE?(V, WGT, *, -)'),
+        ('COVARIATE([CL, V], WGT, [EXP, ABC])'),
     ),
 )
 def test_illegal_mfl(code):


### PR DESCRIPTION
Raise error when parsing unknown covariate effects. As a placeholder for unsupported types, "CUSTOM" can be used to store an effect.