### PR TITLE
Store input/final model within each tool

### DIFF
--- a/src/pharmpy/tools/allometry/tool.py
+++ b/src/pharmpy/tools/allometry/tool.py
@@ -163,7 +163,10 @@ def validate_parameters(model: Model, parameters: Optional[Iterable[Union[str, E
             )
 
 
-def results(start_model_entry, allometry_model_entry):
+def results(context, start_model_entry, allometry_model_entry):
+    # Create links to input model
+    context.store_input_model_entry(start_model_entry)
+
     start_model = start_model_entry.model
     start_res = start_model_entry.modelfit_results
     allometry_model = allometry_model_entry.model
@@ -179,7 +182,7 @@ def results(start_model_entry, allometry_model_entry):
     sumcount = summarize_individuals_count_table(df=suminds)
     sumerrs = summarize_errors_from_entries([start_model_entry, allometry_model_entry])
 
-    return AllometryResults(
+    res = AllometryResults(
         summary_models=summods,
         summary_individuals=suminds,
         summary_individuals_count=sumcount,
@@ -187,6 +190,11 @@ def results(start_model_entry, allometry_model_entry):
         final_model=best_model,
         final_results=allometry_res,
     )
+
+    # Create links to final model
+    context.store_final_model_entry(res.final_model)
+
+    return res
 
 
 @dataclass(frozen=True)

--- a/src/pharmpy/tools/common.py
+++ b/src/pharmpy/tools/common.py
@@ -145,10 +145,6 @@ def create_results(
             final_results = me.modelfit_results
             break
 
-    # Create links to input model and final model
-    context.store_input_model_entry(input_model_entry)
-    context.store_final_model_entry(best_model)
-
     plots = create_plots(best_model, final_results)
 
     # FIXME: Remove best_model, input_model, models when there is function to read db

--- a/src/pharmpy/tools/covsearch/tool.py
+++ b/src/pharmpy/tools/covsearch/tool.py
@@ -179,7 +179,9 @@ def create_workflow(
     wb = WorkflowBuilder(name=NAME_WF)
 
     # FIXME : Handle when model is None
-    start_task = Task("create_modelentry", _start, model, results, max_eval)
+    store_task = Task("store_input_model", _store_input_model, model, results, max_eval)
+    start_task = Task("create_modelentry", _start, model, results)
+    wb.add_task(start_task, predecessors=store_task)
     init_task = Task("init", _init_search_state, search_space)
     wb.add_task(init_task, predecessors=start_task)
 
@@ -222,7 +224,14 @@ def create_workflow(
     return Workflow(wb)
 
 
+def _store_input_model(context, model, results, max_eval):
+    # Create links to input model
+    context.store_input_model_entry(ModelEntry.create(model=model, modelfit_results=results))
+    return max_eval
+
+
 def _start(model, results, max_eval):
+
     if max_eval:
         max_eval_number = round(3.1 * results.function_evaluations_iterations.loc[1])
         # Change last instead of first?
@@ -768,6 +777,7 @@ def task_results(context, p_forward: float, p_backward: float, strictness: str, 
         summary_models=_summarize_models(modelentries, steps),
     )
 
+    # Create links to final model
     context.store_final_model_entry(best_modelentry)
 
     return res

--- a/src/pharmpy/tools/iivsearch/tool.py
+++ b/src/pharmpy/tools/iivsearch/tool.py
@@ -188,6 +188,8 @@ def start(
     strictness,
 ):
     input_model_entry = ModelEntry.create(input_model, modelfit_results=input_res)
+    # Create links to input model
+    context.store_input_model_entry(input_model_entry)
 
     if iiv_strategy != 'no_add':
         base_model = update_initial_estimates(input_model, modelfit_results=input_res)
@@ -370,7 +372,7 @@ def start(
 
     plots = create_plots(final_final_model, final_results)
 
-    return IIVSearchResults(
+    final_results = IIVSearchResults(
         summary_tool=_concat_summaries(sum_tools, keys),
         summary_models=_concat_summaries(sum_models, [0] + keys),  # To include input model
         summary_individuals=_concat_summaries(sum_inds, keys),
@@ -385,6 +387,11 @@ def start(
         final_model_eta_distribution_plot=plots['eta_distribution'],
         final_model_eta_shrinkage=table_final_eta_shrinkage(final_final_model, final_results),
     )
+
+    # Create links to final model
+    context.store_final_model_entry(res.final_model)
+
+    return final_results
 
 
 def _concat_summaries(summaries, keys):

--- a/src/pharmpy/tools/iovsearch/tool.py
+++ b/src/pharmpy/tools/iovsearch/tool.py
@@ -132,6 +132,9 @@ def task_brute_force_search(
     distribution: str,
     input_model_entry: ModelEntry,
 ):
+    # Create links to input model
+    context.store_input_model_entry(input_model_entry)
+
     input_model, input_res = input_model_entry.model, input_model_entry.modelfit_results
     # NOTE: Default is to try all IIV ETAs.
     if list_of_parameters is None:
@@ -333,6 +336,9 @@ def task_results(context, rank_type, cutoff, bic_type, strictness, step_mapping_
 
     # NOTE: This overwrites the default summary_tool field
     res = replace(res, summary_tool=pd.concat(sum_tool, keys=keys, names=['step']))
+
+    # Create links to final model
+    context.store_final_model_entry(res.final_model)
 
     return res
 

--- a/src/pharmpy/tools/linearize/tool.py
+++ b/src/pharmpy/tools/linearize/tool.py
@@ -64,8 +64,13 @@ def create_workflow(
     return Workflow(wb)
 
 
-def start_linearize(model):
-    return ModelEntry.create(model=model)
+def start_linearize(context, model):
+    start_model_entry = ModelEntry.create(model=model)
+
+    # Create links to input model
+    context.store_input_model_entry(start_model_entry)
+
+    return start_model_entry
 
 
 def postprocess(context, model_name, *modelentries):
@@ -80,6 +85,9 @@ def postprocess(context, model_name, *modelentries):
     )
 
     res.to_csv(context.path / "results.csv")
+
+    # Create links to final model
+    context.store_final_model_entry(res.final_model)
 
     return res
 

--- a/src/pharmpy/tools/modelsearch/tool.py
+++ b/src/pharmpy/tools/modelsearch/tool.py
@@ -95,6 +95,9 @@ def start(
     model,
     strictness,
 ):
+    # Create links to input model
+    context.store_input_model_entry(ModelEntry.create(model=model, modelfit_results=results))
+
     wb = WorkflowBuilder()
 
     start_task = Task('start_modelsearch', _start, model, results)
@@ -155,6 +158,9 @@ def start(
             wb.add_task(task_result, predecessors=[start_task] + candidate_model_tasks)
 
     res = call_workflow(wb, 'run_candidate_models', context)
+
+    # Create links to input model and final model
+    context.store_final_model_entry(res.final_model)
 
     return res
 

--- a/src/pharmpy/tools/retries/tool.py
+++ b/src/pharmpy/tools/retries/tool.py
@@ -112,9 +112,13 @@ def create_workflow(
     return Workflow(wb)
 
 
-def _start(results, model):
-    # Convert to modelentry
-    return ModelEntry.create(model=model, modelfit_results=results)
+def _start(context, results, model):
+    start_model_entry = ModelEntry.create(model=model, modelfit_results=results)
+
+    # Create links to input model
+    context.store_input_model_entry(start_model_entry)
+
+    return start_model_entry
 
 
 def create_random_init_model(
@@ -238,6 +242,9 @@ def task_results(context, strictness, retries):
         res,
         summary_tool=_modify_summary_tool(res.summary_tool, retry_runs),
     )
+
+    # Create links to final model
+    context.store_final_model_entry(res.final_model)
 
     return res
 

--- a/src/pharmpy/tools/ruvsearch/tool.py
+++ b/src/pharmpy/tools/ruvsearch/tool.py
@@ -191,6 +191,9 @@ def start(context, input_model, input_res, groups, p_value, skip, max_iter, dv, 
         skip = []
 
     input_model_entry = ModelEntry.create(input_model, modelfit_results=input_res)
+    # Create links to input model
+    context.store_input_model_entry(input_model_entry)
+
     # Check if model has a proportional error
     proportional_workflow = proportional_error_workflow(input_model_entry)
     model_entry = call_workflow(proportional_workflow, 'Convert_error_model', context)
@@ -239,8 +242,6 @@ def start(context, input_model, input_res, groups, p_value, skip, max_iter, dv, 
 
     plots = create_plots(model_entry.model, model_entry.modelfit_results)
 
-    context.store_input_model_entry(input_model_entry)
-
     res = RUVSearchResults(
         cwres_models=pd.concat(cwres_models),
         summary_individuals=sumind,
@@ -259,6 +260,10 @@ def start(context, input_model, input_res, groups, p_value, skip, max_iter, dv, 
             model_entry.model, model_entry.modelfit_results
         ),
     )
+
+    # Create links to final model
+    context.store_final_model_entry(res.final_model)
+
     return res
 
 


### PR DESCRIPTION
When storing the input and final model within `create_results`, sometimes the wrong model was stored (as some of the tools manipulate the final model, for instance covsearch). Now, each tool stores the input model and final model themselves.