### PR TITLE
fix: Add Windows support for Rscript executable in get_rpath function

### DIFF
--- a/src/pharmpy/tools/external/nlmixr/run.py
+++ b/src/pharmpy/tools/external/nlmixr/run.py
@@ -156,7 +156,7 @@ def get_rpath():
     # Windows
     if os.name == 'nt':
         r_candidate = "Rscript.exe"
-    
+
     default_path = conf.rpath
     if default_path != Path(''):
         path = default_path / 'bin' / r_candidate

--- a/src/pharmpy/tools/external/nlmixr/run.py
+++ b/src/pharmpy/tools/external/nlmixr/run.py
@@ -153,7 +153,10 @@ def get_rpath():
     from pharmpy.tools.external.nlmixr import conf
 
     r_candidate = "Rscript"
-
+    # Windows
+    if os.name == 'nt':
+        r_candidate = "Rscript.exe"
+    
     default_path = conf.rpath
     if default_path != Path(''):
         path = default_path / 'bin' / r_candidate


### PR DESCRIPTION
This pull request addresses an issue where the script was failing to locate the Rscript executable on Windows. On Windows, the executable is named Rscript.exe, but the script was checking for Rscript, which caused path.is_file() to return False.