### PR TITLE
Update nlmixr fitting

### DIFF
--- a/src/pharmpy/tools/external/nlmixr/run.py
+++ b/src/pharmpy/tools/external/nlmixr/run.py
@@ -268,12 +268,9 @@ def verification(
     meta = path / '.pharmpy'
     meta.mkdir(parents=True, exist_ok=True)
     write_fix_eta(nonmem_res, path=path)
-    # try:
     # FIXME : use fit() instead and incorporate write_fix_eta
     nlmixr_model_entry = ModelEntry.create(nlmixr_model, modelfit_results=None)
     nlmixr_model_entry = execute_model(nlmixr_model_entry, db, path=path)
-    # except Exception:
-    #     raise Exception("nlmixr2 model could not be fitted")
 
     # Combine the two based on ID and time
     if not ignore_print:

--- a/src/pharmpy/tools/external/nlmixr/run.py
+++ b/src/pharmpy/tools/external/nlmixr/run.py
@@ -46,7 +46,7 @@ def execute_model(model_entry, context, evaluate=False, path=None):
     parent_model = model.parent_model
     model = convert_model(model)
     model = model.replace(parent_model=parent_model)
-
+    model_entry = ModelEntry.create(model=model, parent=model_entry.parent)
     database.store_model(model)
 
     model = model.replace(internals=model.internals.replace(path=path))

--- a/src/pharmpy/tools/run.py
+++ b/src/pharmpy/tools/run.py
@@ -213,6 +213,24 @@ def run_tool_with_name(
         except Exception as err:
             raise InputValidationError(str(err))
 
+    if (
+        "model" in tool_options
+        and "results" in tool_options
+        and "esttool" in common_options
+        and common_options["esttool"] != "dummy"
+    ):
+
+        model_type = str(type(tool_options["model"])).split(".")[-3]
+        results = tool_options["results"]
+        esttool = common_options["esttool"]
+        if results:
+            if esttool != model_type:
+                if not (esttool is None and model_type == "nonmeme"):
+                    warnings.warn(
+                        f"Not recommended to run tools with different estimation tool ({esttool})"
+                        f" than that of the input model ({model_type})"
+                    )
+
     wf: Workflow = create_workflow(*args, **tool_options)
     assert wf.name == name
 


### PR DESCRIPTION
- Warn the user when running tool with input model of a different type than that of the defined "esttool"
- Avoid storing model code of the input model type alongside nlmixr code when running a tool with nlmixr if the input model is of a different type