### PR TITLE
Avoid parsing the same model multiple times in tests

### DIFF
--- a/tests/modeling/test_error.py
+++ b/tests/modeling/test_error.py
@@ -10,7 +10,6 @@ from pharmpy.modeling import (
     has_combined_error_model,
     has_proportional_error_model,
     has_weighted_error_model,
-    read_model,
     read_model_from_string,
     remove_error_model,
     set_additive_error_model,
@@ -415,8 +414,8 @@ $ESTIMATION METHOD=1 INTER MAXEVALS=9990 PRINT=2 POSTHOC
     assert has_proportional_error_model(model, 2)
 
 
-def test_has_proportional_error_model_zero_protection(testdata):
-    model = read_model(testdata / 'nonmem' / 'pheno.mod')
+def test_has_proportional_error_model_zero_protection(testdata, load_model_for_test):
+    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
     assert has_proportional_error_model(model)
     model = remove_error_model(model)
     model = set_proportional_error_model(model, zero_protection=True)

--- a/tests/modeling/test_evaluate.py
+++ b/tests/modeling/test_evaluate.py
@@ -13,7 +13,7 @@ from pharmpy.modeling import (
     evaluate_population_prediction,
     evaluate_weighted_residuals,
 )
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 
 tabpath = Path(__file__).resolve().parent.parent / 'testdata' / 'nonmem' / 'pheno_real_linbase.tab'
 lincorrect = read_nonmem_dataset(
@@ -24,8 +24,9 @@ lincorrect = read_nonmem_dataset(
 
 
 def test_evaluate_expression(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'pheno_noifs.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'pheno_noifs.mod')
+    path = testdata / 'nonmem' / 'models' / 'pheno_noifs.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     ser = evaluate_expression(model, 'TVV', res.parameter_estimates)
     assert ser[0] == pytest.approx(1.413062)
     assert ser[743] == pytest.approx(1.110262)
@@ -58,7 +59,7 @@ def test_evaluate_individual_prediction(load_model_for_test, testdata):
 
     linpath = testdata / 'nonmem' / 'pheno_real_linbase.mod'
     linmod = load_model_for_test(linpath)
-    res = read_modelfit_results(linpath)
+    res = parse_modelfit_results(linmod, linpath)
     pred = evaluate_individual_prediction(model=linmod, etas=res.individual_estimates)
 
     pd.testing.assert_series_equal(lincorrect['CIPREDI'], pred, rtol=1e-4, check_names=False)
@@ -89,7 +90,7 @@ def test_evaluate_epsilon_gradient(load_model_for_test, testdata):
 
     linpath = testdata / 'nonmem' / 'pheno_real_linbase.mod'
     linmod = load_model_for_test(linpath)
-    res = read_modelfit_results(linpath)
+    res = parse_modelfit_results(linmod, linpath)
     grad = evaluate_epsilon_gradient(linmod, etas=res.individual_estimates)
     pd.testing.assert_series_equal(lincorrect['H11'], grad.iloc[:, 0], rtol=1e-4, check_names=False)
 
@@ -97,6 +98,6 @@ def test_evaluate_epsilon_gradient(load_model_for_test, testdata):
 def test_evaluate_weighted_residuals(load_model_for_test, testdata):
     linpath = testdata / 'nonmem' / 'pheno_real_linbase.mod'
     linmod = load_model_for_test(linpath)
-    res = read_modelfit_results(linpath)
+    res = parse_modelfit_results(linmod, linpath)
     wres = evaluate_weighted_residuals(linmod, parameters=dict(res.parameter_estimates))
     pd.testing.assert_series_equal(lincorrect['WRES'], wres, rtol=1e-4, check_names=False)

--- a/tests/modeling/test_parameter_sampling.py
+++ b/tests/modeling/test_parameter_sampling.py
@@ -8,7 +8,7 @@ from pharmpy.modeling import (
     sample_parameters_from_covariance_matrix,
     sample_parameters_uniformly,
 )
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 
 
 def test_create_rng():
@@ -20,16 +20,18 @@ def test_create_rng():
 
 
 def test_sample_parameters_uniformly(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     rng = create_rng(23)
     df = sample_parameters_uniformly(model, res.parameter_estimates, n=3, seed=rng)
     assert df['PTVCL'][0] == 0.004877674495376137
 
 
 def test_sample_parameter_from_covariance_matrix(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     rng = np.random.default_rng(318)
     pe = res.parameter_estimates
     cm = res.covariance_matrix
@@ -65,8 +67,9 @@ def test_sample_parameter_from_covariance_matrix(load_model_for_test, testdata):
 
 
 def test_sample_individual_estimates(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     rng = np.random.default_rng(86)
     ie = res.individual_estimates
     iec = res.individual_estimates_covariance

--- a/tests/modeling/test_parameter_variability.py
+++ b/tests/modeling/test_parameter_variability.py
@@ -38,7 +38,7 @@ from pharmpy.modeling.parameter_variability import (
     _transform_etas,
     get_occasion_levels,
 )
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 
 
 def S(x):
@@ -1746,7 +1746,7 @@ def test_create_joint_distribution_incorrect_params(
 
 def test_create_joint_distribution_choose_param_init(load_model_for_test, pheno_path):
     model = load_model_for_test(pheno_path)
-    res = read_modelfit_results(pheno_path)
+    res = parse_modelfit_results(model, pheno_path)
     params = (model.parameters['IVCL'], model.parameters['IVV'])
     rvs = model.random_variables.etas
     init = _choose_cov_param_init(model, res.individual_estimates, rvs, *params)
@@ -1859,7 +1859,7 @@ def test_update_initial_individual_estimates(
             f.write(etas_file)
 
         model = load_model_for_test('run1.mod')
-        res = read_modelfit_results('run1.mod')
+        res = parse_modelfit_results(model, 'run1.mod')
         model = update_initial_individual_estimates(model, res.individual_estimates, force=force)
         model = model.write_files()
 
@@ -1869,7 +1869,7 @@ def test_update_initial_individual_estimates(
 
 def test_nested_iiv_transformations(load_model_for_test, pheno_path):
     model = load_model_for_test(pheno_path)
-    res = read_modelfit_results(pheno_path)
+    res = parse_modelfit_results(model, pheno_path)
 
     model = create_joint_distribution(model, individual_estimates=res.individual_estimates)
 

--- a/tests/modeling/test_parameters.py
+++ b/tests/modeling/test_parameters.py
@@ -26,7 +26,7 @@ from pharmpy.modeling import (
     unfix_parameters,
     unfix_parameters_to,
 )
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 
 
 def test_get_thetas(pheno):
@@ -158,7 +158,7 @@ def test_add_population_parameter(load_model_for_test, testdata):
 
 def test_set_initial_estimates_move_est(load_model_for_test, pheno_path):
     model = load_model_for_test(pheno_path)
-    res = read_modelfit_results(pheno_path)
+    res = parse_modelfit_results(model, pheno_path)
 
     model = create_joint_distribution(model, individual_estimates=res.individual_estimates)
     model = add_iiv(model, 'S1', 'add')
@@ -204,9 +204,9 @@ def test_set_initial_estimates_move_est(load_model_for_test, pheno_path):
 
 def test_set_initial_estimates_zero_fix(load_model_for_test, pheno_path):
     model = load_model_for_test(pheno_path)
+    res = parse_modelfit_results(model, pheno_path)
     d = {name: 0 for name in model.random_variables.iiv.parameter_names}
     model = fix_parameters_to(model, d)
-    res = read_modelfit_results(pheno_path)
     param_est = res.parameter_estimates.drop(index=['IVCL'])
     model = set_initial_estimates(model, param_est)
     assert model.parameters['IVCL'].init == 0
@@ -230,7 +230,7 @@ def test_set_initial_estimates_no_res(load_model_for_test, testdata, tmp_path):
         shutil.copy(testdata / 'nonmem/pheno.lst', tmp_path / 'run1.lst')
 
         model = load_model_for_test('run1.mod')
-        res = read_modelfit_results('run1.mod')
+        res = parse_modelfit_results(model, 'run1.mod')
 
         modelfit_results = replace(
             res,
@@ -245,7 +245,7 @@ def test_set_initial_estimates_no_res(load_model_for_test, testdata, tmp_path):
 
 def test_set_initial_estimates_subset_parameters_w_correlation(load_model_for_test, pheno_path):
     model = load_model_for_test(pheno_path)
-    res = read_modelfit_results(pheno_path)
+    res = parse_modelfit_results(model, pheno_path)
 
     model = create_joint_distribution(model, individual_estimates=res.individual_estimates)
     model = add_iiv(model, 'S1', 'add')

--- a/tests/modeling/test_plots.py
+++ b/tests/modeling/test_plots.py
@@ -12,18 +12,21 @@ from pharmpy.modeling import (
     plot_transformed_eta_distributions,
     plot_vpc,
 )
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 
 
-def test_plot_iofv_vs_iofv(testdata):
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+def test_plot_iofv_vs_iofv(load_model_for_test, testdata):
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     iofv = res.individual_ofv
     assert plot_iofv_vs_iofv(iofv, iofv, "run1", "run1")
 
 
 def test_plot_individual_predictions(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     plot = plot_individual_predictions(model, res.predictions)
     assert plot
     plot = plot_individual_predictions(model, res.predictions[['PRED']], individuals=[1, 2, 5])
@@ -31,8 +34,9 @@ def test_plot_individual_predictions(load_model_for_test, testdata):
 
 
 def test_plot_transformed_eta_distributions(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'qa' / 'boxcox.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'boxcox.mod')
+    path = testdata / 'nonmem' / 'qa' / 'boxcox.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     pe = res.parameter_estimates
     ie = res.individual_estimates
     plot = plot_transformed_eta_distributions(model, pe, ie, pe)
@@ -40,9 +44,10 @@ def test_plot_transformed_eta_distributions(load_model_for_test, testdata):
 
 
 def test_plot_eta_distributions(tmp_path, load_model_for_test, testdata):
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     with chdir(tmp_path):
-        model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-        res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
         ie = res.individual_estimates
         plot = plot_eta_distributions(model, ie)
         plot.save('Plot.html')
@@ -50,16 +55,18 @@ def test_plot_eta_distributions(tmp_path, load_model_for_test, testdata):
 
 
 def test_plot_dv_vs_ipred(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     plot = plot_dv_vs_ipred(model, res.predictions)
     assert plot
 
 
 def test_plot_dv_vs_ipred_stratify(tmp_path, load_model_for_test, testdata):
+    path = testdata / 'nonmem' / 'pheno_pd.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     with chdir(tmp_path):
-        model = load_model_for_test(testdata / 'nonmem' / 'pheno_pd.mod')
-        res = read_modelfit_results(testdata / 'nonmem' / 'pheno_pd.mod')
         plot = plot_dv_vs_ipred(model, res.predictions, stratify_on='DVID')
         plot.save('chart.html')
         assert plot
@@ -68,15 +75,17 @@ def test_plot_dv_vs_ipred_stratify(tmp_path, load_model_for_test, testdata):
 
 
 def test_plot_dv_vs_pred(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     plot = plot_dv_vs_pred(model, res.predictions)
     assert plot
 
 
 def test_plot_cwres_vs_idv(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     plot = plot_cwres_vs_idv(model, res.residuals, 'WGT', bins=4)
     assert plot
     with pytest.raises(ValueError, match='DVoID column does not exist in dataset.'):
@@ -84,10 +93,10 @@ def test_plot_cwres_vs_idv(load_model_for_test, testdata):
 
 
 def test_plot_abs_cwres_vs_ipred(tmp_path, load_model_for_test, testdata):
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     with chdir(tmp_path):
-        model = load_model_for_test(testdata / 'nonmem' / 'pheno_pd.mod')
-        model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-        res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
         plot = plot_abs_cwres_vs_ipred(model, res.predictions, res.residuals, 'WGT', bins=4)
         plot.save('plot.html')
         assert plot

--- a/tests/modeling/test_results.py
+++ b/tests/modeling/test_results.py
@@ -15,12 +15,14 @@ from pharmpy.modeling import (
     insert_ebes_into_dataset,
     set_iiv_on_ruv,
 )
-from pharmpy.tools import load_example_modelfit_results, read_modelfit_results
+from pharmpy.tools import load_example_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 
 
 def test_calculate_eta_shrinkage(load_model_for_test, testdata):
-    pheno = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    pheno = load_model_for_test(path)
+    res = parse_modelfit_results(pheno, path)
     pe = res.parameter_estimates
     ie = res.individual_estimates
     shrinkage = calculate_eta_shrinkage(pheno, pe, ie)
@@ -34,8 +36,9 @@ def test_calculate_eta_shrinkage(load_model_for_test, testdata):
 
 
 def test_calculate_individual_shrinkage(load_model_for_test, testdata):
-    pheno = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    pheno = load_model_for_test(path)
+    res = parse_modelfit_results(pheno, path)
     ishr = calculate_individual_shrinkage(
         pheno,
         res.parameter_estimates,
@@ -46,8 +49,9 @@ def test_calculate_individual_shrinkage(load_model_for_test, testdata):
 
 
 def test_calculate_individual_parameter_statistics(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'secondary_parameters' / 'pheno.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'secondary_parameters' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'secondary_parameters' / 'pheno.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     rng = np.random.default_rng(103)
     stats = calculate_individual_parameter_statistics(
         model,
@@ -61,8 +65,9 @@ def test_calculate_individual_parameter_statistics(load_model_for_test, testdata
     assert stats['variance'].iloc[0] == pytest.approx(8.086653508585209e-06)
     assert stats['stderr'].iloc[0] == pytest.approx(0.0030651020151471024, abs=1e-6)
 
-    model = load_model_for_test(testdata / 'nonmem' / 'secondary_parameters' / 'run1.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'secondary_parameters' / 'run1.mod')
+    path = testdata / 'nonmem' / 'secondary_parameters' / 'run1.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     rng = np.random.default_rng(5678)
     stats = calculate_individual_parameter_statistics(
         model,
@@ -75,8 +80,9 @@ def test_calculate_individual_parameter_statistics(load_model_for_test, testdata
     assert stats['variance'].iloc[0] == pytest.approx(7.391076132098555e-07)
     assert stats['stderr'].iloc[0] == pytest.approx(0.0009254064127724053, abs=1e-6)
 
-    covmodel = load_model_for_test(testdata / 'nonmem' / 'secondary_parameters' / 'run2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'secondary_parameters' / 'run2.mod')
+    path = testdata / 'nonmem' / 'secondary_parameters' / 'run2.mod'
+    covmodel = load_model_for_test(path)
+    res = parse_modelfit_results(covmodel, path)
     rng = np.random.default_rng(8976)
     stats = calculate_individual_parameter_statistics(
         covmodel,
@@ -97,8 +103,9 @@ def test_calculate_individual_parameter_statistics(load_model_for_test, testdata
 
 
 def test_calculate_pk_parameters_statistics(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox1.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox1.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox1.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     rng = np.random.default_rng(103)
     df = calculate_pk_parameters_statistics(
         model,
@@ -117,8 +124,9 @@ def test_calculate_pk_parameters_statistics(load_model_for_test, testdata):
 def test_calc_pk_two_comp_bolus(load_model_for_test, testdata):
     # Warning: These results are based on a manually modified cov-matrix
     # Results are not verified
-    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox_2comp.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox_2comp.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox_2comp.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     rng = np.random.default_rng(103)
     df = calculate_pk_parameters_statistics(
         model,
@@ -143,14 +151,16 @@ k_e,median,13.319584,2.67527,2.633615
 
 
 def test_aic(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     assert calculate_aic(model, res.ofv) == 740.8947268137307
 
 
 def test_bic(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     ofv = res.ofv
     assert calculate_bic(model, ofv, type='iiv') == 739.0498017015422
     assert calculate_bic(model, ofv, type='fixed') == 756.111852398327
@@ -165,8 +175,9 @@ def test_bic(load_model_for_test, testdata):
 
 def test_check_parameters_near_bounds(load_model_for_test, testdata):
     onePROB = testdata / 'nonmem' / 'modelfit_results' / 'onePROB'
-    nearbound = load_model_for_test(onePROB / 'oneEST' / 'noSIM' / 'near_bounds.mod')
-    res = read_modelfit_results(onePROB / 'oneEST' / 'noSIM' / 'near_bounds.mod')
+    path = onePROB / 'oneEST' / 'noSIM' / 'near_bounds.mod'
+    nearbound = load_model_for_test(path)
+    res = parse_modelfit_results(nearbound, path)
     correct = pd.Series(
         [False, True, False, False, False, False, False, False, True, True, False],
         index=[

--- a/tests/nonmem/output/test_nonmem_results_file.py
+++ b/tests/nonmem/output/test_nonmem_results_file.py
@@ -5,7 +5,7 @@ from numpy import nan
 
 import pharmpy.model.external.nonmem.table as table
 import pharmpy.tools.external.nonmem.results_file as rf
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.workflows.log import Log
 
 
@@ -435,10 +435,10 @@ def test_warnings(testdata, file_name, ref, idx):
     assert message == ref
 
 
-def test_covariance_status(testdata):
-    res = read_modelfit_results(
-        testdata / 'nonmem' / 'modelfit_results' / 'covariance' / 'pheno_nocovariance.mod'
-    )
+def test_covariance_status(load_model_for_test, testdata):
+    path = testdata / 'nonmem' / 'modelfit_results' / 'covariance' / 'pheno_nocovariance.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     assert all(res.standard_errors.isna())
     assert res.covariance_matrix is None
     assert res.correlation_matrix is None

--- a/tests/nonmem/test_fcon.py
+++ b/tests/nonmem/test_fcon.py
@@ -1,8 +1,5 @@
-from pharmpy.modeling import read_model
-
-
 def test_dataset(load_model_for_test, testdata):
-    model = read_model(testdata / 'nonmem' / 'fcon' / 'FCON')
+    model = load_model_for_test(testdata / 'nonmem' / 'fcon' / 'FCON')
     assert model.internals.code.startswith('FILE')
 
     df = model.dataset

--- a/tests/nonmem/test_modelfit_results.py
+++ b/tests/nonmem/test_modelfit_results.py
@@ -7,57 +7,77 @@ from pharmpy.deps import numpy as np
 from pharmpy.deps import pandas as pd
 from pharmpy.internals.fs.cwd import chdir
 from pharmpy.model import Parameter, Parameters
-from pharmpy.modeling import read_model
 from pharmpy.tools import read_modelfit_results
 from pharmpy.tools.external.nonmem.results import parse_modelfit_results, simfit_results
 from pharmpy.workflows.results import read_results
 
 
-def test_ofv(pheno_path):
-    res = read_modelfit_results(pheno_path)
+def test_ofv(pheno, pheno_path):
+    res = parse_modelfit_results(pheno, pheno_path)
     assert res.ofv == 586.27605628188053
 
 
 def test_failed_ofv(testdata, load_model_for_test):
-    res = read_modelfit_results(testdata / 'nonmem' / 'errors' / 'failed_run.mod')
+    path = testdata / 'nonmem' / 'errors' / 'failed_run.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     assert np.isnan(res.ofv)
     assert res.parameter_estimates.isnull().all()
 
-    res = read_modelfit_results(testdata / 'nonmem' / 'errors' / 'run_interrupted.mod')
+    path = testdata / 'nonmem' / 'errors' / 'run_interrupted.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     assert np.isnan(res.ofv)
     assert res.parameter_estimates.isnull().all()
 
 
-def test_special_models(testdata, load_model_for_test):
+def test_special_models_bayes(testdata, load_model_for_test):
     onePROB = testdata / 'nonmem' / 'modelfit_results' / 'onePROB'
-    res = read_modelfit_results(onePROB / 'multEST' / 'noSIM' / 'withBayes.mod')
+    path = onePROB / 'multEST' / 'noSIM' / 'withBayes.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     assert pytest.approx(res.standard_errors['POP_CL'], 1e-13) == 2.51942e00
     succ1 = res.minimization_successful_iterations.iloc[0]
     succ2 = res.minimization_successful_iterations.iloc[1]
     assert succ1 is not None and not succ1
     assert succ2 is not None and not succ2
 
-    res = read_modelfit_results(onePROB / 'oneEST' / 'noSIM' / 'maxeval0.mod')
+
+def test_special_models_eval0(testdata, load_model_for_test):
+    onePROB = testdata / 'nonmem' / 'modelfit_results' / 'onePROB'
+    path = onePROB / 'oneEST' / 'noSIM' / 'maxeval0.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     assert res.minimization_successful is None
 
-    res = read_modelfit_results(onePROB / 'oneEST' / 'noSIM' / 'maxeval3.mod')
+
+def test_special_models_eval3(testdata, load_model_for_test):
+    onePROB = testdata / 'nonmem' / 'modelfit_results' / 'onePROB'
+    path = onePROB / 'oneEST' / 'noSIM' / 'maxeval3.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     assert res.minimization_successful is False
 
 
-def test_covariance(pheno_path, testdata):
-    res = read_modelfit_results(pheno_path)
+def test_covariance_pheno(pheno_path, pheno):
+    res = parse_modelfit_results(pheno, pheno_path)
     cov = res.covariance_matrix
     assert len(cov) == 6
     assert pytest.approx(cov.loc['PTVCL', 'PTVCL'], 1e-13) == 4.41151e-08
     assert pytest.approx(cov.loc['IVV', 'PTVV'], 1e-13) == 7.17184e-05
 
-    res = read_modelfit_results(testdata / 'nonmem/models/pheno5.mod')
+
+def test_covariance_pheno5(testdata, load_model_for_test):
+    path = testdata / 'nonmem' / 'models' / 'pheno5.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     assert res.covstep_successful is True
 
 
-def test_gradients(testdata):
-    model = read_model(testdata / 'nonmem/pheno.mod')
-    res = read_modelfit_results(testdata / 'nonmem/pheno.mod')
+def test_gradients(testdata, load_model_for_test):
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     gradients = res.gradients
     gradients_iterations = res.gradients_iterations
     assert len(gradients) == 5
@@ -78,24 +98,24 @@ def test_gradients(testdata):
     assert res.gradients_iterations.columns.to_list()[1::] == params_before
 
 
-def test_information(pheno_path):
-    res = read_modelfit_results(pheno_path)
+def test_information(pheno, pheno_path):
+    res = parse_modelfit_results(pheno, pheno_path)
     m = res.precision_matrix
     assert len(m) == 6
     assert pytest.approx(m.loc['PTVCL', 'PTVCL'], 1e-13) == 2.99556e07
     assert pytest.approx(m.loc['IVV', 'PTVV'], 1e-13) == -2.80082e03
 
 
-def test_correlation(pheno_path):
-    res = read_modelfit_results(pheno_path)
+def test_correlation(pheno, pheno_path):
+    res = parse_modelfit_results(pheno, pheno_path)
     corr = res.correlation_matrix
     assert len(corr) == 6
     assert corr.loc['PTVCL', 'PTVV'] == 0.00709865
     assert pytest.approx(corr.loc['IVV', 'PTVV'], 1e-13) == 3.56662e-01
 
 
-def test_standard_errors(pheno_path):
-    res = read_modelfit_results(pheno_path)
+def test_standard_errors(pheno, pheno_path):
+    res = parse_modelfit_results(pheno, pheno_path)
     ses = res.standard_errors
     assert len(ses) == 6
     assert pytest.approx(ses['PTVCL'], 1e-13) == 2.10036e-04
@@ -115,16 +135,16 @@ def test_standard_errors(pheno_path):
     pd.testing.assert_series_equal(ses_sd, correct)
 
 
-def test_individual_ofv(pheno_path):
-    res = read_modelfit_results(pheno_path)
+def test_individual_ofv(pheno, pheno_path):
+    res = parse_modelfit_results(pheno, pheno_path)
     iofv = res.individual_ofv
     assert len(iofv) == 59
     assert pytest.approx(iofv[1], 1e-15) == 5.9473520242962552
     assert pytest.approx(iofv[57], 1e-15) == 5.6639479151436394
 
 
-def test_individual_estimates_basic(pheno_path):
-    res = read_modelfit_results(pheno_path)
+def test_individual_estimates_basic(pheno, pheno_path):
+    res = parse_modelfit_results(pheno, pheno_path)
     ie = res.individual_estimates
     assert len(ie) == 59
     assert pytest.approx(ie['ETA_1'][1], 1e-15) == -0.0438608
@@ -133,8 +153,8 @@ def test_individual_estimates_basic(pheno_path):
     assert pytest.approx(ie['ETA_2'][28], 1e-15) == 8.32311e-02
 
 
-def test_individual_estimates_covariance(pheno_path):
-    res = read_modelfit_results(pheno_path)
+def test_individual_estimates_covariance(pheno, pheno_path):
+    res = parse_modelfit_results(pheno, pheno_path)
     cov = res.individual_estimates_covariance
     assert len(cov) == 59
     names = ['ETA_1', 'ETA_2']
@@ -148,8 +168,8 @@ def test_individual_estimates_covariance(pheno_path):
     pd.testing.assert_frame_equal(cov[43], correct2)
 
 
-def test_parameter_estimates(pheno_path):
-    res = read_modelfit_results(pheno_path)
+def test_parameter_estimates(pheno, pheno_path):
+    res = parse_modelfit_results(pheno, pheno_path)
     pe = res.parameter_estimates
     assert len(pe) == 6
     assert pe['PTVCL'] == 4.69555e-3
@@ -158,7 +178,7 @@ def test_parameter_estimates(pheno_path):
 
 def test_parameter_estimates_ext_missing_fix(load_model_for_test, pheno_path, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'errors' / 'run_interrupted.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'errors' / 'run_interrupted.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'errors' / 'run_interrupted.mod')
     assert len(res.parameter_estimates.index.values) == len(model.parameters)
 
 
@@ -171,8 +191,10 @@ def test_simfit(testdata, load_model_for_test):
     assert results[2].ofv == 570.73440114145342
 
 
-def test_residuals(testdata):
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+def test_residuals(testdata, load_model_for_test):
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     df = res.residuals
     assert len(df) == 155
     assert list(df.columns) == ['RES', 'CWRES']
@@ -180,16 +202,21 @@ def test_residuals(testdata):
     assert df.loc[1, 'CWRES'] == -0.401100
 
 
-def test_predictions(testdata):
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+def test_predictions(testdata, load_model_for_test):
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     df = res.predictions
     assert len(df) == 744
     assert set(df.columns) == {'IPRED', 'PRED'}
     assert df.loc[0, 'PRED'] == 18.143
 
 
-def test_runtime_total(testdata):
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+def test_runtime_total(testdata, load_model_for_test):
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
+
     runtime = res.runtime_total
     assert runtime == 4
 
@@ -260,13 +287,15 @@ def test_runtime_different_formats(
         assert runtime == runtime_ref
 
 
-def test_estimation_runtime_steps(pheno_path, testdata):
-    res = read_modelfit_results(pheno_path)
+def test_estimation_runtime_steps_pheno(pheno, pheno_path):
+    res = parse_modelfit_results(pheno, pheno_path)
 
     assert res.estimation_runtime_iterations.iloc[0] == 0.32
     assert res.runtime_total == 4
 
-    res = read_modelfit_results(
+
+def test_estimation_runtime_steps_pheno_mult_est(testdata, load_model_for_test):
+    path = (
         testdata
         / 'nonmem'
         / 'modelfit_results'
@@ -275,14 +304,17 @@ def test_estimation_runtime_steps(pheno_path, testdata):
         / 'noSIM'
         / 'pheno_multEST.mod'
     )
+
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     assert res.estimation_runtime_iterations.iloc[0] == 0.33
     assert res.estimation_runtime_iterations.iloc[1] == 2.75
     assert res.runtime_total == 7
     assert res.estimation_runtime == 0.33
 
 
-def test_evaluation(testdata):
-    res = read_modelfit_results(
+def test_evaluation(testdata, load_model_for_test):
+    path = (
         testdata
         / 'nonmem'
         / 'modelfit_results'
@@ -292,13 +324,18 @@ def test_evaluation(testdata):
         / 'pheno_multEST.mod'
     )
 
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
+
     assert round(res.ofv, 3) == 729.955
     assert res.minimization_successful_iterations.iloc[-1]
     assert not res.minimization_successful
 
 
-def test_serialization(testdata):
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox_2comp.mod')
+def test_serialization(testdata, load_model_for_test):
+    path = testdata / 'nonmem' / 'models' / 'mox_2comp.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     res_json = res.to_json()
     res_decode = read_results(res_json)
 
@@ -306,31 +343,27 @@ def test_serialization(testdata):
     assert res.log.to_dataframe().equals(res_decode.log.to_dataframe())
 
 
-def test_empty_results(testdata, pheno_path):
-    model = read_model(pheno_path)
+def test_empty_results(testdata, pheno):
     res = parse_modelfit_results(
-        model, testdata / 'nonmem' / 'errors' / 'no_header_error_only_iter.ext'
+        pheno, testdata / 'nonmem' / 'errors' / 'no_header_error_only_iter.ext'
     )
     assert np.isnan(res.ofv)
     assert res.parameter_estimates.isnull().all()
 
 
-def test_saem(testdata):
-    res = read_modelfit_results(
-        testdata / 'nonmem' / 'modelfit_results' / 'saem' / 'pheno_saem.mod'
-    )
+def test_saem(testdata, load_model_for_test):
+    path = testdata / 'nonmem' / 'modelfit_results' / 'saem' / 'pheno_saem.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     assert res.individual_ofv is not None
     assert res.ofv == 366.33573391569922
     assert res.individual_eta_samples.loc[(1, 1), 'ETA_1'] == -0.113378
 
 
-def test_derivative_results(testdata):
-    model = read_model(
-        testdata / "nonmem" / "linearize" / "linearize_dir1" / "scm_dir1" / "derivatives.mod"
-    )
-    res = parse_modelfit_results(
-        model, testdata / "nonmem" / "linearize" / "linearize_dir1" / "scm_dir1" / "derivatives.mod"
-    )
+def test_derivative_results(testdata, load_model_for_test):
+    path = testdata / "nonmem" / "linearize" / "linearize_dir1" / "scm_dir1" / "derivatives.mod"
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     assert model.execution_steps[0].derivatives != ()
     assert res.derivatives is not None
 

--- a/tests/tools/test_allometry.py
+++ b/tests/tools/test_allometry.py
@@ -1,6 +1,5 @@
 import pytest
 
-from pharmpy.tools import read_modelfit_results
 from pharmpy.tools.allometry.tool import (
     add_allometry_on_model,
     create_result_tables,
@@ -8,13 +7,14 @@ from pharmpy.tools.allometry.tool import (
     get_best_model,
     validate_input,
 )
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.workflows import ModelEntry, Workflow
 from pharmpy.workflows.contexts import NullContext
 
 
 def test_create_workflow_with_model(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    results = parse_modelfit_results(model, testdata / 'nonmem' / 'pheno.mod')
     assert isinstance(
         create_workflow(model=model, results=results, allometric_variable='WGT'), Workflow
     )
@@ -22,7 +22,7 @@ def test_create_workflow_with_model(load_model_for_test, testdata):
 
 def test_add_allometry_on_model(load_model_for_test, testdata):
     model_start = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'pheno.mod')
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
     me_cand = add_allometry_on_model(
         me_start,
@@ -43,7 +43,7 @@ def test_add_allometry_on_model(load_model_for_test, testdata):
 def test_get_best_model(load_model_for_test, testdata):
     ctx = NullContext()
     model_start = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'pheno.mod')
     model_allometry = model_start.replace(description='allometry')
 
     me_start = ModelEntry(model_start, modelfit_results=res_start)
@@ -60,7 +60,7 @@ def test_get_best_model(load_model_for_test, testdata):
 
 def test_create_result_tables(load_model_for_test, testdata, model_entry_factory):
     model_start = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'pheno.mod')
     model_allometry = model_start.replace(name='allometry', description='allometry')
 
     me_start = ModelEntry(model_start, modelfit_results=res_start)
@@ -71,13 +71,13 @@ def test_create_result_tables(load_model_for_test, testdata, model_entry_factory
 
 def test_validate_input_with_model(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    results = parse_modelfit_results(model, testdata / 'nonmem' / 'pheno.mod')
     validate_input(model=model, results=results, allometric_variable='WGT')
 
 
 def test_validate_input_with_model_and_parameters(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    results = parse_modelfit_results(model, testdata / 'nonmem' / 'pheno.mod')
     validate_input(model=model, results=results, allometric_variable='WGT', parameters=['CL', 'V'])
 
 
@@ -128,7 +128,7 @@ def test_validate_input_raises(
         model_path = ('nonmem/pheno.mod',)
     path = testdata.joinpath(*model_path)
     model = load_model_for_test(path)
-    results = read_modelfit_results(path)
+    results = parse_modelfit_results(model, path)
 
     kwargs = {'model': model, 'results': results, **arguments}
 

--- a/tests/tools/test_amd.py
+++ b/tests/tools/test_amd.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pharmpy.tools import read_modelfit_results, read_results
+from pharmpy.tools import read_results
 from pharmpy.tools.amd.run import (
     _create_model_summary,
     _mechanistic_cov_extraction,
@@ -10,6 +10,7 @@ from pharmpy.tools.amd.run import (
     split_structural_search_space,
     validate_input,
 )
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.mfl.parse import ModelFeatures
 from pharmpy.tools.mfl.parse import parse as mfl_parse
 from pharmpy.workflows.contexts import NullContext
@@ -39,7 +40,7 @@ def test_create_model_summary(testdata):
 )
 def test_invalid_search_space_raises(load_model_for_test, testdata, search_space, error):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     with pytest.raises(ValueError, match=error):
         validate_input(
@@ -58,7 +59,7 @@ def test_invalid_search_space_raises(load_model_for_test, testdata, search_space
 )
 def test_skip_most(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     # If no
     model = model.replace(datainfo=model.datainfo.set_types('unknown'))
@@ -107,7 +108,7 @@ def test_skip_most(load_model_for_test, testdata):
 )
 def test_raise_allometry(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     with pytest.raises(ValueError, match='Invalid `allometric_variable`'):
         later_input_validation(
@@ -128,7 +129,7 @@ def test_raise_allometry(load_model_for_test, testdata):
 )
 def test_raise_empty_search_space(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     with pytest.raises(ValueError, match='`search_space` evaluated to be empty :'):
         validate_input(
@@ -149,7 +150,7 @@ def test_raise_empty_search_space(load_model_for_test, testdata):
 )
 def test_skip_covsearch(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     validate_input(
         model,
@@ -185,7 +186,7 @@ def test_skip_covsearch(load_model_for_test, testdata):
 )
 def test_skip_iovsearch_one_occasion(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     validate_input(
         model,
@@ -219,7 +220,7 @@ def test_skip_iovsearch_one_occasion(load_model_for_test, testdata):
 )
 def test_skip_iovsearch_missing_occasion_raises(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     with pytest.raises(ValueError, match='Invalid `occasion`'):
         later_input_validation(
@@ -240,7 +241,7 @@ def test_skip_iovsearch_missing_occasion_raises(load_model_for_test, testdata):
 )
 def test_ignore_datainfo_fallback(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     validate_input(
         model,
@@ -313,7 +314,7 @@ def test_ignore_datainfo_fallback(load_model_for_test, testdata):
 )
 def test_mechanistic_covariate_option(load_model_for_test, testdata, mechanistic_covariates, error):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     if error != "PASS":
         with pytest.raises(ValueError, match=error):

--- a/tests/tools/test_cdd.py
+++ b/tests/tools/test_cdd.py
@@ -3,7 +3,6 @@ from pytest import approx
 
 import pharmpy.tools.cdd.results as cdd
 from pharmpy.deps import pandas as pd
-from pharmpy.tools import read_modelfit_results
 from pharmpy.tools.external import parse_modelfit_results
 from pharmpy.tools.psn_helpers import model_paths, options_from_command
 
@@ -29,11 +28,14 @@ def test_psn_options():
 
 
 def test_cdd_psn(load_model_for_test, testdata):
+    base_model_path = testdata / 'nonmem' / 'cdd' / 'pheno_real.mod'
+    base_model = load_model_for_test(base_model_path)
+    base_model_results = parse_modelfit_results(base_model, base_model_path)
+
     path = testdata / 'nonmem' / 'cdd' / 'pheno_real_bin10'
-    base_model = load_model_for_test(testdata / 'nonmem' / 'cdd' / 'pheno_real.mod')
-    base_model_results = read_modelfit_results(testdata / 'nonmem' / 'cdd' / 'pheno_real.mod')
-    cdd_models = [load_model_for_test(p) for p in model_paths(path, 'cdd_*.mod')]
-    cdd_model_results = [read_modelfit_results(p) for p in model_paths(path, 'cdd_*.mod')]
+    cdd_paths = model_paths(path, 'cdd_*.mod')
+    cdd_models = list(map(load_model_for_test, cdd_paths))
+    cdd_model_results = list(map(parse_modelfit_results, cdd_models, cdd_paths))
     skipped_individuals = cdd.psn_cdd_skipped_individuals(path)
 
     cdd_bin_id = cdd.calculate_results(
@@ -132,14 +134,15 @@ def test_cdd_psn(load_model_for_test, testdata):
 
 
 def test_cdd_calculate_results(load_model_for_test, testdata):
+    base_model_path = testdata / 'nonmem' / 'cdd' / 'pheno_real.mod'
+    base_model = load_model_for_test(base_model_path)
+    base_model_results = parse_modelfit_results(base_model, base_model_path)
+
     path = testdata / 'nonmem' / 'cdd' / 'pheno_real_bin10'
     skipped_individuals = cdd.psn_cdd_skipped_individuals(path)
-    base_model = load_model_for_test(testdata / 'nonmem' / 'cdd' / 'pheno_real.mod')
-    base_model_results = read_modelfit_results(testdata / 'nonmem' / 'cdd' / 'pheno_real.mod')
     cdd_model_paths = model_paths(path, 'cdd_*.mod')
-
-    cdd_models = [load_model_for_test(p) for p in cdd_model_paths]
-    cdd_model_results = [read_modelfit_results(p) for p in cdd_model_paths]
+    cdd_models = list(map(load_model_for_test, cdd_model_paths))
+    cdd_model_results = list(map(parse_modelfit_results, cdd_models, cdd_model_paths))
 
     # Results for plain PsN run
     delta_ofv = cdd.compute_delta_ofv(base_model_results, cdd_model_results, skipped_individuals)

--- a/tests/tools/test_covsearch.py
+++ b/tests/tools/test_covsearch.py
@@ -10,7 +10,6 @@ from pharmpy.modeling import (
     remove_covariate_effect,
     set_name,
 )
-from pharmpy.tools import read_modelfit_results
 from pharmpy.tools.covsearch.tool import (
     Candidate,
     Effect,
@@ -27,6 +26,7 @@ from pharmpy.tools.covsearch.tool import (
     prepare_mfls,
     validate_input,
 )
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.mfl.parse import ModelFeatures, get_model_features
 from pharmpy.workflows import ModelEntry, Workflow
 
@@ -37,7 +37,7 @@ LARGE_VALID_MFL_STRING = 'COVARIATE?(@IIV, @CONTINUOUS, *);COVARIATE?(@IIV, @CAT
 
 def test_create_workflow_with_model(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    results = parse_modelfit_results(model, testdata / 'nonmem' / 'pheno.mod')
     assert isinstance(
         create_workflow(model=model, results=results, search_space=MINIMAL_VALID_MFL_STRING),
         Workflow,
@@ -50,7 +50,7 @@ def test_create_workflow_with_model(load_model_for_test, testdata):
 def test_validate_input_with_model(load_model_for_test, testdata, model_path):
     path = testdata.joinpath(*model_path)
     model = load_model_for_test(path)
-    results = read_modelfit_results(path)
+    results = parse_modelfit_results(model, path)
     validate_input(model=model, results=results, search_space=LARGE_VALID_MFL_STRING)
 
 
@@ -130,7 +130,7 @@ def test_extract_nonsignificant_effects(
     load_model_for_test, testdata, model_entry_factory, p_value, no_of_nonsignificant_effects
 ):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    modelres = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    modelres = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
     parent_modelentry = ModelEntry(model, modelfit_results=modelres)
 
     search_space = 'COVARIATE?([CL,VC],[WT, AGE],EXP)'
@@ -275,7 +275,7 @@ def test_validate_input_raises(
         model_path = ('nonmem/pheno.mod',)
     path = testdata.joinpath(*model_path)
     model = load_model_for_test(path)
-    results = read_modelfit_results(path)
+    results = parse_modelfit_results(model, path)
 
     harmless_arguments = dict(
         search_space=MINIMAL_VALID_MFL_STRING,
@@ -323,7 +323,7 @@ def test_covariate_filtering(load_model_for_test, testdata):
 
 def test_max_eval(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    modelres = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    modelres = parse_modelfit_results(model, testdata / 'nonmem' / 'pheno.mod')
 
     no_max_eval_model_entry = _start(model, modelres, max_eval=False)
     assert no_max_eval_model_entry.model == model
@@ -398,7 +398,7 @@ def _mock_fit(effect, parent, adaptive_step):
 #         ]
 #
 #     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-#     modelres = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+#     modelres = parse_modelfit_results(model, testdata / 'nonmem' / 'pheno.mod')
 #
 #     candidate_effect_funcs, start = get_effect_funcs_and_base_model(search_space, model)
 #     start = _start(start, modelres, False)
@@ -453,7 +453,7 @@ def _create_candidates(model_entry_factory, funcs, parent_cand, i, p_value):
 
 def test_get_best_candidate(load_model_for_test, testdata, model_entry_factory):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    modelres = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    modelres = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
     parent_model_entry = ModelEntry(model, modelfit_results=modelres)
     parent_cand = Candidate(parent_model_entry, steps=tuple())
 
@@ -487,7 +487,7 @@ def test_get_best_candidate(load_model_for_test, testdata, model_entry_factory):
 
 def test_create_result_tables(load_model_for_test, testdata, model_entry_factory):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    modelres = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    modelres = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
     parent_model_entry = ModelEntry(model, modelfit_results=modelres)
     parent_cand = Candidate(parent_model_entry, steps=tuple())
 

--- a/tests/tools/test_frem.py
+++ b/tests/tools/test_frem.py
@@ -8,7 +8,7 @@ from pytest import approx
 
 import pharmpy.tools as tools
 from pharmpy.deps import pandas as pd
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.frem.models import calculate_parcov_inits, create_model3b
 from pharmpy.tools.frem.results import (
     calculate_results,
@@ -47,8 +47,9 @@ def test_check_covariates_mult_warns(load_model_for_test, testdata):
 
 
 def test_parcov_inits(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_3.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_3.mod')
+    path = testdata / 'nonmem' / 'frem' / 'pheno' / 'model_3.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     params = calculate_parcov_inits(model, res.individual_estimates, 2)
     assert params == approx(
         {
@@ -62,7 +63,9 @@ def test_parcov_inits(load_model_for_test, testdata):
 
 def test_create_model3b(load_model_for_test, testdata):
     model3 = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_3.mod')
-    model3_res = read_modelfit_results(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_3.mod')
+    model3_res = parse_modelfit_results(
+        model3, testdata / 'nonmem' / 'frem' / 'pheno' / 'model_3.mod'
+    )
     model1b = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_1b.mod')
     model3b = create_model3b(model1b, model3, model3_res, 2)
     pset = model3b.parameters
@@ -72,8 +75,9 @@ def test_create_model3b(load_model_for_test, testdata):
 
 
 def test_bipp_covariance(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
+    path = testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     res = calculate_results_using_bipp(
         model, res, continuous=['APGR', 'WGT'], categorical=[], seed=9532
     )
@@ -81,8 +85,9 @@ def test_bipp_covariance(load_model_for_test, testdata):
 
 
 def test_frem_results_pheno(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod')
+    path = testdata / 'nonmem' / 'frem' / 'pheno' / 'model_4.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     rng = np.random.default_rng(39)
     res = calculate_results(
         model, res, continuous=['APGR', 'WGT'], categorical=[], samples=10, seed=rng
@@ -258,8 +263,9 @@ V,all,0.14574143997630676,0.11964944422449278,0.16136355952455325
 
 
 def test_frem_results_pheno_categorical(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'frem' / 'pheno_cat' / 'model_4.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'frem' / 'pheno_cat' / 'model_4.mod')
+    path = testdata / 'nonmem' / 'frem' / 'pheno_cat' / 'model_4.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     rng = np.random.default_rng(8978)
     res = calculate_results(
         model, res, continuous=['WGT'], categorical=['APGRX'], samples=10, seed=rng

--- a/tests/tools/test_iivsearch.py
+++ b/tests/tools/test_iivsearch.py
@@ -15,7 +15,7 @@ from pharmpy.modeling import (
     set_iiv_on_ruv,
     set_name,
 )
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.iivsearch.algorithms import (
     _create_param_dict,
     _extract_clearance_parameter,
@@ -47,8 +47,9 @@ from pharmpy.workflows import ModelEntry, Workflow
 
 
 def test_prepare_input_model(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     model_input, me_input = prepare_input_model(model, res)
 
     assert model_input.description == '[CL]+[VC]+[MAT]'
@@ -67,8 +68,9 @@ def test_prepare_input_model(load_model_for_test, testdata):
 def test_prepare_base_model(
     load_model_for_test, testdata, iiv_strategy, linearize, no_of_params_added, description, has_mfr
 ):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_input = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model_start = load_model_for_test(path)
+    res_input = parse_modelfit_results(model_start, path)
     model_input = add_peripheral_compartment(model_start)
     me_input = ModelEntry.create(model_input, modelfit_results=res_input)
     model_base, me_base = prepare_base_model(me_input, iiv_strategy, linearize)
@@ -99,9 +101,10 @@ def test_prepare_base_model(
 def test_update_linearized_base_model(
     load_model_for_test, testdata, iiv_strategy, param_mapping, description
 ):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     model_start = remove_iiv(model_start, ['ETA_3'])
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     if iiv_strategy != 'no_add':
         model_base = iivsearch_add_iiv(iiv_strategy, model_start, res_start, linearize=True)
@@ -142,8 +145,9 @@ def test_prepare_algorithms(algorithm, correlation_algorithm, list_of_algorithms
 
 
 def test_create_param_mapping(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     me_input = ModelEntry.create(model, modelfit_results=res)
 
     param_mapping = create_param_mapping(me_input, linearize=False)
@@ -165,12 +169,14 @@ def test_create_param_mapping(load_model_for_test, testdata):
 )
 def test_add_iiv(load_model_for_test, testdata, iiv_strategy, linearize, no_of_added_params):
     if not iiv_strategy.startswith('pd'):
-        model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-        res_input = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+        path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+        model_start = load_model_for_test(path)
+        res_input = parse_modelfit_results(model_start, path)
         model_input = add_peripheral_compartment(model_start)
     else:
-        model_start = load_model_for_test(testdata / 'nonmem' / 'pheno_pd.mod')
-        res_input = read_modelfit_results(testdata / 'nonmem' / 'pheno_pd.mod')
+        path = testdata / 'nonmem' / 'pheno_pd.mod'
+        model_start = load_model_for_test(path)
+        res_input = parse_modelfit_results(model_start, path)
         model_start = fix_parameters(model_start, model_start.parameters.names)
         model_input = set_direct_effect(model_start, expr='linear')
 
@@ -191,8 +197,9 @@ def test_add_iiv(load_model_for_test, testdata, iiv_strategy, linearize, no_of_a
 def test_categorize_model_entries(
     load_model_for_test, testdata, model_entry_factory, algorithm, base_model_name
 ):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     model_start = add_peripheral_compartment(model_start)
     model_start = add_pk_iiv(model_start)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
@@ -212,8 +219,9 @@ def test_categorize_model_entries(
 
 
 def test_update_input_model_description(load_model_for_test, testdata):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     model_start = add_peripheral_compartment(model_start)
     model_start = add_pk_iiv(model_start)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
@@ -232,8 +240,9 @@ def test_update_input_model_description(load_model_for_test, testdata):
 def test_create_no_of_etas_candidate_entry(
     load_model_for_test, testdata, to_remove, no_of_etas, description
 ):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     me_candidate = create_no_of_etas_candidate_entry(
@@ -285,8 +294,9 @@ def test_create_no_of_etas_candidate_entry(
 def test_create_block_structure_candidate_entry(
     load_model_for_test, testdata, block_structure, no_of_dists, description
 ):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     me_candidate = create_block_structure_candidate_entry(
@@ -431,8 +441,9 @@ def test_extract_base_parameter(load_model_for_test, testdata):
 def test_brute_force_block_structure(
     load_model_for_test, testdata, list_of_parameters, block_structure, no_of_models
 ):
-    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     model = add_peripheral_compartment(model)
     model = add_iiv(model, list_of_parameters, 'add')
     if block_structure:
@@ -483,10 +494,9 @@ def test_rv_block_structures_5_etas(load_model_for_test, pheno_path):
     assert block_structures_integer_partitions.count((1, 1, 1, 1, 1)) == 1
 
 
-def test_is_rv_block_structure(load_model_for_test, pheno_path):
-    model = load_model_for_test(pheno_path)
-    res = read_modelfit_results(pheno_path)
-    model = add_iiv(model, ['TAD', 'S1'], 'exp')
+def test_is_rv_block_structure(pheno, pheno_path):
+    res = parse_modelfit_results(pheno, pheno_path)
+    model = add_iiv(pheno, ['TAD', 'S1'], 'exp')
 
     etas_block_structure = (('ETA_1', 'ETA_2'), ('ETA_TAD',), ('ETA_S1',))
     model = create_joint_distribution(
@@ -510,8 +520,9 @@ def test_is_rv_block_structure(load_model_for_test, pheno_path):
 
 
 def test_create_joint_dist(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
 
     model = add_peripheral_compartment(model)
     model = add_pk_iiv(model)
@@ -620,16 +631,18 @@ def test_get_eta_names(load_model_for_test, testdata, funcs, keep, param_mapping
 
 
 def test_create_workflow_with_model(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model = load_model_for_test(path)
+    results = parse_modelfit_results(model, path)
     assert isinstance(
         create_workflow(model=model, results=results, algorithm='top_down_exhaustive'), Workflow
     )
 
 
 def test_validate_input_with_model(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model = load_model_for_test(path)
+    results = parse_modelfit_results(model, path)
     validate_input(model=model, results=results, algorithm='top_down_exhaustive')
 
 
@@ -734,7 +747,7 @@ def test_validate_input_raises(
         model_path = ('nonmem/pheno.mod',)
     path = testdata.joinpath(*model_path)
     model = load_model_for_test(path)
-    results = read_modelfit_results(path)
+    results = parse_modelfit_results(model, path)
 
     harmless_arguments = dict(
         algorithm='top_down_exhaustive',

--- a/tests/tools/test_iovsearch.py
+++ b/tests/tools/test_iovsearch.py
@@ -13,7 +13,7 @@ from pharmpy.modeling import (
     remove_iiv,
     remove_iov,
 )
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.iovsearch.tool import (
     _get_iiv_etas_with_corresponding_iov,
     _get_nonfixed_iivs,
@@ -86,8 +86,9 @@ def test_create_iov_base_model_entry(
     no_of_iov_omegas,
     desc_ref,
 ):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     if func:
         model_start = func(model_start)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
@@ -116,8 +117,9 @@ def test_create_candidate_model_entry(
     no_of_iov,
     desc_ref,
 ):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     model_start = add_iov(model_start, 'VISI', distribution='same-as-iiv')
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
     me_cand = create_candidate_model_entry(func, me_start, etas, 1)
@@ -180,14 +182,16 @@ def test_iovsearch_github_issues_976(load_model_for_test, testdata):
 
 
 def test_create_workflow_with_model(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model = load_model_for_test(path)
+    results = parse_modelfit_results(model, path)
     assert isinstance(create_workflow(model=model, results=results, column='APGR'), Workflow)
 
 
 def test_create_result_tables(load_model_for_test, testdata, model_entry_factory):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     model_1 = add_iov(model_start, occ='VISI', list_of_parameters=['ETA_1'])
@@ -236,14 +240,16 @@ def test_create_result_tables(load_model_for_test, testdata, model_entry_factory
 
 
 def test_validate_input_with_model(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model = load_model_for_test(path)
+    results = parse_modelfit_results(model, path)
     validate_input(model=model, results=results, column='APGR')
 
 
 def test_validate_input_with_model_and_list_of_parameters(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model = load_model_for_test(path)
+    results = parse_modelfit_results(model, path)
     validate_input(model=model, results=results, column='APGR', list_of_parameters=['CL', 'V'])
     validate_input(model=model, results=results, column='APGR', list_of_parameters=[['V'], ['CL']])
 
@@ -299,7 +305,7 @@ def test_validate_input_raises(
         model_path = ('nonmem/pheno.mod',)
     path = testdata.joinpath(*model_path)
     model = load_model_for_test(path)
-    results = read_modelfit_results(path)
+    results = parse_modelfit_results(model, path)
 
     kwargs = {'model': model, 'results': results, **arguments}
     if 'column' not in arguments.keys():

--- a/tests/tools/test_linearize.py
+++ b/tests/tools/test_linearize.py
@@ -4,7 +4,7 @@ import pytest
 
 from pharmpy.deps import pandas as pd
 from pharmpy.model import DataInfo
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.linearize.delinearize import delinearize_model
 from pharmpy.tools.linearize.results import calculate_results, psn_linearize_results
 from pharmpy.tools.linearize.tool import (
@@ -19,9 +19,9 @@ from pharmpy.workflows.contexts import NullContext
 
 def test_ofv(load_model_for_test, testdata):
     base = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    baseres = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    baseres = parse_modelfit_results(base, testdata / 'nonmem' / 'pheno.mod')
     lin = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    linres = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    linres = parse_modelfit_results(lin, testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     res = calculate_results(base, baseres, lin, linres)
     correct = """,OFV
 base,730.894727
@@ -34,9 +34,9 @@ lin_estimated,730.847272
 
 def test_iofv(load_model_for_test, testdata):
     base = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    baseres = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    baseres = parse_modelfit_results(base, testdata / 'nonmem' / 'pheno.mod')
     lin = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    linres = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    linres = parse_modelfit_results(lin, testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     res = calculate_results(base, baseres, lin, linres)
     correct = """,base,linear,delta
 1,7.742852,7.722670,-0.020182
@@ -157,12 +157,11 @@ $ESTIMATION METHOD=COND INTER MAXEVAL=0\n'''
 
 def test_create_linearized_model(load_model_for_test, testdata):
     model = load_model_for_test(testdata / "nonmem" / "pheno.mod")
-    derivative_model = load_model_for_test(
+    derivative_model_path = (
         testdata / "nonmem" / "linearize" / "linearize_dir1" / "scm_dir1" / "derivatives.mod"
     )
-    modelres = read_modelfit_results(
-        testdata / "nonmem" / "linearize" / "linearize_dir1" / "scm_dir1" / "derivatives.mod"
-    )
+    derivative_model = load_model_for_test(derivative_model_path)
+    modelres = parse_modelfit_results(derivative_model, derivative_model_path)
 
     derivative_modelentry = ModelEntry.create(model=derivative_model, modelfit_results=modelres)
 

--- a/tests/tools/test_modelrank.py
+++ b/tests/tools/test_modelrank.py
@@ -12,6 +12,7 @@ from pharmpy.modeling import (
     set_initial_estimates,
     set_name,
 )
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.modelrank.ranking import (
     get_aic,
     get_bic,
@@ -34,13 +35,12 @@ from pharmpy.tools.modelrank.tool import (
     rank_models,
     validate_input,
 )
-from pharmpy.tools.run import read_modelfit_results
 from pharmpy.workflows import ModelEntry
 
 
 def test_prepare_model_entries(load_model_for_test, pheno_path):
     model_ref = load_model_for_test(pheno_path)
-    res_ref = read_modelfit_results(pheno_path)
+    res_ref = parse_modelfit_results(model_ref, pheno_path)
     models_cand = []
     for i in range(5):
         model = set_initial_estimates(model_ref, {'PTVCL': float(i)})
@@ -82,7 +82,7 @@ def test_rank_models(
     load_model_for_test, pheno_path, model_entry_factory, strictness, rank_type, alpha
 ):
     model_ref = load_model_for_test(pheno_path)
-    res_ref = read_modelfit_results(pheno_path)
+    res_ref = parse_modelfit_results(model_ref, pheno_path)
     me_ref = ModelEntry.create(model_ref, modelfit_results=res_ref)
     models_cand = [set_name(model, f'model{i}') for i, model in enumerate([model_ref] * 5)]
     mes_cand = model_entry_factory(models_cand, parent=model_ref)
@@ -243,7 +243,7 @@ def test_get_strictness_predicates(
     testdata, load_model_for_test, strictness, model_path, ref_predicates
 ):
     model_start = load_model_for_test(testdata / 'nonmem' / model_path)
-    res_start = read_modelfit_results(testdata / 'nonmem' / model_path)
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / model_path)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     expr = get_strictness_expr(strictness)
@@ -298,7 +298,7 @@ def test_evaluate_strictness(
     testdata, load_model_for_test, strictness, model_path, strictness_fulfilled
 ):
     model_start = load_model_for_test(testdata / 'nonmem' / model_path)
-    res_start = read_modelfit_results(testdata / 'nonmem' / model_path)
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / model_path)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     expr = get_strictness_expr(strictness)
@@ -411,8 +411,8 @@ def test_evaluate_strictness(
 )
 def test_get_rank_values(testdata, load_model_for_test, rank_func, kwargs, ref_dict):
     model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'models' / 'mox2.mod')
     model_start = create_joint_distribution(model_start, rvs=['ETA_1', 'ETA_2'])
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     rank_dict = rank_func(me_start, **kwargs)
@@ -510,7 +510,7 @@ class DummyResults:
 )
 def test_perform_lrt(testdata, load_model_for_test, funcs, ofv, alpha, ref_dict):
     model_parent = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_parent = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res_parent = parse_modelfit_results(model_parent, testdata / 'nonmem' / 'models' / 'mox2.mod')
     me_parent = ModelEntry.create(model_parent, modelfit_results=res_parent)
 
     model_child = set_name(model_parent, 'cand')
@@ -567,7 +567,7 @@ def test_rank_model_entries(
     load_model_for_test, testdata, model_entry_factory, rank_type, rank_kwargs, final_model
 ):
     model_ref = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_ref = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res_ref = parse_modelfit_results(model_ref, testdata / 'nonmem' / 'models' / 'mox2.mod')
     me_ref = ModelEntry.create(model_ref, modelfit_results=res_ref)
 
     models_cand = _create_candidates(model_ref)
@@ -595,7 +595,7 @@ def test_rank_model_entries(
 
 def test_get_best_model_entry(load_model_for_test, testdata, model_entry_factory):
     model_ref = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_ref = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res_ref = parse_modelfit_results(model_ref, testdata / 'nonmem' / 'models' / 'mox2.mod')
     me_ref = ModelEntry.create(model_ref, modelfit_results=res_ref)
 
     models_cand = _create_candidates(model_ref)
@@ -657,7 +657,7 @@ def test_get_model_entries_to_rank(
     no_of_mes_strict,
 ):
     model_ref = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_ref = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res_ref = parse_modelfit_results(model_ref, testdata / 'nonmem' / 'models' / 'mox2.mod')
     me_ref = ModelEntry.create(model_ref, modelfit_results=res_ref)
 
     models_cand = _create_candidates(model_ref)
@@ -728,8 +728,8 @@ def test_validate_input_raises(
     load_model_for_test, pheno_path, no_of_res, kwargs, exception, match
 ):
     model_ref = load_model_for_test(pheno_path)
+    res_ref = parse_modelfit_results(model_ref, pheno_path)
     model_ref = remove_parameter_uncertainty_step(model_ref)
-    res_ref = read_modelfit_results(pheno_path)
     models_cand = [model_ref] * 5
     res_cand = [res_ref] * no_of_res
 
@@ -744,7 +744,7 @@ def test_validate_input_raises(
 
 def test_validate_input_raises_ref_model(load_model_for_test, pheno_path):
     model_ref = load_model_for_test(pheno_path)
-    res_ref = read_modelfit_results(pheno_path)
+    res_ref = parse_modelfit_results(model_ref, pheno_path)
 
     models_cand = []
     for i in range(5):

--- a/tests/tools/test_modelsearch.py
+++ b/tests/tools/test_modelsearch.py
@@ -15,7 +15,7 @@ from pharmpy.modeling import (
     set_zero_order_absorption,
     set_zero_order_elimination,
 )
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.mfl.helpers import funcs, modelsearch_features
 from pharmpy.tools.mfl.parse import parse
 from pharmpy.tools.mfl.parse import parse as mfl_parse
@@ -269,7 +269,7 @@ def test_is_allowed():
 )
 def test_add_iiv_to_func(load_model_for_test, testdata, transform_funcs, no_of_added_etas):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
     model_entry = ModelEntry.create(model, modelfit_results=res)
     no_of_etas_start = len(model.random_variables)
     for func in transform_funcs:
@@ -280,7 +280,7 @@ def test_add_iiv_to_func(load_model_for_test, testdata, transform_funcs, no_of_a
 
 def test_get_best_model(load_model_for_test, testdata, model_entry_factory):
     model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'models' / 'mox2.mod')
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     model_candidate = model_start.replace(name='cand')
@@ -297,7 +297,7 @@ def test_get_best_model(load_model_for_test, testdata, model_entry_factory):
 
 def test_create_base_model(load_model_for_test, testdata):
     model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'models' / 'mox2.mod')
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
     search_space = mfl_parse('ABSORPTION([SEQ-ZO-FO])', mfl_class=True)
     assert has_first_order_absorption(model_start)
@@ -314,7 +314,7 @@ def test_create_base_model(load_model_for_test, testdata):
 
 def test_clear_description(load_model_for_test, testdata):
     model_start = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'pheno.mod')
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
     model_no_desc = clear_description(me_start).model
     assert model_start.description != ''
@@ -335,7 +335,7 @@ def test_clear_description(load_model_for_test, testdata):
 )
 def test_create_candidate(load_model_for_test, testdata, iiv_strategy, allometry, params_added):
     model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'models' / 'mox2.mod')
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     search_space_exhaustive = 'ABSORPTION(ZO);PERIPHERALS(1)'
@@ -390,7 +390,7 @@ def test_create_candidate(load_model_for_test, testdata, iiv_strategy, allometry
 )
 def test_filter_mfl_statements(load_model_for_test, testdata, funcs, search_space, mfl_funcs):
     model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'models' / 'mox2.mod')
     for func in funcs:
         model_start = func(model_start)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
@@ -400,7 +400,7 @@ def test_filter_mfl_statements(load_model_for_test, testdata, funcs, search_spac
 
 def test_categorize_model_entries(load_model_for_test, testdata, model_entry_factory):
     model_start = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'models' / 'mox2.mod')
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
     model_base = set_zero_order_absorption(model_start).replace(name='base')
     me_base = ModelEntry.create(model_base)
@@ -423,7 +423,7 @@ def test_categorize_model_entries(load_model_for_test, testdata, model_entry_fac
 
 def test_create_result_tables(load_model_for_test, testdata, model_entry_factory):
     model_start = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'pheno.mod')
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     funcs = [set_zero_order_absorption, add_peripheral_compartment, set_zero_order_elimination]
@@ -442,7 +442,7 @@ def test_create_result_tables(load_model_for_test, testdata, model_entry_factory
 
 def test_create_workflow_with_model(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    results = parse_modelfit_results(model, testdata / 'nonmem' / 'pheno.mod')
     assert isinstance(
         create_workflow(model, results, MINIMAL_VALID_MFL_STRING, 'exhaustive'), Workflow
     )
@@ -450,7 +450,7 @@ def test_create_workflow_with_model(load_model_for_test, testdata):
 
 def test_validate_input_with_model(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    results = parse_modelfit_results(model, testdata / 'nonmem' / 'pheno.mod')
     validate_input(model, results, MINIMAL_VALID_MFL_STRING, 'exhaustive')
 
 
@@ -558,7 +558,7 @@ def test_validate_input_raises(
         model_path = ('nonmem/pheno.mod',)
     path = testdata.joinpath(*model_path)
     model = load_model_for_test(path)
-    results = read_modelfit_results(path)
+    results = parse_modelfit_results(model, path)
 
     harmless_arguments = dict(
         search_space=MINIMAL_VALID_MFL_STRING,

--- a/tests/tools/test_qa.py
+++ b/tests/tools/test_qa.py
@@ -13,7 +13,7 @@ from pharmpy.modeling import (
     transform_etas_boxcox,
     transform_etas_tdist,
 )
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.qa.results import calc_transformed_etas, calculate_results, psn_qa_results
 from pharmpy.tools.qa.tool import (
     SECTIONS,
@@ -33,8 +33,9 @@ from pharmpy.workflows.results import read_results
     [('tdist', 3), ('boxcox', 3), ('fullblock', 3)],
 )
 def test_create_candidate(load_model_for_test, testdata, trans_type, added_etas):
-    model_base = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_base = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model_base = load_model_for_test(path)
+    res_base = parse_modelfit_results(model_base, path)
     me_base = ModelEntry.create(model_base, modelfit_results=res_base)
 
     me = create_candidate(me_base, trans_type)
@@ -46,8 +47,9 @@ def test_create_candidate(load_model_for_test, testdata, trans_type, added_etas)
 
 
 def test_categorize_model_entries(load_model_for_test, testdata, model_entry_factory):
-    model_base = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_base = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model_base = load_model_for_test(path)
+    res_base = parse_modelfit_results(model_base, path)
     me_base = ModelEntry(model_base, modelfit_results=res_base)
 
     model1 = transform_etas_tdist(model_base).replace(name='tdist')
@@ -69,8 +71,9 @@ def test_categorize_model_entries(load_model_for_test, testdata, model_entry_fac
 
 
 def test_create_dofv_table(load_model_for_test, testdata, model_entry_factory):
-    model_base = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_base = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model_base = load_model_for_test(path)
+    res_base = parse_modelfit_results(model_base, path)
     me_base = ModelEntry(model_base, modelfit_results=res_base)
 
     model1 = transform_etas_tdist(model_base).replace(name='tdist')
@@ -92,8 +95,9 @@ def test_create_dofv_table(load_model_for_test, testdata, model_entry_factory):
 
 
 def test_create_eta_transformation_results(load_model_for_test, testdata, model_entry_factory):
-    model_base = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res_base = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    path = testdata / 'nonmem' / 'models' / 'mox2.mod'
+    model_base = load_model_for_test(path)
+    res_base = parse_modelfit_results(model_base, path)
     me_base = ModelEntry(model_base, modelfit_results=res_base)
 
     model1 = transform_etas_tdist(model_base).replace(name='tdist')
@@ -114,13 +118,15 @@ def test_create_eta_transformation_results(load_model_for_test, testdata, model_
 
 def test_add_etas(load_model_for_test, testdata):
     orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    orig_res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    orig_res = parse_modelfit_results(orig, testdata / 'nonmem' / 'pheno.mod')
     orig_entry = ModelEntry.create(model=orig, modelfit_results=orig_res)
     base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    base_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    base_res = parse_modelfit_results(base, testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     base_entry = ModelEntry.create(model=base, modelfit_results=base_res)
     add_etas = load_model_for_test(testdata / 'nonmem' / 'qa' / 'add_etas_linbase.mod')
-    add_etas_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'add_etas_linbase.mod')
+    add_etas_res = parse_modelfit_results(
+        add_etas, testdata / 'nonmem' / 'qa' / 'add_etas_linbase.mod'
+    )
     add_etas_entry = ModelEntry.create(model=add_etas, modelfit_results=add_etas_res)
     res = calculate_results(
         orig_entry, base_entry, add_etas_model_entry=add_etas_entry, etas_added_to=['CL', 'V']
@@ -142,13 +148,13 @@ V,False,0.010000,NaN
 
 def test_fullblock(load_model_for_test, testdata):
     orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    orig_res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    orig_res = parse_modelfit_results(orig, testdata / 'nonmem' / 'pheno.mod')
     orig_entry = ModelEntry.create(model=orig, modelfit_results=orig_res)
     base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    base_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    base_res = parse_modelfit_results(base, testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     base_entry = ModelEntry.create(model=base, modelfit_results=base_res)
     fb = load_model_for_test(testdata / 'nonmem' / 'qa' / 'fullblock.mod')
-    fb_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'fullblock.mod')
+    fb_res = parse_modelfit_results(fb, testdata / 'nonmem' / 'qa' / 'fullblock.mod')
     fb_entry = ModelEntry.create(model=fb, modelfit_results=fb_res)
     res = calculate_results(orig_entry, base_entry, fullblock_model_entry=fb_entry)
     correct = """,new,old
@@ -170,13 +176,13 @@ def test_fullblock(load_model_for_test, testdata):
 
 def test_boxcox(load_model_for_test, testdata):
     orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    orig_res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    orig_res = parse_modelfit_results(orig, testdata / 'nonmem' / 'pheno.mod')
     orig_entry = ModelEntry.create(model=orig, modelfit_results=orig_res)
     base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    base_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    base_res = parse_modelfit_results(base, testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     base_entry = ModelEntry.create(model=base, modelfit_results=base_res)
     bc = load_model_for_test(testdata / 'nonmem' / 'qa' / 'boxcox.mod')
-    bc_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'boxcox.mod')
+    bc_res = parse_modelfit_results(bc, testdata / 'nonmem' / 'qa' / 'boxcox.mod')
     bc_entry = ModelEntry.create(model=bc, modelfit_results=bc_res)
     res = calculate_results(orig_entry, base_entry, boxcox_model_entry=bc_entry)
     correct = """lambda,new_sd,old_sd
@@ -197,13 +203,13 @@ ETA_2,0.645817,0.429369,0.448917
 
 def test_tdist(load_model_for_test, testdata):
     orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    orig_res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    orig_res = parse_modelfit_results(orig, testdata / 'nonmem' / 'pheno.mod')
     orig_entry = ModelEntry.create(model=orig, modelfit_results=orig_res)
     base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    base_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    base_res = parse_modelfit_results(base, testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     base_entry = ModelEntry.create(model=base, modelfit_results=base_res)
     td = load_model_for_test(testdata / 'nonmem' / 'qa' / 'tdist.mod')
-    td_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'tdist.mod')
+    td_res = parse_modelfit_results(td, testdata / 'nonmem' / 'qa' / 'tdist.mod')
     td_entry = ModelEntry.create(model=td, modelfit_results=td_res)
     res = calculate_results(orig_entry, base_entry, tdist_model_entry=td_entry)
     correct = """df,new_sd,old_sd
@@ -275,13 +281,13 @@ def test_calc_transformed_etas(
 
 def test_iov(load_model_for_test, testdata):
     orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    orig_res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    orig_res = parse_modelfit_results(orig, testdata / 'nonmem' / 'pheno.mod')
     orig_entry = ModelEntry.create(model=orig, modelfit_results=orig_res)
     base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    base_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    base_res = parse_modelfit_results(base, testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     base_entry = ModelEntry.create(model=base, modelfit_results=base_res)
     iov = load_model_for_test(testdata / 'nonmem' / 'qa' / 'iov.mod')
-    iov_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'iov.mod')
+    iov_res = parse_modelfit_results(iov, testdata / 'nonmem' / 'qa' / 'iov.mod')
     iov_entry = ModelEntry.create(model=iov, modelfit_results=iov_res)
     res = calculate_results(orig_entry, base_entry, iov_model_entry=iov_entry)
     correct = """new_iiv_sd,orig_iiv_sd,iov_sd
@@ -297,10 +303,10 @@ ETA_2,0.071481,0.448917,0.400451
 
 def test_scm(load_model_for_test, testdata):
     orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    orig_res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    orig_res = parse_modelfit_results(orig, testdata / 'nonmem' / 'pheno.mod')
     orig_entry = ModelEntry.create(model=orig, modelfit_results=orig_res)
     base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    base_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    base_res = parse_modelfit_results(base, testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     base_entry = ModelEntry.create(model=base, modelfit_results=base_res)
     scm_res = read_results(testdata / 'nonmem' / 'qa' / 'scm_results.json')
     res = calculate_results(orig_entry, base_entry, scm_results=scm_res)
@@ -319,10 +325,10 @@ ETA(2),WGT,0.00887,-0.003273
 
 def test_resmod(load_model_for_test, testdata):
     orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    orig_res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    orig_res = parse_modelfit_results(orig, testdata / 'nonmem' / 'pheno.mod')
     orig_entry = ModelEntry.create(model=orig, modelfit_results=orig_res)
     base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    base_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    base_res = parse_modelfit_results(base, testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     base_entry = ModelEntry.create(model=base, modelfit_results=base_res)
     resmod_res = read_results(testdata / 'nonmem' / 'qa' / 'resmod_results.json')
     res = calculate_results(orig_entry, base_entry, resmod_idv_results=resmod_res)
@@ -341,10 +347,10 @@ def test_resmod(load_model_for_test, testdata):
 
 def test_resmod_dvid(load_model_for_test, testdata):
     orig = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    orig_res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    orig_res = parse_modelfit_results(orig, testdata / 'nonmem' / 'pheno.mod')
     orig_entry = ModelEntry.create(model=orig, modelfit_results=orig_res)
     base = load_model_for_test(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
-    base_res = read_modelfit_results(testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
+    base_res = parse_modelfit_results(base, testdata / 'nonmem' / 'qa' / 'pheno_linbase.mod')
     base_entry = ModelEntry.create(model=base, modelfit_results=base_res)
     resmod_res = psn_resmod_results(testdata / 'psn' / 'resmod_dir2')
     res = calculate_results(orig_entry, base_entry, resmod_idv_results=resmod_res)
@@ -416,7 +422,7 @@ def test_validate_input_raises(
     match,
 ):
     model = load_model_for_test(testdata / 'nonmem' / 'models' / 'mox2.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'models' / 'mox2.mod')
+    res = parse_modelfit_results(model, testdata / 'nonmem' / 'models' / 'mox2.mod')
 
     with pytest.raises(ValueError, match=match):
         validate_input(model, res, **kwargs)

--- a/tests/tools/test_ruvsearch.py
+++ b/tests/tools/test_ruvsearch.py
@@ -13,7 +13,7 @@ from pharmpy.modeling import (
     set_iiv_on_ruv,
     transform_blq,
 )
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.ruvsearch.results import calculate_results, psn_resmod_results
 from pharmpy.tools.ruvsearch.tool import (
     _change_proportional_model,
@@ -32,8 +32,9 @@ from pharmpy.workflows import ModelEntry, Workflow
 
 
 def test_filter_dataset(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem/pheno_pd.mod')
-    res = read_modelfit_results(testdata / 'nonmem/pheno_pd.mod')
+    path = testdata / 'nonmem' / 'pheno_pd.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     indices = model.dataset.index[model.dataset['DVID'] == 2].tolist()
     model_entry = ModelEntry.create(model, modelfit_results=res)
     df = _create_dataset(model_entry, dv=2)
@@ -84,22 +85,25 @@ def test_resmod_results_dvid(testdata):
 
 
 def test_create_workflow_with_model(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model = load_model_for_test(path)
+    results = parse_modelfit_results(model, path)
     remove_parameter_uncertainty_step(model)
     assert isinstance(create_workflow(model=model, results=results), Workflow)
 
 
 def test_validate_input_with_model(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
+    path = testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     model = remove_parameter_uncertainty_step(model)
     validate_input(model=model, results=res)
 
 
 def test_create_dataset(load_model_for_test, testdata, tmp_path):
-    model = load_model_for_test(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
+    path = testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     model_entry = ModelEntry.create(model, modelfit_results=res)
     df = _create_dataset(model_entry, dv=None)
 
@@ -120,7 +124,7 @@ def test_create_dataset(load_model_for_test, testdata, tmp_path):
             f.write(mytab_new)
 
         model = load_model_for_test('mox3.mod')
-        res = read_modelfit_results('mox3.mod')
+        res = parse_modelfit_results(model, 'mox3.mod')
 
         model = transform_blq(model, method='m3', lloq=0.05)
         model_entry = ModelEntry.create(model, modelfit_results=res)
@@ -132,8 +136,9 @@ def test_create_dataset(load_model_for_test, testdata, tmp_path):
 
 
 def test_create_result_tables(load_model_for_test, testdata, model_entry_factory):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     model_1 = set_combined_error_model(model_start)
@@ -192,8 +197,9 @@ def test_change_proportional_model(load_model_for_test, testdata):
     ],
 )
 def test_create_models(load_model_for_test, testdata, func, kwargs, description, y_str):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
+    path = testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     me_base = _create_base_model(me_start, current_iteration=1, dv=None)
@@ -244,8 +250,9 @@ def test_create_models(load_model_for_test, testdata, func, kwargs, description,
 def test_create_best_model(
     load_model_for_test, testdata, model_entry_factory, func, kwargs, best_model_name_ref, y_str
 ):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
+    path = testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     model_base = _create_base_model(me_start, current_iteration=1, dv=None).model
@@ -267,8 +274,9 @@ def test_create_best_model(
 
 
 def test_create_best_model_no_best(load_model_for_test, testdata, model_entry_factory):
-    model_start = load_model_for_test(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
+    path = testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod'
+    model_start = load_model_for_test(path)
+    res_start = parse_modelfit_results(model_start, path)
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     model_base = _create_base_model(me_start, current_iteration=1, dv=None).model
@@ -380,7 +388,7 @@ def test_validate_input_raises(
         model_path = ('nonmem/ruvsearch/mox3.mod',)
     path = testdata.joinpath(*model_path)
     model = load_model_for_test(path)
-    res = read_modelfit_results(path)
+    res = parse_modelfit_results(model, path)
     kwargs = {'model': model, 'results': res, **arguments}
 
     with pytest.raises(exception, match=match):
@@ -388,8 +396,9 @@ def test_validate_input_raises(
 
 
 def test_validate_input_raises_cwres(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
+    path = testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     model = remove_parameter_uncertainty_step(model)
     modelfit_results = replace(res, residuals=res.residuals.drop(columns=['CWRES']))
 
@@ -398,8 +407,9 @@ def test_validate_input_raises_cwres(load_model_for_test, testdata):
 
 
 def test_validate_input_raises_cipredi(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
+    path = testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     model = remove_parameter_uncertainty_step(model)
     modelfit_results = replace(res, predictions=res.predictions.drop(columns=['CIPREDI']))
 
@@ -408,8 +418,9 @@ def test_validate_input_raises_cipredi(load_model_for_test, testdata):
 
 
 def test_validate_input_raises_ipred(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno_real.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno_real.mod')
+    path = testdata / 'nonmem' / 'pheno_real.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     model = remove_parameter_uncertainty_step(model)
     modelfit_results = replace(res, predictions=res.predictions.drop(columns=['IPRED']))
 
@@ -418,8 +429,9 @@ def test_validate_input_raises_ipred(load_model_for_test, testdata):
 
 
 def test_validate_input_raises_blq(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
+    path = testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
     model = transform_blq(model, method='m4', lloq=1.0)
 
     with pytest.raises(ValueError, match="BLQ"):
@@ -427,8 +439,9 @@ def test_validate_input_raises_blq(load_model_for_test, testdata):
 
 
 def test_validate_input_raises_dv(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod')
+    path = testdata / 'nonmem' / 'ruvsearch' / 'mox3.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
 
     with pytest.raises(ValueError, match="No DVID column"):
         validate_input(model=model, results=res, dv=1)

--- a/tests/tools/test_structsearch.py
+++ b/tests/tools/test_structsearch.py
@@ -12,7 +12,7 @@ from pharmpy.modeling import (
     set_description,
     set_name,
 )
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.structsearch.drugmetabolite import create_drug_metabolite_models
 from pharmpy.tools.structsearch.pkpd import create_pkpd_models
 from pharmpy.tools.structsearch.tmdd import (
@@ -134,9 +134,9 @@ def test_pkpd(load_model_for_test, testdata):
         "EFFECTCOMP([LINEAR,EMAX,SIGMOID]);"
         "INDIRECTEFFECT([LINEAR,EMAX,SIGMOID],*)"
     )
-    res = read_modelfit_results(testdata / "nonmem" / "pheno.mod")
-    ests = res.parameter_estimates
     model = load_model_for_test(testdata / "nonmem" / "pheno_pd.mod")
+    res = parse_modelfit_results(model, testdata / "nonmem" / "pheno.mod")
+    ests = res.parameter_estimates
     pkpd_models = create_pkpd_models(
         model, search_space, b_init=5.75, ests=ests, emax_init=2.0, ec50_init=1.0, met_init=0.5
     )
@@ -161,7 +161,7 @@ def test_pkpd(load_model_for_test, testdata):
 
 def test_drug_metabolite(load_model_for_test, testdata):
     model = load_model_for_test(testdata / "nonmem" / "pheno_pd.mod")
-    res = read_modelfit_results(testdata / "nonmem" / "pheno.mod")
+    res = parse_modelfit_results(model, testdata / "nonmem" / "pheno.mod")
     search_space = "METABOLITE([PSC, BASIC]);PERIPHERALS([0,1], MET)"
     wb, candidate_tasks, base_model_description = create_drug_metabolite_models(
         model, res, search_space
@@ -186,7 +186,7 @@ def test_categorize_drug_metabolite_model_entries(
     load_model_for_test, testdata, model_entry_factory
 ):
     model_start = load_model_for_test(testdata / "nonmem" / "pheno_pd.mod")
-    res_start = read_modelfit_results(testdata / "nonmem" / "pheno.mod")
+    res_start = parse_modelfit_results(model_start, testdata / "nonmem" / "pheno.mod")
     me_start = ModelEntry(model_start, modelfit_results=res_start)
 
     base_description = 'base'
@@ -228,19 +228,19 @@ def test_categorize_drug_metabolite_model_entries(
 
 def test_create_workflow_pkpd(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno_pd.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno_pd.mod')
+    results = parse_modelfit_results(model, testdata / 'nonmem' / 'pheno_pd.mod')
     assert isinstance(create_workflow(model=model, results=results, type='pkpd'), Workflow)
 
 
 def test_create_workflow_tmdd(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno_pd.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno_pd.mod')
+    results = parse_modelfit_results(model, testdata / 'nonmem' / 'pheno_pd.mod')
     assert isinstance(create_workflow(model=model, results=results, type='tmdd'), Workflow)
 
 
 def test_create_workflow_drug_metabolite(load_model_for_test, testdata):
     model = load_model_for_test(testdata / 'nonmem' / 'pheno_pd.mod')
-    results = read_modelfit_results(testdata / 'nonmem' / 'pheno_pd.mod')
+    results = parse_modelfit_results(model, testdata / 'nonmem' / 'pheno_pd.mod')
     assert isinstance(
         create_workflow(model=model, results=results, type='drug_metabolite'), Workflow
     )
@@ -248,7 +248,7 @@ def test_create_workflow_drug_metabolite(load_model_for_test, testdata):
 
 def test_create_result_tables(load_model_for_test, testdata, model_entry_factory):
     model_start = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res_start = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    res_start = parse_modelfit_results(model_start, testdata / 'nonmem' / 'pheno.mod')
     me_start = ModelEntry.create(model_start, modelfit_results=res_start)
 
     qss_models = create_qss_models(model_start, res_start.parameter_estimates, None)
@@ -353,7 +353,7 @@ def test_validation(tmp_path, load_model_for_test, testdata, arguments, exceptio
     if "extra_model" in kwargs.keys():
         kwargs["extra_model"] = model
     if "extra_model_results" in kwargs.keys():
-        res = read_modelfit_results(testdata / "nonmem" / "pheno.mod")
+        res = parse_modelfit_results(model, testdata / "nonmem" / "pheno.mod")
         kwargs["extra_model_results"] = res
 
     if exception is not None:

--- a/tests/tools/test_summarize_individuals.py
+++ b/tests/tools/test_summarize_individuals.py
@@ -5,8 +5,7 @@ import packaging
 import pytest
 
 from pharmpy.deps import pandas as pd
-from pharmpy.modeling import read_model
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.tools.funcs import summarize_individuals, summarize_individuals_count_table
 from pharmpy.tools.funcs.summarize_individuals import dofv
 from pharmpy.workflows import ModelEntry
@@ -46,10 +45,9 @@ tflite_condition = (
 
 
 @pytest.mark.skipif(tflite_condition, reason="Skipping tests requiring tflite for Python 3.12")
-def test_tflite_not_installed(pheno_path, monkeypatch):
-    model = read_model(pheno_path)
-    results = read_modelfit_results(pheno_path)
-    me = ModelEntry(model=model, modelfit_results=results)
+def test_tflite_not_installed(pheno, pheno_path, monkeypatch):
+    results = parse_modelfit_results(pheno, pheno_path)
+    me = ModelEntry(model=pheno, modelfit_results=results)
 
     df = summarize_individuals([me])
     assert not df['predicted_dofv'].isnull().any().any()
@@ -59,19 +57,19 @@ def test_tflite_not_installed(pheno_path, monkeypatch):
     assert df['predicted_dofv'].isnull().all().all()
 
 
-def test_dofv_parent_model_is_none(pheno_path):
-    res = read_modelfit_results(pheno_path)
+def test_dofv_parent_model_is_none(pheno, pheno_path):
+    res = parse_modelfit_results(pheno, pheno_path)
     res = dofv(None, res)
     assert np.isnan(res)
 
 
-def test_dofv_modelfit_results_is_none(pheno_path):
-    parent_res = read_modelfit_results(pheno_path)
+def test_dofv_modelfit_results_is_none(pheno, pheno_path):
+    parent_res = parse_modelfit_results(pheno, pheno_path)
     res = dofv(parent_res, None)
     assert res.isna().all()
 
 
-def test_dofv_individual_ofv_is_none(pheno_path):
-    parent_res = read_modelfit_results(pheno_path)
+def test_dofv_individual_ofv_is_none(pheno, pheno_path):
+    parent_res = parse_modelfit_results(pheno, pheno_path)
     res = dofv(parent_res, ModelfitResults())
     assert res.isna().all()

--- a/tests/workflows/test_model_database.py
+++ b/tests/workflows/test_model_database.py
@@ -8,7 +8,7 @@ import pytest
 
 from pharmpy.internals.fs.cwd import chdir
 from pharmpy.modeling import add_time_after_dose
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.workflows import (
     LocalDirectoryDatabase,
     LocalModelDirectoryDatabase,
@@ -107,7 +107,7 @@ def test_store_and_retrieve_model_entry(tmp_path, load_model_for_test, testdata)
             shutil.copy2(path, tmp_path)
         shutil.copy(datadir / 'pheno.dta', 'pheno.dta')
         model = load_model_for_test("pheno_real.mod")
-        modelfit_results = read_modelfit_results("pheno_real.mod")
+        modelfit_results = parse_modelfit_results(model, "pheno_real.mod")
         model_entry = ModelEntry(
             model=model,
             modelfit_results=modelfit_results,

--- a/tests/workflows/test_model_entry.py
+++ b/tests/workflows/test_model_entry.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pharmpy.tools import read_modelfit_results
+from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.workflows import ModelEntry
 
 
@@ -12,8 +12,9 @@ def test_model_entry_init(load_model_for_test, testdata):
 
 
 def test_model_entry_create(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
 
     model_entry = ModelEntry.create(model)
     assert model_entry.model.name == model.name
@@ -30,8 +31,9 @@ def test_model_entry_create(load_model_for_test, testdata):
 
 
 def test_attach_results(load_model_for_test, testdata):
-    model = load_model_for_test(testdata / 'nonmem' / 'pheno.mod')
-    res = read_modelfit_results(testdata / 'nonmem' / 'pheno.mod')
+    path = testdata / 'nonmem' / 'pheno.mod'
+    model = load_model_for_test(path)
+    res = parse_modelfit_results(model, path)
 
     model_entry = ModelEntry(model)
     assert model_entry.model.name == model.name


### PR DESCRIPTION
By using `parse_modelfit_results` instead of `read_modelfit_results`.

This reduces tests running time by ~20% on 8 worker threads.