### PR TITLE
Fix `parse_model` when `dataset is not None`

### DIFF
--- a/src/pharmpy/model/external/nonmem/model.py
+++ b/src/pharmpy/model/external/nonmem/model.py
@@ -357,7 +357,8 @@ def parse_model(
         di = di.replace(missing_data_token=missing_data_token)
 
     try:
-        dataset = parse_dataset(di, control_stream, raw=False)
+        if di.path is not None:
+            dataset = parse_dataset(di, control_stream, raw=False)
     except FileNotFoundError:
         pass
 


### PR DESCRIPTION
Before, an attempt would be made at reading the file `None`.