### PR TITLE
Speed up handling of ignored tokens in record parsers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'pharmacometrics',
     ],
     install_requires=[
-        'lark>=1.1.4',
+        'lark>=1.1.7',
         'sympy>=1.9',
         'symengine>=0.13.0',
         'pandas>=1.4, !=2.1.0',

--- a/src/pharmpy/internals/parse/ignored.py
+++ b/src/pharmpy/internals/parse/ignored.py
@@ -1,4 +1,3 @@
-from importlib.metadata import version
 from typing import Iterable, Iterator, List, Union
 
 from lark import Token, Transformer, Tree
@@ -49,8 +48,6 @@ def _item_range(x: Union[Tree, Token]) -> tuple[int, int]:
     if isinstance(x, Tree):
         i = x.meta.start_pos
         j = x.meta.end_pos
-        if version('lark') == '1.1.6':
-            j = _get_new_end_pos(x)
     else:
         i = x.start_pos
         j = x.end_pos
@@ -58,16 +55,6 @@ def _item_range(x: Union[Tree, Token]) -> tuple[int, int]:
     assert isinstance(i, int)
     assert isinstance(j, int)
     return (i, j)
-
-
-def _get_new_end_pos(x) -> int:
-    # FIXME: Temporary workaround, see https://github.com/lark-parser/lark/issues/1304
-    x = x.children[-1]
-    if isinstance(x, Token):
-        endpos = x.end_pos
-        assert isinstance(endpos, int)
-        return endpos
-    return _get_new_end_pos(x)
 
 
 def _interleave_ignored(source: str, it: Iterator[Union[Tree, Token]]):
@@ -108,9 +95,6 @@ class InterleaveIgnored(Transformer):
 
 def with_ignored_tokens(source, tree):
     new_tree = InterleaveIgnored(source).transform(tree)
-
-    if version('lark') == '1.1.6' and new_tree.children:
-        new_tree.meta.end_pos = _get_new_end_pos(new_tree)
 
     final_meta = Meta()
     # TODO: Propagate line/column information


### PR DESCRIPTION
This is simply a matter of reverting the temporary fix for lark 1.1.6 introduced in the following commits:
  - f8c27609a Temporary fix for lark 1.1.6 (see #1872)
  - fedc5abce Temporary fix for lark 1.1.6 (ctd.) (see #1872)
    - Comment: https://github.com/pharmpy/pharmpy/commit/fedc5abce6d94628260bf58b2a498a408b3a6423#commitcomment-170823891

The issue was addressed in lark 1.1.7:
  - https://github.com/lark-parser/lark/issues/1304#issuecomment-1644469611
  - https://github.com/lark-parser/lark/pull/1305
    - https://github.com/lark-parser/lark/pull/1305/commits/5961d720fb26a6632868bd1e783be93c0e57ea52