### PR TITLE
Handle variable-width NONMEM data input (alternative)

### DIFF
--- a/src/pharmpy/model/external/nonmem/dataset/nmtran.py
+++ b/src/pharmpy/model/external/nonmem/dataset/nmtran.py
@@ -111,7 +111,7 @@ def _stream_NMTRAN(path_or_io: Union[str, Path, TextIO]):
 
 
 @contextmanager
-def NMTRANDataIO(
+def NMTRANDataLines(
     path_or_io: Union[str, Path, TextIO],
     sep: re.Pattern[str],
     ignore_character: Optional[str] = None,
@@ -122,7 +122,7 @@ def NMTRANDataIO(
     ignore = _ignore(ignore_character)
 
     with _stream_NMTRAN(path_or_io) as stream:
-        yield IOFromChunks(map(str.encode, NMTRANStreamIterator(stream, sep, ignore)))
+        yield NMTRANStreamIterator(stream, sep, ignore)
 
 
 def read_NMTRAN_data(io: IOFromChunks, **kwargs: Any) -> pd.DataFrame:

--- a/tests/nonmem/test_read.py
+++ b/tests/nonmem/test_read.py
@@ -7,7 +7,7 @@ from pharmpy.deps import pandas as pd
 from pharmpy.model import DatasetError, DatasetWarning
 from pharmpy.model.external.nonmem.dataset import read_nonmem_dataset
 from pharmpy.model.external.nonmem.dataset.convert import convert_fortran_number
-from pharmpy.model.external.nonmem.dataset.nmtran import SEP_INPUT, NMTRANDataIO
+from pharmpy.model.external.nonmem.dataset.nmtran import SEP_INPUT, IOFromChunks, NMTRANDataLines
 
 
 def test_read_nonmem_dataset(testdata):
@@ -39,19 +39,22 @@ def test_read_nonmem_dataset(testdata):
 
 def test_data_io_alpha(testdata):
     path = testdata / 'nonmem' / 'pheno.dta'
-    with NMTRANDataIO(path, SEP_INPUT, '@') as data_io:
+    with NMTRANDataLines(path, SEP_INPUT, '@') as lines:
+        data_io = IOFromChunks(map(str.encode, lines))
         assert data_io.read(7) == b'1,0.,25'
 
 
 def test_data_io_i(testdata):
     path = testdata / 'nonmem' / 'pheno.dta'
-    with NMTRANDataIO(path, SEP_INPUT, 'I') as data_io:
+    with NMTRANDataLines(path, SEP_INPUT, 'I') as lines:
+        data_io = IOFromChunks(map(str.encode, lines))
         assert data_io.read(13) == b'1,0.,25.0,1.4'
 
 
 def test_data_io_q(testdata):
     path = testdata / 'nonmem' / 'pheno.dta'
-    with NMTRANDataIO(path, SEP_INPUT, 'Q') as data_io:
+    with NMTRANDataLines(path, SEP_INPUT, 'Q') as lines:
+        data_io = IOFromChunks(map(str.encode, lines))
         assert data_io.read(5) == b'ID,TI'
 
 
@@ -171,7 +174,7 @@ def test_read_nonmem_dataset_header_too_short_raw():
     assert list(df.iloc[0]) == ['1', '2', '3']
     assert list(df.iloc[1]) == ['4', '5', '']
     assert list(df.iloc[2]) == ['6', '7', '8']
-    assert list(df.columns) == ['A', None, None]
+    assert list(df.columns) == ['A', 'Unnamed: 1', 'Unnamed: 2']
     assert list(df.dtypes) == [
         np.dtype('O'),
         np.dtype('O'),
@@ -202,7 +205,7 @@ def test_nonmem_dataset_variable_width_long_then_short_raw():
     assert list(df.iloc[1]) == ['4', '5', '']
     assert list(df.iloc[2]) == ['6', '', '']
     assert list(df.iloc[3]) == ['7', '8', '9']
-    assert list(df.columns) == ['ID', 'DV', None]
+    assert list(df.columns) == ['ID', 'DV', 'Unnamed: 2']
     assert list(df.dtypes) == [
         np.dtype('O'),
         np.dtype('O'),
@@ -212,38 +215,92 @@ def test_nonmem_dataset_variable_width_long_then_short_raw():
 
 def test_nonmem_dataset_variable_width_short_then_long_1():
     colnames = ['ID', 'DV']
-    with pytest.raises(pd.errors.ParserError):
-        read_nonmem_dataset(StringIO("1\n2,3,DATE TIME\n5,6\n7,8,9"), colnames=colnames)
+    with pytest.warns(UserWarning):
+        df = read_nonmem_dataset(StringIO("1\n2,3,DATE TIME\n5,6\n7,8,9"), colnames=colnames)
+    assert len(df) == 4
+    assert list(df.iloc[0]) == [1, 0.0]
+    assert list(df.iloc[1]) == [2, 3.0]
+    assert list(df.iloc[2]) == [5, 6.0]
+    assert list(df.iloc[3]) == [7, 8.0]
+    assert list(df.columns) == ['ID', 'DV']
+    assert list(df.dtypes) == [
+        np.dtype('int32'),
+        np.dtype('float64'),
+    ]
 
 
 def test_nonmem_dataset_variable_width_short_then_long_2():
     colnames = ['ID', 'DV']
-    with pytest.raises(pd.errors.ParserError):
-        read_nonmem_dataset(StringIO("1,2,3\n4,5,6 7\n8"), colnames=colnames)
+    df = read_nonmem_dataset(StringIO("1,2,3\n4,5,6 7\n8"), colnames=colnames)
+    assert len(df) == 3
+    assert list(df.iloc[0]) == [1, 2.0]
+    assert list(df.iloc[1]) == [4, 5.0]
+    assert list(df.iloc[2]) == [8, 0.0]
+    assert list(df.columns) == ['ID', 'DV']
+    assert list(df.dtypes) == [
+        np.dtype('int32'),
+        np.dtype('float64'),
+    ]
 
 
 def test_nonmem_dataset_variable_width_short_then_long_3():
     colnames = ['ID', 'DV']
-    with pytest.raises(pd.errors.ParserError):
-        read_nonmem_dataset(StringIO("1,2,3\n4\t5\n6\n7 8,9 #! @"), colnames=colnames)
+    df = read_nonmem_dataset(StringIO("1,2,3\n4\t5\n6\n7 8,9 #! @"), colnames=colnames)
+    assert len(df) == 4
+    assert list(df.iloc[0]) == [1, 2.0]
+    assert list(df.iloc[1]) == [4, 5.0]
+    assert list(df.iloc[2]) == [6, 0.0]
+    assert list(df.iloc[3]) == [7, 8.0]
+    assert list(df.columns) == ['ID', 'DV']
+    assert list(df.dtypes) == [
+        np.dtype('int32'),
+        np.dtype('float64'),
+    ]
 
 
 def test_nonmem_dataset_variable_width_short_then_long_raw_1():
     colnames = ['ID', 'DV']
-    with pytest.raises(pd.errors.ParserError):
-        read_nonmem_dataset(StringIO("2,3,4\n5,6\t7 8,9"), colnames=colnames, raw=True)
+    df = read_nonmem_dataset(StringIO("2,3,4\n5,6\t7 8,9"), colnames=colnames, raw=True)
+    assert len(df) == 2
+    assert list(df.iloc[0]) == ['2', '3', '4']
+    assert list(df.iloc[1]) == ['5', '6', '7']
+    assert list(df.columns) == ['ID', 'DV', 'Unnamed: 2']
+    assert list(df.dtypes) == [
+        np.dtype('O'),
+        np.dtype('O'),
+        np.dtype('O'),
+    ]
 
 
 def test_nonmem_dataset_variable_width_short_then_long_raw_2():
     colnames = ['ID', 'DV']
-    with pytest.raises(pd.errors.ParserError):
-        read_nonmem_dataset(StringIO("1 2 3\n4\t5\n6 7 8 9 @ @"), colnames=colnames, raw=True)
+    df = read_nonmem_dataset(StringIO("1 2 3\n4\t5\n6 7 8 9 @ @"), colnames=colnames, raw=True)
+    assert len(df) == 3
+    assert list(df.iloc[0]) == ['1', '2', '3']
+    assert list(df.iloc[1]) == ['4', '5', '']
+    assert list(df.iloc[2]) == ['6', '7', '8']
+    assert list(df.columns) == ['ID', 'DV', 'Unnamed: 2']
+    assert list(df.dtypes) == [
+        np.dtype('O'),
+        np.dtype('O'),
+        np.dtype('O'),
+    ]
 
 
 def test_nonmem_dataset_variable_width_short_then_long_raw_3():
     colnames = ['ID', 'DV']
-    with pytest.raises(pd.errors.ParserError):
-        read_nonmem_dataset(StringIO("1,2,3\n4,5\n6\n7,8,9,@"), colnames=colnames, raw=True)
+    df = read_nonmem_dataset(StringIO("1,2,3\n4,5\n6\n7,8,9,@"), colnames=colnames, raw=True)
+    assert len(df) == 4
+    assert list(df.iloc[0]) == ['1', '2', '3']
+    assert list(df.iloc[1]) == ['4', '5', '']
+    assert list(df.iloc[2]) == ['6', '', '']
+    assert list(df.iloc[3]) == ['7', '8', '9']
+    assert list(df.columns) == ['ID', 'DV', 'Unnamed: 2']
+    assert list(df.dtypes) == [
+        np.dtype('O'),
+        np.dtype('O'),
+        np.dtype('O'),
+    ]
 
 
 def test_nonmem_dataset_variable_width_long_then_short_drop():
@@ -284,18 +341,37 @@ def test_nonmem_dataset_variable_width_long_then_short_drop_raw():
 
 def test_nonmem_dataset_variable_width_short_then_long_drop():
     colnames = ['ID', 'DV', 'WT']
-    with pytest.raises(pd.errors.ParserError):
-        read_nonmem_dataset(
+    with pytest.warns(UserWarning):
+        df = read_nonmem_dataset(
             StringIO("1\n2,3,4\n5,6\n7,8,9"), colnames=colnames, drop=[False, True, False]
         )
+    assert len(df) == 4
+    assert list(df.iloc[0]) == [1, '', 0.0]
+    assert list(df.iloc[1]) == [2, '3', 4.0]
+    assert list(df.iloc[2]) == [5, '6', 0.0]
+    assert list(df.iloc[3]) == [7, '8', 9.0]
+    assert list(df.columns) == ['ID', 'DV', 'WT']
+    assert list(df.dtypes) == [
+        np.dtype('int32'),
+        np.dtype('O'),
+        np.dtype('float64'),
+    ]
 
 
 def test_nonmem_dataset_variable_width_short_then_long_drop_raw():
     colnames = ['ID', 'DV', 'WT']
-    with pytest.raises(pd.errors.ParserError):
-        read_nonmem_dataset(
-            StringIO("2,3,4\n5,6,7,8,9"), colnames=colnames, raw=True, drop=[False, True, False]
-        )
+    df = read_nonmem_dataset(
+        StringIO("2,3,4\n5,6,7,8,9"), colnames=colnames, raw=True, drop=[False, True, False]
+    )
+    assert len(df) == 2
+    assert list(df.iloc[0]) == ['2', '3', '4']
+    assert list(df.iloc[1]) == ['5', '6', '7']
+    assert list(df.columns) == ['ID', 'DV', 'WT']
+    assert list(df.dtypes) == [
+        np.dtype('O'),
+        np.dtype('O'),
+        np.dtype('O'),
+    ]
 
 
 def test_read_nonmem_dataset_null_value():


### PR DESCRIPTION
- Alternative to #4133.
- The first commit adds some test to highlight the state of the implementation before changes: https://github.com/pharmpy/pharmpy/pull/4136/commits/0c5cf58377d3eb389763c4a6c17c5ff51480786d
- The last commit includes test updates that highlight the support increase for variable-width NONMEM data input:
https://github.com/pharmpy/pharmpy/pull/4136/commits/934a9781c25c0413ca12184534876be4d3f3e540#diff-c1af32fe1cbaf257c3c7ba939a2f3008aba014434eec49b7a39d958ff0b1c3fe
- Measured no significant difference in data parsing speed.