### PR TITLE
Rewrite `make_peekable` as `PeekableIterator`

### DIFF
--- a/src/pharmpy/internals/iterator/lookahead.py
+++ b/src/pharmpy/internals/iterator/lookahead.py
@@ -1,6 +1,6 @@
 import sys
 from itertools import islice, tee
-from typing import Iterable, Iterator, TypeVar
+from typing import Generic, Iterable, Iterator, TypeVar
 
 T = TypeVar('T')
 
@@ -28,15 +28,26 @@ else:
             return tee(iterable, n)
 
 
-def make_peekable(iterator: Iterator[T]):
-    # NOTE: Adapted from https://docs.python.org/3/library/itertools.html#itertools.tee
-    # NOTE: Extra copy required for Python 3.11
-    (tee_iterator,) = _tee(iterator, 1)
+def _fork(iterable: Iterable[T]):
+    return _tee(iterable, 1)[0]
 
-    def lookahead(n: int) -> Iterator[T]:
+
+class PeekableIterator(Generic[T]):
+    def __init__(self, iterator: Iterator[T]):
+        # NOTE: Adapted from https://docs.python.org/3/library/itertools.html#itertools.tee
+        # NOTE: Extra copy required for Python 3.11
+        self._it = _fork(iterator)
+
+    def __next__(self):
+        return next(self._it)
+
+    def __iter__(self):
+        return self._it  # NOTE: This bypasses `__next__` in `for ... in ...` constructs.
+
+    def lookahead(self, n: int):
         # NOTE: Extra copy required for Python 3.11
         # SEE: https://github.com/python/cpython/issues/137597#issuecomment-3186240062
-        (forked_iterator,) = _tee(tee_iterator, 1)
-        return islice(forked_iterator, n)
+        return islice(_fork(self._it), n)
 
-    return tee_iterator, lookahead
+    def peek(self):
+        return next(self.lookahead(1))


### PR DESCRIPTION
- This follows up on https://github.com/pharmpy/pharmpy/pull/4186#discussion_r2690311479
- No measurable difference in performance for large `.lst` files (~2M lines).