### PR TITLE
More detailed checks of `keep`-option in IIVSearch 

### DIFF
--- a/src/pharmpy/tools/iivsearch/tool.py
+++ b/src/pharmpy/tools/iivsearch/tool.py
@@ -718,10 +718,10 @@ def validate_input(
 ):
     if keep and model:
         for parameter in keep:
-            try:
-                has_random_effect(model, parameter, "iiv")
-            except KeyError:
-                warnings.warn(f"Parameter {parameter} has no iiv and is ignored")
+            if parameter not in map(lambda x: str(x), model.statements.free_symbols):
+                raise ValueError(f'Symbol `{parameter}` does not exist in input model')
+            if not has_random_effect(model, parameter, "iiv"):
+                warnings.warn(f"Parameter `{parameter}` has no iiv and is ignored")
 
     if strictness is not None and "rse" in strictness.lower():
         if model.execution_steps[-1].parameter_uncertainty_method is None:

--- a/tests/tools/test_iivsearch.py
+++ b/tests/tools/test_iivsearch.py
@@ -640,6 +640,12 @@ def test_validate_input_with_model(load_model_for_test, testdata):
             ValueError,
             'Value `E_q` must be denoted with `%`',
         ),
+        (
+            ('nonmem', 'pheno.mod'),
+            {'keep': ('X',)},
+            ValueError,
+            'Symbol `X` does not exist in input model',
+        ),
     ],
 )
 def test_validate_input_raises(
@@ -668,7 +674,7 @@ def test_validate_input_raises(
 
 @pytest.mark.parametrize(
     ('model_path', 'arguments', 'warning', 'match'),
-    [(["nonmem", "pheno.mod"], dict(keep=["NONEXISTENT"]), UserWarning, 'Parameter')],
+    [(["nonmem", "pheno.mod"], dict(keep=["CL"]), UserWarning, 'Parameter')],
 )
 def test_validate_input_warn(
     load_model_for_test,
@@ -683,6 +689,7 @@ def test_validate_input_warn(
     path = testdata.joinpath(*model_path)
     model = load_model_for_test(path)
     results = read_modelfit_results(path)
+    model = remove_iiv(model, 'CL')
 
     harmless_arguments = dict(
         algorithm='top_down_exhaustive',


### PR DESCRIPTION
Raise in IIVSearch if parameter in keep-option does not exist, warn if no IIV exists.