### PR TITLE
Cache expensive property `CompartmentalSystem#eqs`

### DIFF
--- a/src/pharmpy/model/statements.py
+++ b/src/pharmpy/model/statements.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
+from functools import cached_property
 from typing import Any, Optional, Self, Union, overload
 
 import pharmpy.internals.unicode as unicode
@@ -718,7 +719,7 @@ class CompartmentalSystem(Statement):
         """Independent variable of CompartmentalSystem"""
         return self._t
 
-    @property
+    @cached_property
     def eqs(self) -> tuple[BooleanExpr, ...]:
         """Tuple of equations"""
         amount_funcs = Matrix(list(self.amounts))


### PR DESCRIPTION
Some timings:

**main** (bb7e69466)

```console
$ tox -e unit-profile -- -n0 -s tests/modeling/test_expressions.py::test_get_pk_parameters
...
         34571208 function calls (32150873 primitive calls) in 11.914 seconds

   Ordered by: cumulative time
   List reduced from 3392 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       68    0.000    0.000   11.944    0.176 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:115(pytest_runtest_protocol)
       68    0.001    0.000   11.927    0.175 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:123(runtestprotocol)
      204    0.001    0.000   11.926    0.058 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:231(call_and_report)
 1437/748    0.002    0.000   11.925    0.016 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pluggy/_hooks.py:497(__call__)
 1437/748    0.001    0.000   11.923    0.016 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pluggy/_manager.py:111(_hookexec)
 1437/748    0.007    0.000   11.922    0.016 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pluggy/_callers.py:76(_multicall)
      204    0.001    0.000   11.904    0.058 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:332(from_call)
      204    0.000    0.000   11.901    0.058 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:245(<lambda>)
       68    0.000    0.000   11.846    0.174 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:168(pytest_runtest_call)
       68    0.000    0.000   11.845    0.174 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/python.py:1718(runtest)
       68    0.001    0.000   11.843    0.174 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/python.py:159(pytest_pyfunc_call)
       68    0.002    0.000   11.841    0.174 /workspaces/pharmpy/tests/modeling/test_expressions.py:418(test_get_pk_parameters)
      116    0.004    0.000    6.483    0.056 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/modeling/expressions.py:1579(get_pk_parameters)
      116    0.004    0.000    5.223    0.045 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/modeling/expressions.py:791(get_individual_parameters)
      616    0.024    0.000    5.035    0.008 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/model/external/nonmem/model.py:134(update_source)
       68    0.001    0.000    4.366    0.064 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/modeling/pd.py:28(add_effect_compartment)
       48    0.000    0.000    3.790    0.079 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/modeling/pd.py:298(_add_effect)
      444    0.010    0.000    3.607    0.008 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/model/statements.py:721(eqs)
      616    0.026    0.000    3.605    0.006 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/model/external/nonmem/update.py:705(update_statements)
      116    0.010    0.000    3.306    0.029 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/modeling/expressions.py:901(_cut_partial_odes)
```
<img width="1241" height="1083" alt="Screenshot 2025-11-20 at 13 12 44" src="https://github.com/user-attachments/assets/5aeb6502-db3a-4995-bc8b-b30986e0e487" />

![main](https://github.com/user-attachments/assets/221fc123-d23a-4ec3-ab6a-409a333a0a68)


**king-of-poppk:perf-comparmental-system-eqs-1** (4447f5e27)

```console
$ tox -e unit-profile -- -n0 -s tests/modeling/test_expressions.py::test_get_pk_parameters
...
         28295976 function calls (26328817 primitive calls) in 9.851 seconds

   Ordered by: cumulative time
   List reduced from 3393 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       68    0.000    0.000    9.882    0.145 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:115(pytest_runtest_protocol)
       68    0.001    0.000    9.866    0.145 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:123(runtestprotocol)
      204    0.001    0.000    9.865    0.048 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:231(call_and_report)
 1437/748    0.002    0.000    9.863    0.013 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pluggy/_hooks.py:497(__call__)
 1437/748    0.001    0.000    9.861    0.013 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pluggy/_manager.py:111(_hookexec)
 1437/748    0.007    0.000    9.861    0.013 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pluggy/_callers.py:76(_multicall)
      204    0.001    0.000    9.842    0.048 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:332(from_call)
      204    0.000    0.000    9.839    0.048 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:245(<lambda>)
       68    0.000    0.000    9.782    0.144 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/runner.py:168(pytest_runtest_call)
       68    0.000    0.000    9.782    0.144 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/python.py:1718(runtest)
       68    0.001    0.000    9.779    0.144 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/_pytest/python.py:159(pytest_pyfunc_call)
       68    0.003    0.000    9.777    0.144 /workspaces/pharmpy/tests/modeling/test_expressions.py:418(test_get_pk_parameters)
      116    0.004    0.000    4.924    0.042 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/modeling/expressions.py:1579(get_pk_parameters)
      616    0.025    0.000    4.630    0.008 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/model/external/nonmem/model.py:134(update_source)
       68    0.001    0.000    3.899    0.057 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/modeling/pd.py:28(add_effect_compartment)
      116    0.004    0.000    3.656    0.032 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/modeling/expressions.py:791(get_individual_parameters)
       48    0.000    0.000    3.313    0.069 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/modeling/pd.py:298(_add_effect)
      616    0.026    0.000    3.178    0.005 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/model/external/nonmem/update.py:705(update_statements)
      144    0.001    0.000    2.561    0.018 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/modeling/odes.py:108(add_individual_parameter)
      192    0.001    0.000    2.022    0.011 /workspaces/pharmpy/.tox/unit-profile/lib/python3.12/site-packages/pharmpy/modeling/parameters.py:666(add_population_parameter)
```


<img width="1661" height="1210" alt="Screenshot 2025-11-20 at 13 07 25" src="https://github.com/user-attachments/assets/f91c8a66-2ee0-4906-a868-4f6503bde855" />

![king-of-poppk:perf-comparmental-system-eqs-1](https://github.com/user-attachments/assets/e60a57a5-b8e5-450f-898b-3508d7c2d60c)


