### PR TITLE
Cache expensive properties of `RandomVariables` instances

### DIFF
--- a/src/pharmpy/basic/matrix.py
+++ b/src/pharmpy/basic/matrix.py
@@ -11,11 +11,13 @@ from .expr import Expr
 
 
 class Matrix:
-    def __init__(self, source: Union[sympy.Matrix, symengine.Matrix, Matrix, Iterable] = ()):
+    def __init__(
+        self, source: Union[sympy.ImmutableMatrix, symengine.ImmutableMatrix, Matrix, Iterable] = ()
+    ):
         if isinstance(source, Matrix):
             self._m = source._m
         else:
-            self._m = symengine.Matrix(source)
+            self._m = symengine.ImmutableMatrix(source)
 
     @overload
     def __getitem__(self, ind: tuple[int, int]) -> Expr: ...
@@ -39,7 +41,7 @@ class Matrix:
 
     def __getitem__(self, ind) -> Union[Expr, Matrix]:
         a = self._m[ind]
-        if isinstance(a, symengine.DenseMatrix):
+        if isinstance(a, symengine.ImmutableDenseMatrix):
             return Matrix(a)
         else:
             return Expr(a)
@@ -95,7 +97,7 @@ class Matrix:
         return len(self._m)
 
     def __hash__(self):
-        return hash(sympy.ImmutableMatrix(self._m))
+        return hash(self._m)
 
     def __add__(self, other) -> Matrix:
         other = self._convert_input(other)
@@ -154,14 +156,14 @@ class Matrix:
         if is_symmetric and self._each_entry_is_a_symbol():
             return None
 
-        isp = sympy.Matrix(self._m).is_positive_semidefinite
+        isp = sympy.ImmutableMatrix(self._m).is_positive_semidefinite
         return isp
 
     def _each_entry_is_a_symbol(self) -> bool:
         return all(map(lambda s: isinstance(s, symengine.Symbol), self._m))
 
     def eigenvals(self) -> dict[Expr, Expr]:
-        d = sympy.Matrix(self._m).eigenvals()
+        d = sympy.ImmutableMatrix(self._m).eigenvals()
         assert isinstance(d, dict)
         ud = {Expr(key): Expr(val) for key, val in d.items()}
         return ud
@@ -174,11 +176,11 @@ class Matrix:
 
     def __getstate__(self):
         state = self.__dict__.copy()
-        state['_m'] = sympy.Matrix(self._m)
+        state['_m'] = sympy.ImmutableMatrix(self._m)
         return state
 
     def __setstate__(self, state):
-        state['_m'] = symengine.Matrix(state['_m'])
+        state['_m'] = symengine.ImmutableMatrix(state['_m'])
         self.__dict__.update(state)
 
     def to_numpy(self) -> np.ndarray:

--- a/src/pharmpy/model/external/nonmem/model.py
+++ b/src/pharmpy/model/external/nonmem/model.py
@@ -180,7 +180,7 @@ class Model(BaseModel):
                     rv_trans[name] = f'ETA({i})'
                 i += 1
 
-        if model._random_variables.etas.names != ['eta_dummy']:
+        if model._random_variables.etas.names != ('eta_dummy',):
             model, abbr_map = abbr_translation(model, rv_trans)
             trans = {key: value for key, value in trans.items() if key not in abbr_map.values()}
 

--- a/src/pharmpy/model/model.py
+++ b/src/pharmpy/model/model.py
@@ -222,10 +222,10 @@ class Model(Immutable):
             if not symbs.issubset(symbs_all):
                 # E.g. after solve_ode_system
                 if statement.symbol.is_function():
-                    symbs_all.add(Expr.symbol(statement.symbol.name))
-                    for arg in statement.symbol.args:
-                        if arg.is_symbol():
-                            symbs_all.add(arg)
+                    symbs_all = symbs_all.union(
+                        (Expr.symbol(statement.symbol.name),),
+                        (arg for arg in statement.symbol.args if arg.is_symbol()),
+                    )
 
                 for symb in symbs:
                     if symb in symbs_all:

--- a/src/pharmpy/modeling/expressions.py
+++ b/src/pharmpy/modeling/expressions.py
@@ -249,12 +249,12 @@ def create_symbol(model: Model, stem: str, force_numbering: bool = False):
 
 
 def _create_symbol(statements, parameters, random_variables, datainfo, stem, force_numbering):
-    symbols = [str(symbol) for symbol in statements.free_symbols]
-    params = [param.name for param in parameters]
+    symbols = (str(symbol) for symbol in statements.free_symbols)
+    params = (param.name for param in parameters)
     rvs = random_variables.names
     dataset_col = datainfo.names
 
-    all_names = symbols + params + rvs + dataset_col
+    all_names = {*symbols, *params, *rvs, *dataset_col}
 
     if str(stem) not in all_names and not force_numbering:
         return Expr(str(stem))

--- a/src/pharmpy/tools/qa/results.py
+++ b/src/pharmpy/tools/qa/results.py
@@ -282,7 +282,7 @@ def calc_add_etas(original_model_entry, add_etas_model_entry, etas_added_to):
         return None, dofv_tab
     origres = original_model_entry.modelfit_results
     original_etas = original_model_entry.model.random_variables.etas.names
-    all_etas = original_etas + etas_added_to
+    all_etas = [*original_etas, *etas_added_to]
     added = [True] * len(original_etas) + [False] * len(etas_added_to)
     params = add_etas_model_entry.model.random_variables.etas.variance_parameters
     params = [Expr.symbol(p) for p in params]

--- a/tests/model/test_random_variables.py
+++ b/tests/model/test_random_variables.py
@@ -281,7 +281,7 @@ def test_names():
     dist1 = NormalDistribution.create('ETA1', 'iiv', 0, 1)
     dist2 = NormalDistribution.create('ETA2', 'iiv', 0, 0.1)
     rvs = RandomVariables.create([dist1, dist2])
-    assert rvs.names == ['ETA1', 'ETA2']
+    assert rvs.names == ('ETA1', 'ETA2')
 
 
 def test_epsilons():
@@ -290,7 +290,7 @@ def test_epsilons():
     dist3 = NormalDistribution.create('EPS', 'ruv', 0, 0.1)
     rvs = RandomVariables.create([dist1, dist2, dist3])
     assert rvs.epsilons == RandomVariables.create([dist3])
-    assert rvs.epsilons.names == ['EPS']
+    assert rvs.epsilons.names == ('EPS',)
 
 
 def test_etas():
@@ -299,7 +299,7 @@ def test_etas():
     dist3 = NormalDistribution.create('EPS', 'ruv', 0, 0.1)
     rvs = RandomVariables.create([dist1, dist2, dist3])
     assert rvs.etas == RandomVariables.create([dist1, dist2])
-    assert rvs.etas.names == ['ETA', 'ETA2']
+    assert rvs.etas.names == ('ETA', 'ETA2')
 
 
 def test_iiv_iov():
@@ -308,9 +308,9 @@ def test_iiv_iov():
     dist3 = NormalDistribution.create('EPS', 'ruv', 0, 0.1)
     rvs = RandomVariables.create([dist1, dist2, dist3])
     assert rvs.iiv == RandomVariables.create([dist1])
-    assert rvs.iiv.names == ['ETA']
+    assert rvs.iiv.names == ('ETA',)
     assert rvs.iov == RandomVariables.create([dist2])
-    assert rvs.iov.names == ['ETA2']
+    assert rvs.iov.names == ('ETA2',)
 
 
 def test_subs():
@@ -336,7 +336,7 @@ def test_subs():
         [[symbol('x'), symbol('OMEGA21')], [symbol('OMEGA21'), symbol('OMEGA22')]]
     )
     assert rvs['ETA3'].variance == symbol('y')
-    assert rvs.names == ['ETA1', 'w', 'ETA3']
+    assert rvs.names == ('ETA1', 'w', 'ETA3')
     dist3 = dist2.subs({'ETA3': 'X'})
     assert dist3.names == ('X',)
 
@@ -571,12 +571,12 @@ def test_variance_parameters():
     )
     dist2 = NormalDistribution.create('ETA(3)', 'iiv', 0, symbol('OMEGA(3,3)'))
     rvs = RandomVariables.create([dist1, dist2])
-    assert rvs.variance_parameters == ['OMEGA(1,1)', 'OMEGA(2,2)', 'OMEGA(3,3)']
+    assert rvs.variance_parameters == ('OMEGA(1,1)', 'OMEGA(2,2)', 'OMEGA(3,3)')
 
     dist1 = NormalDistribution.create('x', 'iiv', 0, symbol('omega'))
     dist2 = NormalDistribution.create('y', 'iiv', 0, symbol('omega'))
     rvs = RandomVariables.create([dist1, dist2])
-    assert rvs.variance_parameters == ['omega']
+    assert rvs.variance_parameters == ('omega',)
 
     dist3 = JointNormalDistribution.create(
         ['ETA(1)', 'ETA(2)'],
@@ -588,7 +588,7 @@ def test_variance_parameters():
         ],
     )
     rvs = RandomVariables.create([dist3])
-    assert rvs.variance_parameters == ['OMEGA(1,1)']
+    assert rvs.variance_parameters == ('OMEGA(1,1)',)
 
 
 def test_get_variance():

--- a/tests/nonmem/test_nonmem_model.py
+++ b/tests/nonmem/test_nonmem_model.py
@@ -1267,7 +1267,7 @@ $OMEGA 0.01
 $SIGMA 1
 '''
     model = Model.parse_model_from_string(code)
-    assert model.random_variables.etas.names == ['ETA_MY']
+    assert model.random_variables.etas.names == ('ETA_MY',)
 
     model = add_iiv(model, ['Y'], 'exp', '+', eta_names=['ETA_DUMMY'])
     model = remove_iiv(model, ['ETA_MY'])


### PR DESCRIPTION
The original motivation comes from `pharmpy.model.external.nonmem.update.create_name_map` being expensive to compute due to the following line:

https://github.com/pharmpy/pharmpy/blob/794e64224728e166e91edd522185a630beab7d0e/src/pharmpy/model/external/nonmem/update.py#L2421

Initially, I thought I'd just locally cache the computed property, then I realized this construct was used in many places, so it seemed more natural to just make all of those efficient without manual caching:

https://github.com/pharmpy/pharmpy/blob/794e64224728e166e91edd522185a630beab7d0e/src/pharmpy/modeling/estimation.py#L63-L65

https://github.com/pharmpy/pharmpy/blob/794e64224728e166e91edd522185a630beab7d0e/src/pharmpy/modeling/estimation.py#L159-L161

https://github.com/pharmpy/pharmpy/blob/794e64224728e166e91edd522185a630beab7d0e/src/pharmpy/modeling/estimation.py#L171-L173

https://github.com/pharmpy/pharmpy/blob/794e64224728e166e91edd522185a630beab7d0e/src/pharmpy/model/external/nlmixr/ini.py#L19

https://github.com/pharmpy/pharmpy/blob/794e64224728e166e91edd522185a630beab7d0e/src/pharmpy/model/external/nlmixr/error_model.py#L191-L192

https://github.com/pharmpy/pharmpy/blob/794e64224728e166e91edd522185a630beab7d0e/src/pharmpy/model/external/nonmem/update.py#L90

https://github.com/pharmpy/pharmpy/blob/794e64224728e166e91edd522185a630beab7d0e/src/pharmpy/model/external/nonmem/update.py#L2223

I then extended automated caching to properties that look expensive to compute.