### PR TITLE
Improve typing of `NONMEMResultsFile.estimation_status` and `NONMEMResultsFile.covariance_status`

### DIFF
--- a/src/pharmpy/tools/external/nonmem/results.py
+++ b/src/pharmpy/tools/external/nonmem/results.py
@@ -689,7 +689,7 @@ def _parse_lst(n: int, path: Path, table_numbers: list[int | None], log: Log | N
     except (KeyError, FileNotFoundError):
         log_likelihood = np.nan
 
-    covstatus = rfile.covariance_status(covstatus_table_number)['covariance_step_ok']
+    covstatus = rfile.covariance_status(covstatus_table_number).covariance_step_ok
     assert covstatus is None or isinstance(covstatus, bool)
 
     if log_likelihood_table_number is not None:
@@ -735,13 +735,13 @@ def parse_estimation_status(results_file: NONMEMResultsFile, table_numbers: list
     estimate_near_boundary = []
     for tabno in table_numbers:
         estimation_status = results_file.estimation_status(tabno)
-        minimization_successful.append(estimation_status['minimization_successful'])
-        function_evaluations.append(estimation_status['function_evaluations'])
-        significant_digits.append(estimation_status['significant_digits'])
-        estimate_near_boundary.append(estimation_status['estimate_near_boundary'])
-        if estimation_status['maxevals_exceeded'] is True:
+        minimization_successful.append(estimation_status.minimization_successful)
+        function_evaluations.append(estimation_status.function_evaluations)
+        significant_digits.append(estimation_status.significant_digits)
+        estimate_near_boundary.append(estimation_status.estimate_near_boundary)
+        if estimation_status.maxevals_exceeded is True:
             tc = 'maxevals_exceeded'
-        elif estimation_status['rounding_errors'] is True:
+        elif estimation_status.rounding_errors is True:
             tc = 'rounding_errors'
         else:
             tc = None

--- a/tests/nonmem/output/test_nonmem_results_file.py
+++ b/tests/nonmem/output/test_nonmem_results_file.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from pathlib import Path
 
 import pandas as pd
@@ -8,6 +9,8 @@ import pharmpy.model.external.nonmem.table as table
 import pharmpy.tools.external.nonmem.results_file as rf
 from pharmpy.tools.external.results import parse_modelfit_results
 from pharmpy.workflows.log import Log
+
+anan = pytest.approx(nan, nan_ok=True)
 
 
 def test_supported_version():
@@ -39,6 +42,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': 4.9,
                 'function_evaluations': 98,
                 'warning': False,
+                'ofv_with_constant': None,
             },
             True,
         ),
@@ -56,6 +60,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': nan,
                 'function_evaluations': nan,
                 'warning': None,
+                'ofv_with_constant': None,
             },
             False,
         ),
@@ -73,6 +78,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': 3.1,
                 'function_evaluations': 62,
                 'warning': True,
+                'ofv_with_constant': None,
             },
             False,
         ),
@@ -90,6 +96,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': nan,
                 'function_evaluations': nan,
                 'warning': None,
+                'ofv_with_constant': None,
             },
             None,
         ),
@@ -107,6 +114,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': 3.1,
                 'function_evaluations': 112,
                 'warning': True,
+                'ofv_with_constant': None,
             },
             True,
         ),
@@ -124,6 +132,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': nan,
                 'function_evaluations': nan,
                 'warning': False,
+                'ofv_with_constant': None,
             },
             False,
         ),
@@ -141,6 +150,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': nan,
                 'function_evaluations': 153,
                 'warning': False,
+                'ofv_with_constant': None,
             },
             False,
         ),
@@ -158,6 +168,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': nan,
                 'function_evaluations': 153,
                 'warning': False,
+                'ofv_with_constant': None,
             },
             False,
         ),
@@ -175,6 +186,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': 3.6,
                 'function_evaluations': 107,
                 'warning': False,
+                'ofv_with_constant': None,
             },
             True,
         ),
@@ -192,6 +204,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': 4.2,
                 'function_evaluations': 208,
                 'warning': False,
+                'ofv_with_constant': None,
             },
             True,
         ),
@@ -209,6 +222,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': nan,
                 'function_evaluations': 735,
                 'warning': False,
+                'ofv_with_constant': None,
             },
             False,
         ),
@@ -226,6 +240,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': 4.2,
                 'function_evaluations': 208,
                 'warning': False,
+                'ofv_with_constant': None,
             },
             True,
         ),
@@ -243,6 +258,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': nan,
                 'function_evaluations': nan,
                 'warning': False,
+                'ofv_with_constant': None,
             },
             False,
         ),
@@ -260,6 +276,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': nan,
                 'function_evaluations': nan,
                 'warning': False,
+                'ofv_with_constant': None,
             },
             False,
         ),
@@ -291,6 +308,7 @@ def test_data_io(pheno_lst):
                 'significant_digits': nan,
                 'function_evaluations': 5,
                 'warning': False,
+                'ofv_with_constant': 3376.151276351326,
             },
             False,
         ),
@@ -300,7 +318,7 @@ def test_estimation_status(testdata, file, table_number, expected, covariance_st
     p = Path(testdata / 'nonmem' / 'modelfit_results' / 'onePROB' / 'oneEST' / 'noSIM')
     log = Log()
     rfile = rf.NONMEMResultsFile(p / file, log=log)
-    actual = rfile.estimation_status(table_number)
+    actual = asdict(rfile.estimation_status(table_number))
     assert actual.keys() == expected.keys()
     for key in expected.keys():
         assert type(actual[key]) is type(expected[key])
@@ -311,9 +329,9 @@ def test_estimation_status(testdata, file, table_number, expected, covariance_st
         else:
             assert actual[key] == expected[key]
     if covariance_step_ok is None:
-        assert rfile.covariance_status(table_number)['covariance_step_ok'] is None
+        assert rfile.covariance_status(table_number).covariance_step_ok is None
     else:
-        assert rfile.covariance_status(table_number)['covariance_step_ok'] == covariance_step_ok
+        assert rfile.covariance_status(table_number).covariance_step_ok == covariance_step_ok
 
 
 @pytest.mark.parametrize(
@@ -322,35 +340,29 @@ def test_estimation_status(testdata, file, table_number, expected, covariance_st
         (
             'anneal2_V7_30_beta.lst',
             2,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': True,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': nan,
-                'function_evaluations': nan,
-                'warning': False,
-            },
+            rf.TermSection(
+                minimization_successful=True,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                warning=False,
+                significant_digits=anan,
+                function_evaluations=anan,
+            ),
             True,
         ),
         (
             'superid2_6_V7_30_beta.lst',
             2,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': True,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': nan,
-                'function_evaluations': nan,
-                'warning': False,
-            },
+            rf.TermSection(
+                minimization_successful=True,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                warning=False,
+                significant_digits=anan,
+                function_evaluations=anan,
+            ),
             True,
         ),
     ],
@@ -359,84 +371,77 @@ def test_estimation_status_multest(testdata, file, table_number, expected, covar
     p = Path(testdata / 'nonmem' / 'modelfit_results' / 'onePROB' / 'multEST' / 'noSIM')
     rfile = rf.NONMEMResultsFile(p / file)
     assert rfile.estimation_status(table_number) == expected
-    assert rfile.covariance_status(table_number)['covariance_step_ok'] == covariance_step_ok
+    assert rfile.covariance_status(table_number).covariance_step_ok == covariance_step_ok
 
 
 def test_estimation_status_empty():
     rfile = rf.NONMEMResultsFile()
     assert rfile._supported_nonmem_version is False
-    assert rfile.estimation_status(1) == rf.NONMEMResultsFile.unknown_termination()
+    assert rfile.estimation_status(1) == rf.TermSection(
+        significant_digits=anan,
+        function_evaluations=anan,
+    )
 
 
 def test_estimation_status_withsim(testdata):
     p = Path(testdata / 'nonmem' / 'modelfit_results' / 'onePROB' / 'oneEST' / 'withSIM')
     rfile = rf.NONMEMResultsFile(p / 'control3boot.res', log=Log())
 
-    assert rfile.estimation_status(45) == {
-        'ebv_shrinkage': None,
-        'eps_shrinkage': None,
-        'minimization_successful': True,
-        'eta_shrinkage': None,
-        'estimate_near_boundary': False,
-        'rounding_errors': False,
-        'maxevals_exceeded': False,
-        'significant_digits': 3.3,
-        'function_evaluations': 192,
-        'warning': False,
-    }
-    assert rfile.covariance_status(45)['covariance_step_ok'] is False
+    assert rfile.estimation_status(45) == rf.TermSection(
+        minimization_successful=True,
+        estimate_near_boundary=False,
+        rounding_errors=False,
+        maxevals_exceeded=False,
+        significant_digits=3.3,
+        function_evaluations=192,
+        warning=False,
+    )
+    assert rfile.covariance_status(45).covariance_step_ok is False
 
-    assert rfile.estimation_status(70) == {
-        'ebv_shrinkage': None,
-        'eps_shrinkage': None,
-        'minimization_successful': True,
-        'eta_shrinkage': None,
-        'estimate_near_boundary': True,
-        'rounding_errors': False,
-        'maxevals_exceeded': False,
-        'significant_digits': 3.6,
-        'function_evaluations': 202,
-        'warning': False,
-    }
-    assert rfile.covariance_status(70)['covariance_step_ok'] is False
+    assert rfile.estimation_status(70) == rf.TermSection(
+        minimization_successful=True,
+        estimate_near_boundary=True,
+        rounding_errors=False,
+        maxevals_exceeded=False,
+        significant_digits=3.6,
+        function_evaluations=202,
+        warning=False,
+    )
+    assert rfile.covariance_status(70).covariance_step_ok is False
 
-    assert rfile.estimation_status(100) == {
-        'ebv_shrinkage': None,
-        'eps_shrinkage': None,
-        'minimization_successful': True,
-        'eta_shrinkage': None,
-        'estimate_near_boundary': False,
-        'rounding_errors': False,
-        'maxevals_exceeded': False,
-        'significant_digits': 5.6,
-        'function_evaluations': 100,
-        'warning': False,
-    }
-    assert rfile.covariance_status(100)['covariance_step_ok'] is True
+    assert rfile.estimation_status(100) == rf.TermSection(
+        minimization_successful=True,
+        estimate_near_boundary=False,
+        rounding_errors=False,
+        maxevals_exceeded=False,
+        significant_digits=5.6,
+        function_evaluations=100,
+        warning=False,
+    )
+    assert rfile.covariance_status(100).covariance_step_ok is True
 
 
 def test_ofv_table_gap(testdata):
     p = Path(testdata / 'nonmem' / 'modelfit_results' / 'multPROB' / 'multEST' / 'withSIM')
     rfile = rf.NONMEMResultsFile(p / 'multprobmix_nm730.lst', log=Log())
 
-    assert rfile.estimation_status(2) == {
-        'ebv_shrinkage': None,
-        'eps_shrinkage': None,
-        'minimization_successful': False,
-        'eta_shrinkage': None,
-        'estimate_near_boundary': False,
-        'rounding_errors': False,
-        'maxevals_exceeded': True,
-        'significant_digits': nan,
-        'function_evaluations': 16,
-        'warning': False,
-    }
+    assert rfile.estimation_status(2) == rf.TermSection(
+        minimization_successful=False,
+        estimate_near_boundary=False,
+        rounding_errors=False,
+        maxevals_exceeded=True,
+        significant_digits=anan,
+        function_evaluations=16,
+        warning=False,
+    )
 
     table_numbers = (1, 2, 3, 4, 6, 8, 10, 11, 12, 13)
     ext_table_file = table.NONMEMTableFile(p / 'multprobmix_nm730.ext')
 
     for n in table_numbers:
-        assert rfile.ofv(n) == pytest.approx(ext_table_file.table_no(n).final_ofv)
+        ext_table = ext_table_file.table_no(n)
+        assert isinstance(ext_table, table.ExtTable)
+        assert rfile.ofv(n) == pytest.approx(ext_table.final_ofv)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- ~To be rebased on #4201.~ **DONE**

@rikardn ~Failures on NaN do not happen in Python 3.12. Any idea why?~ **EDIT**: Probably some changes in how dataclass comparison is mocked in Python 3.13. Fixed with `pytest.approx(np.nan, nan_ok=True)`.

<details>

```console
FAILED tests/nonmem/output/test_nonmem_results_file.py::test_estimation_status_empty - AssertionError: assert TermInfo(minimization_successful=None, estimate_near_boundary=None, rounding_errors=None, maxevals_exceeded=None, significant_digits=nan, function_evaluations=nan, ofv_with_constant=None, warning=None, eta_shrinkage=None, ebv_shrinkage=None, eps_shrinkage=None) == TermInfo(minimization_successful=None, estimate_near_boundary=None, rounding_errors=None, maxevals_exceeded=None, significant_digits=nan, function_evaluations=nan, ofv_with_constant=None, warning=None, eta_shrinkage=None, ebv_shrinkage=None, eps_shrinkage=None)
  
  Matching attributes:
  ['minimization_successful',
   'estimate_near_boundary',
   'rounding_errors',
   'maxevals_exceeded',
   'ofv_with_constant',
   'warning',
   'eta_shrinkage',
   'ebv_shrinkage',
   'eps_shrinkage']
  Differing attributes:
  ['significant_digits', 'function_evaluations']
  
  Drill down into differing attribute significant_digits:
    significant_digits: nan != nan
  
  Drill down into differing attribute function_evaluations:
    function_evaluations: nan != nan
FAILED tests/nonmem/output/test_nonmem_results_file.py::test_ofv_table_gap - AssertionError: assert TermInfo(minimization_successful=False, estimate_near_boundary=False, rounding_errors=False, maxevals_exceeded=True, significant_digits=nan, function_evaluations=16, ofv_with_constant=None, warning=False, eta_shrinkage=None, ebv_shrinkage=None, eps_shrinkage=None) == TermInfo(minimization_successful=False, estimate_near_boundary=False, rounding_errors=False, maxevals_exceeded=True, significant_digits=nan, function_evaluations=16, ofv_with_constant=None, warning=False, eta_shrinkage=None, ebv_shrinkage=None, eps_shrinkage=None)
  
  Matching attributes:
  ['minimization_successful',
   'estimate_near_boundary',
   'rounding_errors',
   'maxevals_exceeded',
   'function_evaluations',
   'ofv_with_constant',
   'warning',
   'eta_shrinkage',
   'ebv_shrinkage',
   'eps_shrinkage']
  Differing attributes:
  ['significant_digits']
  
  Drill down into differing attribute significant_digits:
    significant_digits: nan != nan
FAILED tests/nonmem/output/test_nonmem_results_file.py::test_estimation_status_multest[anneal2_V7_30_beta.lst-2-expected0-True] - AssertionError: assert TermInfo(minimization_successful=True, estimate_near_boundary=False, rounding_errors=False, maxevals_exceeded=False, significant_digits=nan, function_evaluations=nan, ofv_with_constant=None, warning=False, eta_shrinkage=None, ebv_shrinkage=None, eps_shrinkage=None) == TermInfo(minimization_successful=True, estimate_near_boundary=False, rounding_errors=False, maxevals_exceeded=False, significant_digits=nan, function_evaluations=nan, ofv_with_constant=None, warning=False, eta_shrinkage=None, ebv_shrinkage=None, eps_shrinkage=None)
  
  Matching attributes:
  ['minimization_successful',
   'estimate_near_boundary',
   'rounding_errors',
   'maxevals_exceeded',
   'ofv_with_constant',
   'warning',
   'eta_shrinkage',
   'ebv_shrinkage',
   'eps_shrinkage']
  Differing attributes:
  ['significant_digits', 'function_evaluations']
  
  Drill down into differing attribute significant_digits:
    significant_digits: nan != nan
  
  Drill down into differing attribute function_evaluations:
    function_evaluations: nan != nan
FAILED tests/nonmem/output/test_nonmem_results_file.py::test_estimation_status_multest[superid2_6_V7_30_beta.lst-2-expected1-True] - AssertionError: assert TermInfo(minimization_successful=True, estimate_near_boundary=False, rounding_errors=False, maxevals_exceeded=False, significant_digits=nan, function_evaluations=nan, ofv_with_constant=None, warning=False, eta_shrinkage=None, ebv_shrinkage=None, eps_shrinkage=None) == TermInfo(minimization_successful=True, estimate_near_boundary=False, rounding_errors=False, maxevals_exceeded=False, significant_digits=nan, function_evaluations=nan, ofv_with_constant=None, warning=False, eta_shrinkage=None, ebv_shrinkage=None, eps_shrinkage=None)
  
  Matching attributes:
  ['minimization_successful',
   'estimate_near_boundary',
   'rounding_errors',
   'maxevals_exceeded',
   'ofv_with_constant',
   'warning',
   'eta_shrinkage',
   'ebv_shrinkage',
   'eps_shrinkage']
  Differing attributes:
  ['significant_digits', 'function_evaluations']
  
  Drill down into differing attribute significant_digits:
    significant_digits: nan != nan
  
  Drill down into differing attribute function_evaluations:
    function_evaluations: nan != nan
```

</details>