### PR TITLE
Improve DX of `parse_model` benchmark script

### DIFF
--- a/scripts/benchmark/model/external/nonmem/parse_model.py
+++ b/scripts/benchmark/model/external/nonmem/parse_model.py
@@ -1,4 +1,5 @@
 import re
+import os
 import sys
 import time
 import traceback
@@ -173,7 +174,7 @@ def _models(roots: Iterable[PurePath], pattern: re.Pattern[str]):
         if path.is_file():
             yield path
         else:
-            for dirpath, _, filenames in path.walk():
+            for dirpath, _, filenames in os.walk(path):
                 for filename in filenames:
                     if pattern.search(filename):
                         yield Path(dirpath, filename)


### PR DESCRIPTION
- Now runs on Python 3.11
- Adds a `--debug` flag for failures