### PR TITLE
Support verbatim in `IF` branches and `DO WHILE` bodies in code records (NONMEM parsing)

### DIFF
--- a/src/pharmpy/model/external/nonmem/records/grammars/code_record.lark
+++ b/src/pharmpy/model/external/nonmem/records/grammars/code_record.lark
@@ -45,7 +45,7 @@ _sep: ","
 
 _condition: _lpar bool_expr _rpar
 
-while: DOWHILE _condition _empty_lines _statements? ENDDO
+while: DOWHILE _condition _empty_lines _statements_and_verbatims? ENDDO
 
 block_if: block_if_start (block_if_elseif)* (block_if_else)? block_if_end
 block_if_start: IF _condition THEN _empty_lines _statements_and_verbatims?

--- a/tests/nonmem/records/test_code.py
+++ b/tests/nonmem/records/test_code.py
@@ -277,6 +277,7 @@ ENDIF''',
                 (S('NINDR') * (S('IREP') - 1) + 1, sympy.Eq(sympy.Function('newind')(), 0))
             ),
         ),
+        ('$PK\n Y = 10\nDO WHILE (Y > 0)\n" VERBATIME "!"\n Y = Y - 1 \nEND DO', S('Y'), 10),
     ],
 )
 def test_single_assignments(parser, buf, sym, expression):


### PR DESCRIPTION
- Fixes #4155.