### PR TITLE
Handle multiline shrinkage `.lst` output and `E**shrink(%):` format

### DIFF
--- a/tests/nonmem/output/test_nonmem_results_file.py
+++ b/tests/nonmem/output/test_nonmem_results_file.py
@@ -13,6 +13,21 @@ from pharmpy.workflows.log import Log
 anan = pytest.approx(nan, nan_ok=True)
 
 
+def _assert_estimation_status(_actual: rf.TermInfo, _expected: rf.TermInfo):
+    expected = asdict(_expected)
+    actual = asdict(_actual)
+
+    assert actual.keys() == expected.keys()
+    for key in expected.keys():
+        assert type(actual[key]) is type(expected[key])
+        if isinstance(expected[key], pd.DataFrame):
+            assert str(actual[key]) == str(expected[key])
+        elif expected[key] is nan:
+            assert actual[key] is nan
+        else:
+            assert actual[key] == expected[key]
+
+
 def test_supported_version():
     assert rf.NONMEMResultsFile.supported_version(None) is False
     assert rf.NONMEMResultsFile.supported_version('7.1.0') is False
@@ -31,285 +46,362 @@ def test_data_io(pheno_lst):
         (
             'phenocorr.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': True,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': 4.9,
-                'function_evaluations': 98,
-                'warning': False,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=True,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                significant_digits=4.9,
+                function_evaluations=98,
+                warning=False,
+            ),
             True,
         ),
         (
             'hessian_error.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': False,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': None,
-                'rounding_errors': None,
-                'maxevals_exceeded': None,
-                'significant_digits': nan,
-                'function_evaluations': nan,
-                'warning': None,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=False,
+            ),
             False,
         ),
         (
             'large_s_matrix_cov_fail.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': True,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': 3.1,
-                'function_evaluations': 62,
-                'warning': True,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=True,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                significant_digits=3.1,
+                function_evaluations=62,
+                warning=True,
+                ebv_shrinkage=pd.DataFrame(
+                    data={
+                        "EBVshrink(%):": [
+                            3.6501e01,
+                            3.6538e01,
+                            5.3119e01,
+                            3.3266e01,
+                            4.0104e01,
+                            3.7548e01,
+                            2.0563e01,
+                            2.2176e01,
+                            1.6328e01,
+                            1.5847e01,
+                            3.3517e01,
+                            3.3526e01,
+                            4.9502e01,
+                            4.9855e01,
+                        ]
+                    },
+                ),
+                eps_shrinkage=pd.DataFrame(
+                    data={"EPSshrink(%):": [2.3471e01]},
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={
+                        "ETAshrink(%):": [
+                            3.9737e01,
+                            5.5124e01,
+                            4.3564e01,
+                            3.3676e01,
+                            3.0325e01,
+                            3.4879e01,
+                            3.8156e01,
+                            2.1724e01,
+                            1.6271e01,
+                            2.9704e01,
+                            4.4234e01,
+                            4.8502e01,
+                            5.4318e01,
+                            4.7864e01,
+                        ]
+                    },
+                ),
+            ),
             False,
         ),
         (
             'nm710_fail_negV.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': None,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': None,
-                'rounding_errors': None,
-                'maxevals_exceeded': None,
-                'significant_digits': nan,
-                'function_evaluations': nan,
-                'warning': None,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(),
             None,
         ),
         (
             'sparse_matrix_with_msfi.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': True,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': 3.1,
-                'function_evaluations': 112,
-                'warning': True,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=True,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                significant_digits=3.1,
+                function_evaluations=112,
+                warning=True,
+                ebv_shrinkage=pd.DataFrame(
+                    data={
+                        "EBVshrink(%):": [
+                            4.5964e01,
+                            3.4348e01,
+                            5.2009e01,
+                            3.3063e01,
+                            3.3978e01,
+                            3.7211e01,
+                            2.1345e01,
+                            2.3314e01,
+                            1.5965e01,
+                            1.6086e01,
+                            3.2729e01,
+                            3.3373e01,
+                            5.1050e01,
+                            4.9976e01,
+                        ]
+                    },
+                ),
+                eps_shrinkage=pd.DataFrame(
+                    data={"EPSshrink(%):": [3.2079e01]},
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={
+                        "ETAshrink(%):": [
+                            4.7663e01,
+                            5.2882e01,
+                            4.3524e01,
+                            3.6822e01,
+                            3.8634e01,
+                            3.5256e01,
+                            4.0755e01,
+                            2.8192e01,
+                            2.0729e01,
+                            2.9972e01,
+                            4.9818e01,
+                            4.8307e01,
+                            6.6686e01,
+                            4.9792e01,
+                        ]
+                    },
+                ),
+            ),
             True,
         ),
         (
             'warfarin_ddmore.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': True,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': nan,
-                'function_evaluations': nan,
-                'warning': False,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=True,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                warning=False,
+                eps_shrinkage=pd.DataFrame(
+                    data={"EPSshrink(%):": [7.6245e00]},
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={"ETAshrink(%):": [1.3927e00, 1.3092e01, 4.9181e01, 5.3072e01]},
+                ),
+            ),
             False,
         ),
         (
             'mox_fail_nonp.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': False,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': nan,
-                'function_evaluations': 153,
-                'warning': False,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=False,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                function_evaluations=153,
+                warning=False,
+                ebv_shrinkage=pd.DataFrame(
+                    data={"EBVshrink(%):": [3.7232e00, 2.5777e01, 1.4788e01, 2.4381e01, 1.6695e01]},
+                ),
+                eps_shrinkage=pd.DataFrame(
+                    data={"EPSshrink(%):": [2.5697e01]},
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={"ETAshrink(%):": [3.1277e01, 5.2053e01, 7.5691e00, 7.8837e01, 8.2298e01]},
+                ),
+            ),
             False,
         ),
         (
             'mox_nocov_nonp.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': False,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': nan,
-                'function_evaluations': 153,
-                'warning': False,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=False,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                function_evaluations=153,
+                warning=False,
+                ebv_shrinkage=pd.DataFrame(
+                    data={"EBVshrink(%):": [3.7232e00, 2.5777e01, 1.4788e01, 2.4381e01, 1.6695e01]},
+                ),
+                eps_shrinkage=pd.DataFrame(
+                    data={"EPSshrink(%):": [2.5697e01]},
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={"ETAshrink(%):": [3.1277e01, 5.2053e01, 7.5691e00, 7.8837e01, 8.2298e01]},
+                ),
+            ),
             False,
         ),
         (
             'pheno_nonp.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': True,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': 3.6,
-                'function_evaluations': 107,
-                'warning': False,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=True,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                significant_digits=3.6,
+                function_evaluations=107,
+                warning=False,
+                ebv_shrinkage=pd.DataFrame(
+                    data={"EBVshrink(%):": [3.8428e01, 4.4592e00]},
+                ),
+                eps_shrinkage=pd.DataFrame(
+                    data={"EPSshrink(%):": [2.7971e01]},
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={"ETAshrink(%):": [3.8721e01, 4.6492e00]},
+                ),
+            ),
             True,
         ),
         (
             'theo.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': True,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': 4.2,
-                'function_evaluations': 208,
-                'warning': False,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=True,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                significant_digits=4.2,
+                function_evaluations=208,
+                warning=False,
+            ),
             True,
         ),
         (
             'theo_nonp.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': False,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': True,
-                'rounding_errors': True,
-                'maxevals_exceeded': False,
-                'significant_digits': nan,
-                'function_evaluations': 735,
-                'warning': False,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=False,
+                estimate_near_boundary=True,
+                rounding_errors=True,
+                maxevals_exceeded=False,
+                function_evaluations=735,
+                warning=False,
+                ebv_shrinkage=pd.DataFrame(
+                    data={"EBVshrink(%):": [9.6560e01, 1.6545e01, 1.6532e01, 1.0000e02]},
+                ),
+                eps_shrinkage=pd.DataFrame(
+                    data={"EPSshrink(%):": [3.2692e00]},
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={"ETAshrink(%):": [9.6393e01, 1.2506e01, 1.2492e01, 1.0000e02]},
+                ),
+            ),
             False,
         ),
         (
             'theo_withcov.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': True,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': 4.2,
-                'function_evaluations': 208,
-                'warning': False,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=True,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                significant_digits=4.2,
+                function_evaluations=208,
+                warning=False,
+            ),
             True,
         ),
         (
             'UseCase7.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': True,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': nan,
-                'function_evaluations': nan,
-                'warning': False,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=True,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                warning=False,
+                ebv_shrinkage=pd.DataFrame(
+                    data={"EBVshrink(%):": [9.0057e00, 1.5538e01, 4.7502e01, 6.4241e01]},
+                ),
+                eps_shrinkage=pd.DataFrame(
+                    data={"EPSshrink(%):": [1.3572e01]},
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={"ETAshrink(%):": [9.0067e00, 1.5526e01, 4.7506e01, 1.2182e01]},
+                ),
+            ),
             False,
         ),
         (
             'example6b_V7_30_beta.lst',
             1,
-            {
-                'ebv_shrinkage': None,
-                'eps_shrinkage': None,
-                'minimization_successful': True,
-                'eta_shrinkage': None,
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': False,
-                'significant_digits': nan,
-                'function_evaluations': nan,
-                'warning': False,
-                'ofv_with_constant': None,
-            },
+            rf.TermInfo(
+                minimization_successful=True,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=False,
+                warning=False,
+                eps_shrinkage=pd.DataFrame(
+                    data={
+                        "EPSshrink(%):": [1.5539e01, 6.8462e00],
+                    },
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={
+                        "ETAshrink(%):": [
+                            6.3623e-01,
+                            4.5490e00,
+                            9.5378e00,
+                            2.1243e00,
+                            1.5371e00,
+                            6.0355e00,
+                            4.0732e-01,
+                            1.7659e00,
+                        ],
+                    },
+                ),
+            ),
             False,
         ),
         (
             'maxeval3.lst',
             1,
-            {
-                'ebv_shrinkage': pd.DataFrame(
+            rf.TermInfo(
+                minimization_successful=False,
+                estimate_near_boundary=False,
+                rounding_errors=False,
+                maxevals_exceeded=True,
+                function_evaluations=5,
+                warning=False,
+                ofv_with_constant=3376.151276351326,
+                ebv_shrinkage=pd.DataFrame(
                     data={
-                        0: ["EBVSHRINKSD(%)", "EBVSHRINKVR(%)"],
-                        1: [8.0993, 15.5430],
-                        2: [1.8003, 3.5683],
+                        "EBVSHRINKSD(%)": [8.0993e00, 1.8003e00],
+                        "EBVSHRINKVR(%)": [1.5543e01, 3.5683e00],
                     },
-                ).set_index(0),
-                'eps_shrinkage': pd.DataFrame(
-                    data={0: ["EPSSHRINKSD(%)", "EPSSHRINKVR(%)"], 1: [1.000000e-10, 1.000000e-10]},
-                ).set_index(0),
-                'minimization_successful': False,
-                'eta_shrinkage': pd.DataFrame(
+                ),
+                eps_shrinkage=pd.DataFrame(
                     data={
-                        0: ["ETASHRINKSD(%)", "ETASHRINKVR(%)"],
-                        1: [1.000000e-10, 1.000000e-10],
-                        2: [14.424, 26.768],
+                        "EPSSHRINKSD(%)": [1.0000e-10],
+                        "EPSSHRINKVR(%)": [1.0000e-10],
                     },
-                ).set_index(0),
-                'estimate_near_boundary': False,
-                'rounding_errors': False,
-                'maxevals_exceeded': True,
-                'significant_digits': nan,
-                'function_evaluations': 5,
-                'warning': False,
-                'ofv_with_constant': 3376.151276351326,
-            },
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={
+                        "ETASHRINKSD(%)": [1.0000e-10, 1.4424e01],
+                        "ETASHRINKVR(%)": [1.0000e-10, 2.6768e01],
+                    },
+                ),
+            ),
             False,
         ),
     ],
@@ -318,16 +410,8 @@ def test_estimation_status(testdata, file, table_number, expected, covariance_st
     p = Path(testdata / 'nonmem' / 'modelfit_results' / 'onePROB' / 'oneEST' / 'noSIM')
     log = Log()
     rfile = rf.NONMEMResultsFile(p / file, log=log)
-    actual = asdict(rfile.estimation_status(table_number))
-    assert actual.keys() == expected.keys()
-    for key in expected.keys():
-        assert type(actual[key]) is type(expected[key])
-        if isinstance(expected[key], pd.DataFrame):
-            assert str(expected[key]) == str(actual[key])
-        elif expected[key] is nan:
-            assert actual[key] is nan
-        else:
-            assert actual[key] == expected[key]
+    actual = rfile.estimation_status(table_number)
+    _assert_estimation_status(actual, expected)
     if covariance_step_ok is None:
         assert rfile.covariance_status(table_number).covariance_step_ok is None
     else:
@@ -346,8 +430,12 @@ def test_estimation_status(testdata, file, table_number, expected, covariance_st
                 rounding_errors=False,
                 maxevals_exceeded=False,
                 warning=False,
-                significant_digits=anan,
-                function_evaluations=anan,
+                eps_shrinkage=pd.DataFrame(
+                    data={"EPSshrink(%):": [-7.7375e01]},
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={"ETAshrink(%):": [4.7323e01, 3.9939e01, 2.4474e01, 0.0000e00]},
+                ),
             ),
             True,
         ),
@@ -360,8 +448,21 @@ def test_estimation_status(testdata, file, table_number, expected, covariance_st
                 rounding_errors=False,
                 maxevals_exceeded=False,
                 warning=False,
-                significant_digits=anan,
-                function_evaluations=anan,
+                eps_shrinkage=pd.DataFrame(
+                    data={"EPSshrink(%):": [1.1964e01]},
+                ),
+                eta_shrinkage=pd.DataFrame(
+                    data={
+                        "ETAshrink(%):": [
+                            1.1115e01,
+                            1.0764e01,
+                            -1.9903e-01,
+                            -4.3835e-02,
+                            -9.1709e-02,
+                            -1.9494e-02,
+                        ]
+                    },
+                ),
             ),
             True,
         ),
@@ -370,7 +471,7 @@ def test_estimation_status(testdata, file, table_number, expected, covariance_st
 def test_estimation_status_multest(testdata, file, table_number, expected, covariance_step_ok):
     p = Path(testdata / 'nonmem' / 'modelfit_results' / 'onePROB' / 'multEST' / 'noSIM')
     rfile = rf.NONMEMResultsFile(p / file)
-    assert rfile.estimation_status(table_number) == expected
+    _assert_estimation_status(rfile.estimation_status(table_number), expected)
     assert rfile.covariance_status(table_number).covariance_step_ok == covariance_step_ok
 
 
@@ -425,14 +526,31 @@ def test_ofv_table_gap(testdata):
     p = Path(testdata / 'nonmem' / 'modelfit_results' / 'multPROB' / 'multEST' / 'withSIM')
     rfile = rf.NONMEMResultsFile(p / 'multprobmix_nm730.lst', log=Log())
 
-    assert rfile.estimation_status(2) == rf.TermInfo(
-        minimization_successful=False,
-        estimate_near_boundary=False,
-        rounding_errors=False,
-        maxevals_exceeded=True,
-        significant_digits=anan,
-        function_evaluations=16,
-        warning=False,
+    _assert_estimation_status(
+        rfile.estimation_status(2),
+        rf.TermInfo(
+            minimization_successful=False,
+            estimate_near_boundary=False,
+            rounding_errors=False,
+            maxevals_exceeded=True,
+            function_evaluations=16,
+            warning=False,
+            eta_shrinkage=pd.DataFrame(
+                data={
+                    'ETAshrink(%):': [1.7703, 12.038, 8.5112],
+                },
+            ),
+            ebv_shrinkage=pd.DataFrame(
+                data={
+                    'EBVshrink(%):': [1.1841, 9.9088, 9.0686],
+                },
+            ),
+            eps_shrinkage=pd.DataFrame(
+                data={
+                    'EPSshrink(%):': [10.166],
+                },
+            ),
+        ),
     )
 
     table_numbers = (1, 2, 3, 4, 6, 8, 10, 11, 12, 13)


### PR DESCRIPTION
- ~To be rebased on #4208.~ **DONE**
- This is a follow-up on #4174.