### PR TITLE
Explicitly exclude Pandas v3 compatibility in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     'lark>=1.1.7',
     'sympy>=1.9',
     'symengine>=0.13.0',
-    'pandas>=1.4, !=2.1.0',
+    'pandas>=1.4, !=2.1.0, <3.0.0',
     'numexpr>=2.7.0',
     'altair>=6.0.0',
     'itables>=2.4.0',


### PR DESCRIPTION
GHA currently runs on a fixed version of `pandas` (2.3.3). Pandas v3 introduces breaking changes, see for instance:
  - #4319 
  - #4304